### PR TITLE
Prevent checkpointed DTLs from restarting resilvers

### DIFF
--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -5866,13 +5866,14 @@ vdev_defer_resilver(vdev_t *vd)
 
 /*
  * Clears the resilver deferred flag on all leaf devs under vd. Returns
- * B_TRUE if we have devices that need to be resilvered and are available to
- * accept resilver I/Os.
+ * B_TRUE if we cleared a deferred device that still needs to be resilvered
+ * and is available to accept resilver I/Os.
  */
 boolean_t
 vdev_clear_resilver_deferred(vdev_t *vd, dmu_tx_t *tx)
 {
 	boolean_t resilver_needed = B_FALSE;
+	boolean_t was_deferred;
 	spa_t *spa = vd->vdev_spa;
 
 	for (int c = 0; c < vd->vdev_children; c++) {
@@ -5892,9 +5893,10 @@ vdev_clear_resilver_deferred(vdev_t *vd, dmu_tx_t *tx)
 	    !vd->vdev_ops->vdev_op_leaf)
 		return (resilver_needed);
 
+	was_deferred = vd->vdev_resilver_deferred;
 	vd->vdev_resilver_deferred = B_FALSE;
 
-	return (!vdev_is_dead(vd) && !vd->vdev_offline &&
+	return (was_deferred && !vdev_is_dead(vd) && !vd->vdev_offline &&
 	    vdev_resilver_needed(vd, NULL, NULL));
 }
 

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -975,7 +975,7 @@ tests = ['attach_import', 'attach_multiple', 'attach_rebuild',
     'rebuild_disabled_feature', 'rebuild_multiple', 'rebuild_raidz',
     'replace_import', 'replace_rebuild', 'replace_resilver',
     'replace_resilver_sit_out', 'resilver_restart_001',
-    'resilver_restart_002', 'scrub_cancel']
+    'resilver_restart_002', 'resilver_restart_003', 'scrub_cancel']
 tags = ['functional', 'replacement']
 
 [tests/functional/reservation]

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -2021,6 +2021,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/replacement/replace_resilver_sit_out.ksh \
 	functional/replacement/resilver_restart_001.ksh \
 	functional/replacement/resilver_restart_002.ksh \
+	functional/replacement/resilver_restart_003.ksh \
 	functional/replacement/scrub_cancel.ksh \
 	functional/replacement/setup.ksh \
 	functional/reservation/cleanup.ksh \

--- a/tests/zfs-tests/tests/functional/replacement/resilver_restart_003.ksh
+++ b/tests/zfs-tests/tests/functional/replacement/resilver_restart_003.ksh
@@ -1,0 +1,93 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/replacement/replacement.cfg
+
+#
+# DESCRIPTION:
+#	Verify that a resilver does not restart after completing while a pool
+#	checkpoint is present.
+#
+# STRATEGY:
+#	1. Create a single-disk pool and write data.
+#	2. Start an attach resilver and suspend scan progress.
+#	3. Create a checkpoint while the resilver is active.
+#	4. Let the resilver finish.
+#	5. Verify the checkpoint-retained DTL does not start another resilver.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	log_must set_tunable32 SCAN_SUSPEND_PROGRESS \
+	    $ORIG_SCAN_SUSPEND_PROGRESS
+	log_must set_tunable32 RESILVER_MIN_TIME_MS $ORIG_RESILVER_MIN_TIME
+	log_must zpool events
+	destroy_pool $TESTPOOL1
+	rm -f ${VDEV_FILES[0]} $SPARE_VDEV_FILE
+}
+
+function wait_for_event # pattern timeout
+{
+	typeset pattern=$1
+	typeset timeout=${2:-60}
+	typeset -i events=0
+
+	for (( iter = 0; iter < timeout; iter++ )); do
+		events=$(zpool events | grep -cF "$pattern")
+		(( events > 0 )) && return 0
+		sleep 1
+	done
+
+	return 1
+}
+
+log_assert "Checkpointed DTLs do not restart a completed resilver"
+
+ORIG_SCAN_SUSPEND_PROGRESS=$(get_tunable SCAN_SUSPEND_PROGRESS)
+ORIG_RESILVER_MIN_TIME=$(get_tunable RESILVER_MIN_TIME_MS)
+
+log_onexit cleanup
+
+log_must truncate -s $VDEV_FILE_SIZE ${VDEV_FILES[0]} $SPARE_VDEV_FILE
+log_must zpool create -f -O recordsize=128K $TESTPOOL1 ${VDEV_FILES[0]}
+log_must eval "dd if=/dev/urandom of=/$TESTPOOL1/file bs=1M count=32" \
+	">/dev/null 2>&1"
+
+log_must zpool events -c
+log_must set_tunable32 RESILVER_MIN_TIME_MS 20
+log_must set_tunable32 SCAN_SUSPEND_PROGRESS 1
+log_must zpool attach $TESTPOOL1 ${VDEV_FILES[0]} $SPARE_VDEV_FILE
+
+log_must wait_for_event "sysevent.fs.zfs.resilver_start" 60
+log_must zpool checkpoint $TESTPOOL1
+
+log_must set_tunable32 SCAN_SUSPEND_PROGRESS 0
+log_must wait_for_event "sysevent.fs.zfs.resilver_finish" 120
+
+# Wait a few txgs to ensure completion does not queue a deferred resilver.
+sync_pool $TESTPOOL1 true
+sync_pool $TESTPOOL1 true
+
+resilver_starts=$(zpool events | grep -cF "sysevent.fs.zfs.resilver_start")
+(( resilver_starts != 1 )) &&
+	log_fail "expected 1 resilver start, found $resilver_starts"
+
+log_pass "Completed resilver was not restarted with checkpoint present"


### PR DESCRIPTION
### Motivation and Context
Pool checkpoints intentionally preserve DTL_MISSING entries after a scan because checkpoint-only blocks are not traversed. That retained DTL is needed if the pool is rewound, but it does not mean a new resilver was deferred.

Deferred resilvers rely on `vdev_resilver_deferred` to mark vdevs that missed txgs outside the active scan range. Treating any remaining DTL as deferred work breaks that distinction, so a completed resilver with a checkpoint can immediately queue another resilver and repeat indefinitely.

This fixes #11434 and fixes #17109. It follows the deferred-resilver intent from #7732 and keeps the restart avoidance added by #9588: a follow-up scan is only needed when a vdev was actually deferred.

### Description
The follow-up resilver request is now gated on whether a leaf vdev had `vdev_resilver_deferred` set before it was cleared. Checkpoint-retained DTLs remain intact, while real deferred resilvers still run after the current scan completes.

A regression test creates a checkpoint during an attach resilver, lets the resilver finish, and verifies that no second `resilver_start` event is generated.

### How Has This Been Tested?
- `scripts/cstyle.pl module/zfs/vdev.c`
- `git diff --check`
- `bash -n tests/zfs-tests/tests/functional/replacement/resilver_restart_003.ksh`
- `scripts/commitcheck.sh HEAD`

I did not run the ZFS Test Suite in this environment because this checkout is not configured (`Makefile` and `config.status` are absent) and `ksh` is not installed.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).