### PR TITLE
dsl_scan: detect 'unencrypted block in encrypted objset' during scrub

### DIFF
--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -2381,6 +2381,43 @@ dsl_scan_visitbp(const blkptr_t *bp, const zbookmark_phys_t *zb,
 	}
 
 	/*
+	 * Detect "unencrypted block in encrypted object set" corruption.
+	 * On an encrypted dataset every BP — leaf data block or indirect —
+	 * must have BP_USES_CRYPT set. The read path in dbuf.c converts
+	 * a missing flag to EIO, and the create path historically panicked
+	 * in zfs_mknode.
+	 *
+	 * Log each occurrence so it appears in 'zpool status -v', and
+	 * count it for the scan's permanent-error tally. Both leaf and
+	 * indirect levels are checked: leaf BPs store data MAC in blk_cksum
+	 * directly, while indirect BPs store a MAC-of-MAC computed over
+	 * their children's MACs (see zio_crypt_do_indirect_mac_checksum_abd
+	 * in zio_crypt.c). Both forms are corrupted equally when the flag
+	 * is lost during write, so neither read nor scrub can verify them.
+	 *
+	 * Embedded BPs (BP_IS_EMBEDDED) inline their data into the BP
+	 * itself and never carry the encryption flag — skip them.
+	 *
+	 * Refs: #14330 #15275 #16065 #14709 #18186
+	 */
+	if (ds != NULL && !BP_IS_EMBEDDED(bp) && !BP_USES_CRYPT(bp)) {
+		objset_t *bp_os;
+		if (dmu_objset_from_ds(ds, &bp_os) == 0 &&
+		    bp_os->os_encrypted) {
+			scn->scn_phys.scn_errors++;
+			spa_log_error(dp->dp_spa, zb,
+			    BP_GET_PHYSICAL_BIRTH(bp));
+			zfs_dbgmsg("scrub: encrypted objset %llu has BP "
+			    "without BP_USES_CRYPT (object %llu, "
+			    "level %u, blkid %llu)",
+			    (u_longlong_t)zb->zb_objset,
+			    (u_longlong_t)zb->zb_object,
+			    (uint_t)zb->zb_level,
+			    (u_longlong_t)zb->zb_blkid);
+		}
+	}
+
+	/*
 	 * Check if this block contradicts any filesystem flags.
 	 */
 	spa_feature_t f = SPA_FEATURE_LARGE_BLOCKS;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Motivation and Context

The "unencrypted block in encrypted object set" failure class on
natively-encrypted datasets has been reported continuously from ZFS
2.0.x through 2.4.x across several open issues:

- #14330 — "Another encryption bug: 'unencrypted block in encrypted'"
- #15275 — "[6.5.x, 2.2.99git] PANIC in zfs_mknode->sa_buf_hold"
  (closed by #15464/#15465 backport for 2.2.1, but new reports keep
  arriving on 2.3.x — see e.g. the 2024-11 comment about Debian 12 +
  rsync that re-opened the discussion)
- #16065 — "PANIC: unencrypted block in encrypted object set"
  (Ubuntu 24.04 / ZFS 2.2; still reproducing on 2.3.1 per the
  2025-05-30 comment from @darkpixel)
- #15464 — "OpenZFS 2.2.0 copy_file_range(2) ... panic" (root-cause
  fix that closed the original `zfs_clone_range()` vector but did
  not eliminate every path that produces this corruption shape)

PR #15677 (Dec 2023) converted the *read*-path panic in `dbuf.c` to a
logged error. Users hitting the bug today still cannot easily identify
which file is affected: the symptom is either a kernel panic in
`zfs_mknode` (CREATE path, still `VERIFY0(sa_buf_hold)`) or an
intermittent EIO from `dbuf_read` with no per-file attribution.

### Description

Add a BP check in `dsl_scan_visitbp()`: when a dataset is encrypted
yet a block pointer lacks `BP_USES_CRYPT`, count it as a scan error,
push the offending bookmark into the SPA error log (so it surfaces
in `zpool status -v` as a permanent error against the affected file),
and emit a `zfs_dbgmsg` with exact bookmark coordinates (including
the BP level) for offline `zdb` correlation.

The check covers both leaf blocks (level 0, file data) and indirect
blocks (level > 0, MAC-of-MAC over children). Embedded BPs are
explicitly skipped — they inline data into the BP itself and never
carry the CRYPT flag by design. Hole BPs are skipped earlier in
`dsl_scan_visitbp()`.

Detection only — no repair. Users who hit it should delete the
affected file and restore from backup, recreate the pool without
ZFS native encryption (LUKS underneath still provides data-at-rest
protection on most affected deployments), or use the existing
`zfs send -U` + `zfs recv` recovery flow (PR #18240).

### Relationship to PR #18474 (thorough scrub)

PR #18474 (alek-p, in review) adds a "thorough scrub" mode that
decrypts and decompresses every block during a scrub, catching
corruption where the on-disk checksum is valid but decryption or
decompression fails on blocks that carry `BP_IS_ENCRYPTED`.

The two efforts are **complementary, not overlapping**:

| Bug class | Detected by #18474 | Detected by #18587 |
|---|:---:|:---:|
| `BP_IS_ENCRYPTED` set, data fails to decrypt/decompress | yes | no |
| `BP_USES_CRYPT` missing on encrypted dataset (decrypt path never enters) | no | yes |

#18474 walks past lost-CRYPT-flag blocks because they never enter
the decrypt path; #18587 walks past decrypt-failures because the BP
looks intact. Running both gives full coverage of the
encrypted-block-corruption space surfaced in the issues above.

### How Has This Been Tested?

- VM: Arch Linux on linux-lts 6.12.10 with ZFS master built from
  current branch (after rebase onto master).
- Scrub instrumentation (temporary `zfs_dbgmsg` per visited BP,
  removed in final commit) verified that the new check filter
  correctly classifies BPs across both leaf and indirect levels:
    - on `os_encrypted=1` objsets: every visited non-embedded BP
      with `BP_USES_CRYPT` clear was captured by the new branch
    - on `os_encrypted=0` objsets: zero false matches
- Note: no in-tree reproducer creates the corruption state this
  check targets. The state is reported by users on long-running
  pools (often after `zfs receive` of encrypted streams onto a
  fresh pool, or hardware-induced corruption per #16065). The
  detection logic was verified by examining every BP visited
  during scrubs of synthetic encrypted pools — the conditional
  filter behaves as designed.
- `make checkstyle` passes for the modified file.
- ZTS rsend and encryption suites pass with the patch applied
  (no regression on synthetic pools that do not contain the
  target corruption).

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly. *(deferred — see open question below)*
- [x] I have read the [contributing document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes. *(see open question below)*
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

### Open questions for reviewers

1. **Test coverage.** No existing reproducer in-tree creates the
   exact "encrypted BP without `BP_USES_CRYPT`" state. Users
   report it in production but I was unable to construct a
   minimal reproducer in a VM. A follow-up zinject extension
   (e.g. `ZINJECT_LOSE_CRYPT_FLAG`, modeled on the no-op injection
   type added in #16085) would unblock a deterministic ZTS test;
   happy to submit that as a prerequisite if reviewers prefer.

2. **Should `zpool status` surface a count** of `encryption flag
   mismatches` separately from the standard "permanent errors"
   counter? Current change reuses the existing `spa_log_error`
   infrastructure so the error appears in the standard list; a
   dedicated counter would require a new event subtype which
   feels out of scope for a detection-only patch.

3. **Repair path.** I prototyped three repair modes (smart flip
   when MAC validates, re-encrypt rewrite, free fallback) but
   pulled them out of this PR because none were verified against
   a real reproducer. Happy to follow up with them in a separate
   PR once detection is in place and we have observability into
   how often this fires in practice.
