### PR TITLE
spa: expose max_missing_tvds_cachefile and _scan on Linux

### DIFF
--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -918,6 +918,19 @@ but that was not proven to be useful.
 Number of missing top-level vdevs which will be allowed during
 pool import (only in read-only mode).
 .
+.It Sy zfs_max_missing_tvds_cachefile Ns = Ns Sy 2 Pq u64
+Number of missing top-level vdevs tolerated when importing a pool
+from a cachefile, before the trusted config is read from the MOS.
+A cachefile can fall out of sync with the on-disk config after a
+device removal that did not rewrite the cachefile, so the default
+of 2 still lets the import reach a copy of the MOS.
+.
+.It Sy zfs_max_missing_tvds_scan Ns = Ns Sy 0 Pq u64
+Number of missing top-level vdevs tolerated when importing a pool
+by scanning device paths, before the trusted config is read from
+the MOS.
+Defaults to 0 because a scan should detect every present device.
+.
 .It Sy zfs_max_nvlist_src_size Ns = Sy 0 Pq u64
 Maximum size in bytes allowed to be passed as
 .Sy zc_nvlist_src_size

--- a/module/os/freebsd/zfs/sysctl_os.c
+++ b/module/os/freebsd/zfs/sysctl_os.c
@@ -381,18 +381,6 @@ SYSCTL_INT(_vfs_zfs, OID_AUTO, ccw_retry_interval,
 	"Configuration cache file write, retry after failure, interval"
 	" (seconds)");
 
-extern uint64_t zfs_max_missing_tvds_cachefile;
-
-SYSCTL_UQUAD(_vfs_zfs, OID_AUTO, max_missing_tvds_cachefile,
-	CTLFLAG_RWTUN, &zfs_max_missing_tvds_cachefile, 0,
-	"Allow importing pools with missing top-level vdevs in cache file");
-
-extern uint64_t zfs_max_missing_tvds_scan;
-
-SYSCTL_UQUAD(_vfs_zfs, OID_AUTO, max_missing_tvds_scan,
-	CTLFLAG_RWTUN, &zfs_max_missing_tvds_scan, 0,
-	"Allow importing pools with missing top-level vdevs during scan");
-
 /* spa_misc.c */
 
 extern int zfs_flags;

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -11811,6 +11811,12 @@ ZFS_MODULE_PARAM(zfs, zfs_, max_missing_tvds, U64, ZMOD_RW,
 	"Allow importing pool with up to this number of missing top-level "
 	"vdevs (in read-only mode)");
 
+ZFS_MODULE_PARAM(zfs, zfs_, max_missing_tvds_cachefile, U64, ZMOD_RW,
+	"Allow importing pools with missing top-level vdevs in cache file");
+
+ZFS_MODULE_PARAM(zfs, zfs_, max_missing_tvds_scan, U64, ZMOD_RW,
+	"Allow importing pools with missing top-level vdevs during scan");
+
 ZFS_MODULE_PARAM(zfs_livelist_condense, zfs_livelist_condense_, zthr_pause, INT,
 	ZMOD_RW, "Set the livelist condense zthr to pause");
 


### PR DESCRIPTION
### Motivation and Context

`zfs_max_missing_tvds_cachefile` and `zfs_max_missing_tvds_scan` were only exposed on FreeBSD as tunables via `SYSCTL_UQUAD` but not on Linux.

### Description

Register both variables on Linux via `ZFS_MODULE_PARAM` in shared `spa.c`, drop the FreeBSD `SYSCTL_UQUAD` declarations, and document them in `zfs.4`.

### How Has This Been Tested?

**Linux (Arch, kernel 6.19.10):** both appear under `/sys/module/zfs/parameters/` after module rebuild, read the expected defaults of 2 and 0.

**FreeBSD (16.0-CURRENT):** commit compiles cleanly with clang.

### Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the contributing document.
- [ ] I have added tests to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain Signed-off-by.