### PR TITLE
.github: update workflows README

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -41,7 +41,7 @@ The steps inside one entry are:
 1) set up QEMU and boot the guest (~2-4m)
 2) install build dependencies in the guest (~2-4m)
 3) build zfs modules in the guest (~8-12m)
-4) run sanity + zloop + functional tests (~2-4h)
+4) run functional tests (~2-4h)
 5) package and upload per-OS test logs (~10s)
 
 A per-OS entry takes about 3 to 4 hours. Once all entries finish, the

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,61 +1,96 @@
 
-## The testings are done this way
+## CI overview
+
+The main test pipeline is `zfs-qemu.yml`. Code checking and other
+workflows run independently alongside it.
 
 ```mermaid
 flowchart TB
-subgraph CleanUp and Summary
-  CleanUp+Summary
+subgraph Functional testing
+  Setup[test-config: pick ci_type + OS matrix]
+  Setup --> almalinux
+  Setup --> centos[centos-stream]
+  Setup --> debian
+  Setup --> fedora
+  Setup --> ubuntu
+  Setup --> freebsd
+  almalinux --> Cleanup[cleanup + summary]
+  centos --> Cleanup
+  debian --> Cleanup
+  fedora --> Cleanup
+  ubuntu --> Cleanup
+  freebsd --> Cleanup
 end
 
-subgraph Functional Testings
-  sanity-checks-20.04
-  zloop-checks-20.04
-  functional-testing-20.04-->Part1-20.04
-  functional-testing-20.04-->Part2-20.04
-  functional-testing-20.04-->Part3-20.04
-  functional-testing-20.04-->Part4-20.04
-  functional-testing-22.04-->Part1-22.04
-  functional-testing-22.04-->Part2-22.04
-  functional-testing-22.04-->Part3-22.04
-  functional-testing-22.04-->Part4-22.04
-  sanity-checks-22.04
-  zloop-checks-22.04
-end
-
-subgraph Code Checking + Building
-  Build-Ubuntu-20.04
+subgraph Code checking
+  checkstyle.yaml
   codeql.yml
-  checkstyle.yml
-  Build-Ubuntu-22.04
+  smatch.yml
 end
 
-  Build-Ubuntu-20.04-->sanity-checks-20.04
-  Build-Ubuntu-20.04-->zloop-checks-20.04
-  Build-Ubuntu-20.04-->functional-testing-20.04
-  Build-Ubuntu-22.04-->sanity-checks-22.04
-  Build-Ubuntu-22.04-->zloop-checks-22.04
-  Build-Ubuntu-22.04-->functional-testing-22.04
-
-  sanity-checks-20.04-->CleanUp+Summary
-  Part1-20.04-->CleanUp+Summary
-  Part2-20.04-->CleanUp+Summary
-  Part3-20.04-->CleanUp+Summary
-  Part4-20.04-->CleanUp+Summary
-  Part1-22.04-->CleanUp+Summary
-  Part2-22.04-->CleanUp+Summary
-  Part3-22.04-->CleanUp+Summary
-  Part4-22.04-->CleanUp+Summary
-  sanity-checks-22.04-->CleanUp+Summary
+subgraph Other workflows
+  zfs-arm.yml
+  zloop.yml
+  labels.yml
+end
 ```
 
+Every `qemu-vm` matrix entry runs on a fixed `ubuntu-24.04` host.
+The steps inside one entry are:
 
-1) build zfs modules for Ubuntu 20.04 and 22.04 (~15m)
-2) 2x zloop test (~10m) + 2x sanity test (~25m)
-3) 4x functional testings in parts 1..4 (each ~1h)
-4) cleanup and create summary
-   - content of summary depends on the results of the steps
+1) set up QEMU and boot the guest (~2-4m)
+2) install build dependencies in the guest (~2-4m)
+3) build zfs modules in the guest (~8-12m)
+4) run sanity + zloop + functional tests (~2-4h)
+5) package and upload per-OS test logs (~10s)
 
-When everything runs fine, the full run should be done in
-about 2 hours.
+A per-OS entry takes about 3 to 4 hours. Once all entries finish, the
+`cleanup` job aggregates the results into a summary.
 
-The codeql.yml and checkstyle.yml are not part in this circle.
+### `ci_type` selection
+
+`test-config` runs `.github/workflows/scripts/generate-ci-type.py` against
+the PR's changed files and picks one of:
+
+| `ci_type` | OS matrix                                  |
+|-----------|--------------------------------------------|
+| `docs`    | empty (documentation-only PRs)             |
+| `quick`   | 6 Linux + 1 FreeBSD                        |
+| `linux`   | all supported Linux distros                |
+| `freebsd` | all supported FreeBSD versions             |
+| default   | cross-platform sample                      |
+
+Pushes to `openzfs/zfs` skip the matrix entirely; only PRs (and pushes to
+forks) build.
+
+Authors can force a specific ci_type by adding `ZFS-CI-Type: <type>` to
+the most recent commit message. The `ZTS_OS_OVERRIDE` repository variable
+can also alter the selection. The `workflow_dispatch` trigger accepts
+`fedora_kernel_ver` (Fedora-only run with a chosen kernel) and
+`specific_os` (pin the matrix to one OS).
+
+### Supported guests
+
+Auto-selected:
+
+- Linux: almalinux 8/9/10, centos-stream 9/10, debian 11/12/13,
+  fedora 43/44, ubuntu 22/24/26
+- FreeBSD: 14.4-RELEASE/STABLE, 15.0-RELEASE, 15.1-STABLE, 16.0-CURRENT
+
+Available via `specific_os` or `ZTS_OS_OVERRIDE`:
+
+- archlinux, tumbleweed
+
+### Code checking
+
+- `checkstyle.yaml`: source-style checks
+- `codeql.yml`: CodeQL analysis
+- `smatch.yml`: smatch analysis
+
+### Other workflows
+
+- `zfs-arm.yml`: ARM build on `ubuntu-24.04-arm`
+- `zloop.yml`: host-side zloop
+- `labels.yml`: maintains PR status labels
+- `zfs-qemu-packages.yml`: manually dispatched, builds release RPMs or
+  tests RPM installation from the ZFS yum repo


### PR DESCRIPTION
### Motivation and Context

The current .github/workflows/README.md has outdated info.

### Description

- Update the mermaid diagram
- Document the ci_type selection (docs / quick / linux / freebsd / default) and custom override repo variables

### How Has This Been Tested?

Doc-only change. Per-step timing were sampled across different recent PRs.

### Types of changes

- [x] Documentation

### Checklist:

- [x] My code follows the OpenZFS code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the contributing document.
- [x] All commit messages are properly formatted and contain Signed-off-by.