### PR TITLE
zbookmark_compare: avoid negative shift in block span calculation

### DIFF
--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -5984,6 +5984,31 @@ static zio_pipe_stage_t *zio_pipeline[] = {
  * equivalent, compare appropriately to bookmarks in other objects, and to
  * compare appropriately to other bookmarks in the meta-dnode.
  */
+static inline void
+zbookmark_compare_verify(uint8_t ibs, const zbookmark_phys_t *zb)
+{
+#ifdef ZFS_DEBUG
+	/* Sanity checks for the incoming indirect block shift. */
+	if (zb->zb_level > 0) {
+		/*
+		 * For level > 0, then ibs must be set to a valid block shift,
+		 * no exceptions.
+		 */
+		ASSERT3U(ibs, >=, SPA_MINBLOCKSHIFT);
+		ASSERT3U(ibs, <=, SPA_MAXBLOCKSHIFT);
+	} else if (ibs > 0) {
+		/*
+		 * For level == 0, ibs is optional and may be zero. If it is
+		 * set, then it may be the meta-dnode where "data" block is
+		 * more like an indirect block, full of block pointers. So ibs
+		 * must be at least SPA_BLKPTRSHIFT.
+		 */
+		ASSERT3U(ibs, >=, SPA_BLKPTRSHIFT);
+		ASSERT3U(ibs, <=, SPA_MAXBLOCKSHIFT);
+	}
+#endif
+}
+
 int
 zbookmark_compare(uint16_t dbss1, uint8_t ibs1, uint16_t dbss2, uint8_t ibs2,
     const zbookmark_phys_t *zb1, const zbookmark_phys_t *zb2)
@@ -6002,14 +6027,17 @@ zbookmark_compare(uint16_t dbss1, uint8_t ibs1, uint16_t dbss2, uint8_t ibs2,
 	    zb1->zb_blkid == zb2->zb_blkid)
 		return (0);
 
-	IMPLY(zb1->zb_level > 0, ibs1 >= SPA_MINBLOCKSHIFT);
-	IMPLY(zb2->zb_level > 0, ibs2 >= SPA_MINBLOCKSHIFT);
+	zbookmark_compare_verify(ibs1, zb1);
+	zbookmark_compare_verify(ibs2, zb2);
 
 	/*
-	 * BP_SPANB calculates the span in blocks.
+	 * BP_SPANB calculates the span in blocks. Zero for the indirect
+	 * shift means we're at level 0, so the span is just the blkid.
 	 */
-	zb1L0 = (zb1->zb_blkid) * BP_SPANB(ibs1, zb1->zb_level);
-	zb2L0 = (zb2->zb_blkid) * BP_SPANB(ibs2, zb2->zb_level);
+	zb1L0 = (ibs1 == 0) ? (zb1->zb_blkid) :
+	    (zb1->zb_blkid) * BP_SPANB(ibs1, zb1->zb_level);
+	zb2L0 = (ibs2 == 0) ? (zb2->zb_blkid) :
+	    (zb2->zb_blkid) * BP_SPANB(ibs2, zb2->zb_level);
 
 	if (zb1->zb_object == DMU_META_DNODE_OBJECT) {
 		zb1obj = zb1L0 * (dbss1 << (SPA_MINBLOCKSHIFT - DNODE_SHIFT));


### PR DESCRIPTION
_[Sponsors: TrueNAS]_

### Motivation and Context

Fixes #14777

### Description

`BP_SPANB` subtracts `SPA_BLKPTRSHIFT` from the indirect block shift before shifting it. However, 0 is a legal value for `ibs` here, and the math is all unsigned, so the subtract can underflow, which is UB, and even if the compiler does resolve it to something negative, a negative shift is also UB.

Its unclear if this can be a correctness issue because it (hopefully!) only impacts the sort order. It's definitely not good though, and UBSAN has been seen to complain about.

This commit fixes it by only calling `BP_SPANB` if the ibs not zero, instead just using the block id, which is the intent. The asserts are extended to ensure that if it is non-zero, it is in a safe range.

### How Has This Been Tested?

ZTS run completed and passed, so that's nice. However! #14777 mentions scrub with L2ARC, which we don't have a test for (unless its hidden down the back somewhere and I missed it). But it also might be coincidental. The examples all show a negative shifts that aren't `0 - SPA_BLKPTRSHIFT == -7`, so either that's the UB at play, or its real and different things are calling `zbookmark_compare()` with weird small values for `ibs`. I suspect the former, but I don't really know this code path at all.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
