### PR TITLE
enforce exact decompressed length for lz4, gzip, and zstd

### DIFF
--- a/module/zfs/gzip.c
+++ b/module/zfs/gzip.c
@@ -96,12 +96,16 @@ zfs_gzip_decompress_buf(void *s_start, void *d_start, size_t s_len,
 	/* check if hardware accelerator can be used */
 	if (qat_dc_use_accel(d_len)) {
 		if (qat_compress(QAT_DECOMPRESS, s_start, s_len,
-		    d_start, d_len, &dstlen) == CPA_STATUS_SUCCESS)
-			return (0);
+		    d_start, d_len, &dstlen) == CPA_STATUS_SUCCESS) {
+			if ((size_t)dstlen == d_len)
+				return (0);
+		}
 		/* if hardware de-compress fail, do it again with software */
 	}
 
 	if (uncompress_func(d_start, &dstlen, s_start, s_len) != Z_OK)
+		return (-1);
+	if ((size_t)dstlen != d_len)
 		return (-1);
 
 	return (0);

--- a/module/zfs/lz4_zfs.c
+++ b/module/zfs/lz4_zfs.c
@@ -88,17 +88,24 @@ zfs_lz4_decompress_buf(void *s_start, void *d_start, size_t s_len,
 	(void) n;
 	const char *src = s_start;
 	uint32_t bufsiz = BE_IN32(src);
+	int decoded;
 
 	/* invalid compressed buffer size encoded at start */
 	if (bufsiz + sizeof (bufsiz) > s_len)
 		return (1);
 
 	/*
-	 * Returns 0 on success (decompression function returned non-negative)
-	 * and non-zero on failure (decompression function returned negative).
+	 * LZ4_uncompress_unknownOutputSize returns the number of bytes decoded
+	 * on success, or a negative value on failure. An OpenZFS block must
+	 * expand to exactly d_len bytes
 	 */
-	return (LZ4_uncompress_unknownOutputSize(&src[sizeof (bufsiz)],
-	    d_start, bufsiz, d_len) < 0);
+	decoded = LZ4_uncompress_unknownOutputSize(&src[sizeof (bufsiz)],
+	    d_start, bufsiz, d_len);
+	if (decoded < 0)
+		return (1);
+	if (d_len != (size_t)decoded)
+		return (1);
+	return (0);
 }
 
 ZFS_COMPRESS_WRAP_DECL(zfs_lz4_compress)

--- a/module/zstd/zfs_zstd.c
+++ b/module/zstd/zfs_zstd.c
@@ -682,6 +682,15 @@ zfs_zstd_decompress_level_buf(void *s_start, void *d_start, size_t s_len,
 		return (1);
 	}
 
+	/*
+	 * An OpenZFS compressed block must expand to exactly d_len bytes.
+	 * ZSTD_decompressDCtx returns the decompressed size on success.
+	 */
+	if (result != d_len) {
+		ZSTDSTAT_BUMP(zstd_stat_dec_fail);
+		return (1);
+	}
+
 	if (level) {
 		*level = curlevel;
 	}


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context

We don't want to mask partial decompression (failure) and treat it as a success. I don't know if that has ever actually happened nor what the implications are appart from missing a chance at auto-healing. Either way we should be consistent with the decompression functions' APIs and they describe that a partial decompression length is a valid return value. However this doesn't make sense in our context as we should be getting back the size we put in, anything else to me is a failure.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
Decompressors must expand a OpenZFS block to exactly the expected number of bytes. Treat decompression to an unexpected length as failure, so truncated or short output is not accepted as valid decompression. This makes our handling of decompress function return values consistent with the decompression functions' APIs.

Note we already do this [destination size checking for zle decompression](https://github.com/openzfs/zfs/blob/master/module/zfs/zle.c#L93).

<!--- Describe your changes in detail -->

### How Has This Been Tested?
zfs-tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
