### PR TITLE
unit/zap: test "core" ZAP operations

### DIFF
--- a/include/sys/zap.h
+++ b/include/sys/zap.h
@@ -259,6 +259,7 @@ int zap_lookup_length_uint64_by_dnode(dnode_t *dn, const uint64_t *key,
  * exist, 0 if it does. This is like zap_lookup(), but may be more efficient.
  */
 int zap_contains(objset_t *os, uint64_t zapobj, const char *name);
+int zap_contains_by_dnode(dnode_t *dn, const char *name);
 
 /*
  * Prefetch the blocks within the ZAP where the given key is stored. The
@@ -309,6 +310,8 @@ int zap_add_uint64_by_dnode(dnode_t *dn, const uint64_t *key,
  */
 int zap_update(objset_t *os, uint64_t zapobj, const char *name,
     int integer_size, uint64_t num_integers, const void *val, dmu_tx_t *tx);
+int zap_update_by_dnode(dnode_t *dn, const char *name, int integer_size,
+    uint64_t num_integers, const void *val, dmu_tx_t *tx);
 
 /* Update by uint64_t[] key. */
 int zap_update_uint64(objset_t *os, uint64_t zapobj, const uint64_t *key,
@@ -326,6 +329,8 @@ int zap_update_uint64_by_dnode(dnode_t *dn, const uint64_t *key,
  * return ENOENT.
  */
 int zap_length(objset_t *os, uint64_t zapobj, const char *name,
+    uint64_t *integer_size, uint64_t *num_integers);
+int zap_length_by_dnode(dnode_t *dn, const char *name,
     uint64_t *integer_size, uint64_t *num_integers);
 
 /* Attribute length by uint64_t[] key. */
@@ -585,6 +590,7 @@ typedef struct zap_stats {
  * know what you're doing.
  */
 int zap_get_stats(objset_t *os, uint64_t zapobj, zap_stats_t *zs);
+int zap_get_stats_by_dnode(dnode_t *dn, zap_stats_t *zs);
 
 /* ZAP subsystem setup/teardown */
 void zap_init(void);

--- a/module/zfs/zap.c
+++ b/module/zfs/zap.c
@@ -354,12 +354,24 @@ zap_lookup_uint64_by_dnode(dnode_t *dn, const uint64_t *key,
 /* zap_contains */
 
 int
-zap_contains(objset_t *os, uint64_t zapobj, const char *name)
+zap_contains_by_dnode(dnode_t *dn, const char *name)
 {
-	int err = zap_lookup_norm(os, zapobj, name, 0,
+	int err = zap_lookup_norm_by_dnode(dn, name, 0,
 	    0, NULL, 0, NULL, 0, NULL);
 	if (err == EOVERFLOW || err == EINVAL)
 		err = 0; /* found, but skipped reading the value */
+	return (err);
+}
+
+int
+zap_contains(objset_t *os, uint64_t zapobj, const char *name)
+{
+	dnode_t *dn;
+	int err = dnode_hold(os, zapobj, FTAG, &dn);
+	if (err != 0)
+		return (err);
+	err = zap_contains_by_dnode(dn, name);
+	dnode_rele(dn, FTAG);
 	return (err);
 }
 
@@ -550,7 +562,7 @@ zap_add_uint64(objset_t *os, uint64_t zapobj, const uint64_t *key,
 
 /* zap_update */
 
-static int
+int
 zap_update_by_dnode(dnode_t *dn, const char *name, int integer_size,
     uint64_t num_integers, const void *val, dmu_tx_t *tx)
 {
@@ -647,7 +659,7 @@ zap_update_uint64(objset_t *os, uint64_t zapobj, const uint64_t *key,
 
 /* zap_length */
 
-static int
+int
 zap_length_by_dnode(dnode_t *dn, const char *name, uint64_t *integer_size,
     uint64_t *num_integers)
 {
@@ -1208,7 +1220,7 @@ zap_cursor_serialize(zap_cursor_t *zc)
 
 /* zap_get_stats */
 
-static int
+int
 zap_get_stats_by_dnode(dnode_t *dn, zap_stats_t *zs)
 {
 	zap_t *zap;

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -46,7 +46,9 @@ PHONY += unit unit-coverage
 _unit_run_%: %D%/%
 	@echo "  UNITTEST $<" ; $<
 
-_unit_coverage_%: _unit_run_%
+_unit_coverage_%: %D%/%
+	@${LCOV} --quiet --zerocounters --directory $(top_srcdir) >/dev/null
+	@echo "  UNITTEST $<" ; $<
 	@${LCOV} --quiet --capture  \
 		--test-name $(subst _unit_coverage_, , $@) \
 		--directory $(top_srcdir) \

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -44,11 +44,11 @@ nodist_%C%_test_zap_SOURCES = \
 PHONY += unit unit-coverage
 
 _unit_run_%: %D%/%
-	@echo "  UNITTEST $<" ; $<
+	@echo "  UNITTEST $<" ; $< $(TOPT)
 
 _unit_coverage_%: %D%/%
 	@${LCOV} --quiet --zerocounters --directory $(top_srcdir) >/dev/null
-	@echo "  UNITTEST $<" ; $<
+	@echo "  UNITTEST $<" ; $< $(TOPT)
 	@${LCOV} --quiet --capture  \
 		--test-name $(subst _unit_coverage_, , $@) \
 		--directory $(top_srcdir) \

--- a/tests/unit/README.md
+++ b/tests/unit/README.md
@@ -45,6 +45,10 @@ Running test suite with seed 0x18e131ac...
 ...
 ```
 
+The test framework provides various options for controlling how the tests are
+run. Add the `--help` switch for more info. If using the make rule, options can
+be passed via the `TOPT=` param.
+
 ### Building just for tests
 
 Recommended “minimum” build for just the unit tests, with additional debug to

--- a/tests/unit/test_zap.c
+++ b/tests/unit/test_zap.c
@@ -231,6 +231,290 @@ test_zap_basic(const MunitParameter params[], void *data)
 
 /* ========== */
 
+/*
+ * "Core" ZAP API tests. Covers the most basic functionality upon which which
+ * everything else is built.
+ *
+ * Note that to avoid microzap upgrade here, we only short keys and
+ * single-uint64 values.
+ */
+
+/* zap_add: add new items. */
+static MunitResult
+test_zap_add(const MunitParameter params[], void *data)
+{
+	(void) data;
+
+	dnode_t *dn = mock_zap_create_params(params, "type");
+	dmu_tx_t *tx = (dmu_tx_t *)mock_tx_create();
+
+	/* A key added can be found by that name. */
+	uint64_t va = 1, var = 0;
+	unit_ok(zap_add_by_dnode(dn, "a", sizeof (uint64_t), 1, &va, tx));
+	unit_ok(zap_lookup_by_dnode(dn, "a", sizeof (uint64_t), 1, &var));
+	unit_eq(var, 1);
+
+	/* Another key added can be found by that name. */
+	uint64_t vb = 2, vbr = 0;
+	unit_ok(zap_add_by_dnode(dn, "b", sizeof (uint64_t), 1, &vb, tx));
+	unit_ok(zap_lookup_by_dnode(dn, "b", sizeof (uint64_t), 1, &vbr));
+	unit_eq(vbr, 2);
+
+	/* The first key is still findable with the right value. */
+	var = 0;
+	unit_ok(zap_lookup_by_dnode(dn, "a", sizeof (uint64_t), 1, &var));
+	unit_eq(var, 1);
+
+	/* Adding the key again fails. */
+	unit_err(zap_add_by_dnode(dn, "a",
+	    sizeof (uint64_t), 1, &va, tx), EEXIST);
+
+	/* Adding the key with a different value still fails. */
+	va = 2;
+	unit_err(zap_add_by_dnode(dn, "a",
+	    sizeof (uint64_t), 1, &va, tx), EEXIST);
+
+	/* And is still findable with the original value. */
+	var = 0;
+	unit_ok(zap_lookup_by_dnode(dn, "a", sizeof (uint64_t), 1, &var));
+	unit_eq(var, 1);
+
+	mock_tx_destroy((mock_dmu_tx_t *)tx);
+	unit_true(mock_zap_is_params(dn, params, "type"));
+	mock_zap_destroy(dn);
+
+	return (MUNIT_OK);
+}
+
+/* zap_update: add new or replace existing items. */
+static MunitResult
+test_zap_update(const MunitParameter params[], void *data)
+{
+	(void) data;
+
+	dnode_t *dn = mock_zap_create_params(params, "type");
+	dmu_tx_t *tx = (dmu_tx_t *)mock_tx_create();
+
+	/* Update on a non-existent key inserts it. */
+	uint64_t va = 1, var = 0;
+	unit_ok(zap_update_by_dnode(dn, "a", sizeof (uint64_t), 1, &va, tx));
+	unit_ok(zap_lookup_by_dnode(dn, "a", sizeof (uint64_t), 1, &var));
+	unit_eq(var, 1);
+
+	/* Update on an existing key replaces it without error. */
+	va = 2;
+	unit_ok(zap_update_by_dnode(dn, "a", sizeof (uint64_t), 1, &va, tx));
+	unit_ok(zap_lookup_by_dnode(dn, "a", sizeof (uint64_t), 1, &var));
+	unit_eq(var, 2);
+
+	/* Count should still be 1 (no duplicate was created). */
+	uint64_t count = 0;
+	unit_ok(zap_count_by_dnode(dn, &count));
+	unit_eq(count, 1);
+
+	mock_tx_destroy((mock_dmu_tx_t *)tx);
+	unit_true(mock_zap_is_params(dn, params, "type"));
+	mock_zap_destroy(dn);
+
+	return (MUNIT_OK);
+}
+
+/* zap_remove: remove existing items. */
+static MunitResult
+test_zap_remove(const MunitParameter params[], void *data)
+{
+	(void) data;
+
+	dnode_t *dn = mock_zap_create_params(params, "type");
+	dmu_tx_t *tx = (dmu_tx_t *)mock_tx_create();
+
+	/* Removing a non-existing key fails. */
+	unit_err(zap_remove_by_dnode(dn, "a", tx), ENOENT);
+
+	/* Adding two keys. */
+	uint64_t va = 1, vb = 2;
+	unit_ok(zap_add_by_dnode(dn, "a", sizeof (uint64_t), 1, &va, tx));
+	unit_ok(zap_add_by_dnode(dn, "b", sizeof (uint64_t), 1, &vb, tx));
+
+	/* Remove an existing key succeeds. */
+	unit_ok(zap_remove_by_dnode(dn, "a", tx));
+
+	/* After removing, looking up removed key fails. */
+	uint64_t var = 0;
+	unit_err(
+	    zap_lookup_by_dnode(dn, "a", sizeof (uint64_t), 1, &var), ENOENT);
+
+	/* Looking up the other key succeeds, and has the correct value. */
+	uint64_t vbr = 0;
+	unit_ok(zap_lookup_by_dnode(dn, "b", sizeof (uint64_t), 1, &vbr));
+	unit_eq(vbr, 2);
+
+	mock_tx_destroy((mock_dmu_tx_t *)tx);
+	unit_true(mock_zap_is_params(dn, params, "type"));
+	mock_zap_destroy(dn);
+
+	return (MUNIT_OK);
+}
+
+/* zap_count: number of entries, typically without lookup or traversal. */
+static MunitResult
+test_zap_count(const MunitParameter params[], void *data)
+{
+	(void) data;
+
+	dnode_t *dn = mock_zap_create_params(params, "type");
+	dmu_tx_t *tx = (dmu_tx_t *)mock_tx_create();
+
+	/* A new ZAP has zero entries. */
+	uint64_t count = 0;
+	unit_ok(zap_count_by_dnode(dn, &count));
+	unit_eq(count, 0);
+
+	/* Adding two keys bumps the count to 2. */
+	uint64_t v = 1;
+	unit_ok(zap_add_by_dnode(dn, "a", sizeof (uint64_t), 1, &v, tx));
+	unit_ok(zap_add_by_dnode(dn, "b", sizeof (uint64_t), 1, &v, tx));
+	unit_ok(zap_count_by_dnode(dn, &count));
+	unit_eq(count, 2);
+
+	/* Removing a key reduces the count. */
+	unit_ok(zap_remove_by_dnode(dn, "a", tx));
+	unit_ok(zap_count_by_dnode(dn, &count));
+	unit_eq(count, 1);
+
+	mock_tx_destroy((mock_dmu_tx_t *)tx);
+	unit_true(mock_zap_is_params(dn, params, "type"));
+	mock_zap_destroy(dn);
+
+	return (MUNIT_OK);
+}
+
+/* zap_contains: existence check without reading the value. */
+static MunitResult
+test_zap_contains(const MunitParameter params[], void *data)
+{
+	(void) data;
+
+	dnode_t *dn = mock_zap_create_params(params, "type");
+	dmu_tx_t *tx = (dmu_tx_t *)mock_tx_create();
+
+	uint64_t v = 1;
+	unit_ok(zap_add_by_dnode(dn, "a", sizeof (uint64_t), 1, &v, tx));
+	unit_ok(zap_contains_by_dnode(dn, "a"));
+	unit_err(zap_contains_by_dnode(dn, "b"), ENOENT);
+
+	mock_tx_destroy((mock_dmu_tx_t *)tx);
+	unit_true(mock_zap_is_params(dn, params, "type"));
+	mock_zap_destroy(dn);
+
+	return (MUNIT_OK);
+}
+
+/* zap_length: item metadata without reading the value. */
+static MunitResult
+test_zap_length(const MunitParameter params[], void *data)
+{
+	(void) data;
+
+	dnode_t *dn = mock_zap_create_params(params, "type");
+	dmu_tx_t *tx = (dmu_tx_t *)mock_tx_create();
+
+	/* uint64: integer_size=8, num_integers=1. */
+	uint64_t v = 42;
+	unit_ok(zap_add_by_dnode(dn, "u64",
+	    sizeof (uint64_t), 1, &v, tx));
+
+	uint64_t isz = 0, nint = 0;
+	unit_ok(zap_length_by_dnode(dn, "u64", &isz, &nint));
+	unit_eq(isz, 8);
+	unit_eq(nint, 1);
+
+	/* Missing key returns ENOENT. */
+	unit_err(zap_length_by_dnode(dn, "nope", &isz, &nint), ENOENT);
+
+	/* Either output pointer may be NULL. */
+	isz = 0; nint = 0;
+	unit_ok(zap_length_by_dnode(dn, "u64", NULL, &nint));
+	unit_ok(zap_length_by_dnode(dn, "u64", &isz, NULL));
+	unit_eq(isz, 8);
+	unit_eq(nint, 1);
+
+	mock_tx_destroy((mock_dmu_tx_t *)tx);
+	unit_true(mock_zap_is_params(dn, params, "type"));
+	mock_zap_destroy(dn);
+
+	return (MUNIT_OK);
+}
+
+/* ========== */
+
+/*
+ * Separate stats tests for each ZAP type, since they are about internals and
+ * so can and will produce different results.
+ */
+
+static MunitResult
+test_microzap_stats(const MunitParameter params[], void *data)
+{
+	(void) params; (void) data;
+
+	dnode_t *dn = mock_zap_create_microzap();
+	dmu_tx_t *tx = (dmu_tx_t *)mock_tx_create();
+
+	zap_stats_t zs;
+	uint64_t v = 1;
+	unit_ok(zap_add_by_dnode(dn, "a", sizeof (uint64_t), 1, &v, tx));
+	unit_ok(zap_add_by_dnode(dn, "b", sizeof (uint64_t), 1, &v, tx));
+	unit_ok(zap_get_stats_by_dnode(dn, &zs));
+
+	/* We added two entries. */
+	unit_eq(zs.zs_num_entries, 2);
+
+	/* MicroZAP is always a single block. */
+	unit_eq(zs.zs_num_blocks, 1);
+
+	/* Blocksize matches what we passed to mock_dnode_create(). */
+	unit_eq(zs.zs_blocksize, 512);
+
+	mock_tx_destroy((mock_dmu_tx_t *)tx);
+	unit_true(mock_zap_is_microzap(dn));
+	mock_zap_destroy(dn);
+
+	return (MUNIT_OK);
+}
+
+static MunitResult
+test_fatzap_stats(const MunitParameter params[], void *data)
+{
+	(void) params; (void) data;
+
+	dnode_t *dn = mock_zap_create_fatzap();
+	dmu_tx_t *tx = (dmu_tx_t *)mock_tx_create();
+
+	zap_stats_t zs;
+	uint64_t v = 1;
+	unit_ok(zap_add_by_dnode(dn, "a", sizeof (uint64_t), 1, &v, tx));
+	unit_ok(zap_add_by_dnode(dn, "b", sizeof (uint64_t), 1, &v, tx));
+	unit_ok(zap_get_stats_by_dnode(dn, &zs));
+
+	/* We added two entries. */
+	unit_eq(zs.zs_num_entries, 2);
+
+	/* One header block, one leaf block. */
+	unit_eq(zs.zs_num_blocks, 2);
+
+	/* FatZAP block size set by tuneable. */
+	unit_eq(zs.zs_blocksize, 1 << fzap_default_block_shift);
+
+	mock_tx_destroy((mock_dmu_tx_t *)tx);
+	unit_true(mock_zap_is_fatzap(dn));
+	mock_zap_destroy(dn);
+
+	return (MUNIT_OK);
+}
+
+/* ========== */
+
 /* Test suite definition and boilerplate. */
 
 #define	UNIT_PARAM_ZAP_TYPES(p)	\
@@ -241,11 +525,24 @@ static const MunitParameterEnum zap_type_params[] = {
 	{ 0 },
 };
 
+#define	UNIT_TEST_ZAP_TYPES(name, func)	\
+	UNIT_TEST(name, func, zap_type_params)
+
 static const MunitTest zap_tests[] = {
 	UNIT_TEST("mock_microzap_sanity",	test_mock_microzap_sanity),
 	UNIT_TEST("mock_fatzap_sanity",		test_mock_fatzap_sanity),
 
-	UNIT_TEST("zap_basic",	test_zap_basic,	zap_type_params),
+	UNIT_TEST_ZAP_TYPES("zap_basic",	test_zap_basic),
+
+	UNIT_TEST_ZAP_TYPES("zap_add",		test_zap_add),
+	UNIT_TEST_ZAP_TYPES("zap_update",	test_zap_update),
+	UNIT_TEST_ZAP_TYPES("zap_remove",	test_zap_remove),
+	UNIT_TEST_ZAP_TYPES("zap_count",	test_zap_count),
+	UNIT_TEST_ZAP_TYPES("zap_contains",	test_zap_contains),
+	UNIT_TEST_ZAP_TYPES("zap_length",	test_zap_length),
+
+	UNIT_TEST("microzap_stats",		test_microzap_stats),
+	UNIT_TEST("fatzap_stats",		test_fatzap_stats),
 
 	{ 0 },
 };


### PR DESCRIPTION
_[Sponsors: TrueNAS]_

### Motivation and Context

Extends the ZAP unit tests to cover the "core" functions.

### Description

Adds basic tests covering add, update, remove, count, contains and length. These are fairly light because they need to cover the things that both ZAP types can handle, which limits values to a single `uint64_t`.

To make this possible, the existing `zap_update_by_dnode()`, `zap_length_by_dnode()` and `zap_get_stats_by_dnode()` functions are exposed, and `zap_contains_by_dnode()` added.

(This, incidentally, is another reason for #18551. I would normally be against adding additional code that is only called by tests and never by real code, but by establishing the pattern where `_by_dnode()` is the "actual" implementation, with the objset+object variants as tiny wrappers, then we ensure we're testing the actual work, and keeping the untested surface very small and simple).

`zap_get_stats_by_dnode()` is covered here. It's arguably not "core" but its a simple interface that doesn't really belong elsewhere (in the rough groupings I have for future PRs anyway).

`zap_lookup_by_dnode()` will be covered in a future PR; most of its surface is in variations in key and value length, and in key normalisation. There's very little to actually test here.

There's two minor quality-of-life improvements in the `unit-coverage` target included. It will now clean up the counters from the previous runs, and it can now take options for the target test. This makes it easier to see what an individual test+params covers.

### How Has This Been Tested?

ZTS is running locally, since there is a minor core change, but I'm not expecting anything.

Beyond that, its tests! Current coverage (via sekret tech):

```
$ coverage-report tests/unit/test_zap.info
File                               Lines                Functions                 Branches
------------------------------------------------------------------------------------------
zap_micro.c       65.1%  (   155/   238)   78.6%  (    11/    14)    0.0%  (     0/     0)
zap_leaf.c        53.4%  (   249/   466)   69.6%  (    16/    23)    0.0%  (     0/     0)
zap_impl.c        50.4%  (   117/   232)   60.0%  (    15/    25)    0.0%  (     0/     0)
zap_fat.c         41.5%  (   276/   665)   59.5%  (    22/    37)    0.0%  (     0/     0)
zap.c             22.9%  (   139/   606)   14.1%  (    10/    71)    0.0%  (     0/     0)
u8_textprep.c      0.0%  (     0/   802)    0.0%  (     0/    12)    0.0%  (     0/     0)
```

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
