### PR TITLE
FreeBSD: Make it possible to build openzfs.ko with sanitizers

### DIFF
--- a/module/Makefile.bsd
+++ b/module/Makefile.bsd
@@ -65,6 +65,12 @@ CFLAGS+= -DZFS_DEBUG -g
 CFLAGS += -DNDEBUG
 .endif
 
+.for _SAN in KASAN KMSAN KUBSAN
+.if defined(WITH_${_SAN}) && ${WITH_${_SAN}} == "true"
+KERN_OPTS_EXTRA+= ${_SAN}
+.endif
+.endfor
+
 .if defined(WITH_GCOV) && ${WITH_GCOV} == "true"
 CFLAGS+=	 -fprofile-arcs -ftest-coverage
 .endif


### PR DESCRIPTION
Add make options which let one respectively compile the kernel modules with the address sanitizer, memory sanitizer, and undefined behaviour sanitizer enabled.  This makes it much easier to run the ZTS with those sanitizers enabled.

### Motivation and Context
It's desirable to be able to run ZFS with kernel sanitizers enabled. This is trivial when building the copy of OpenZFS vendored into the FreeBSD src tree, but not easily done otherwise. The change makes it easier to build openzfs.ko with sanitizers enabled, by exposing a few make variables that can be set during a build.

### Description
If `WITH_K*SAN` is set to true, add the corresponding kernel option so that FreeBSD's kernel module build infrastructure does the right thing.

### How Has This Been Tested?
Manual testing, checked the symbol tables of openzfs.ko to verify that the corresponding sanitizer was enabled, booted FreeBSD with openzfs.ko and ran a few tests from the ZTS.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
