### PR TITLE
CI: Update checkstyle checkout action to v6

### DIFF
--- a/.github/workflows/checkstyle.yaml
+++ b/.github/workflows/checkstyle.yaml
@@ -12,7 +12,7 @@ jobs:
   checkstyle:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         ref: ${{ github.event.pull_request.head.sha }}
     - name: Install dependencies


### PR DESCRIPTION
### Motivation and Context
The `checkstyle` workflow was the only one still on `actions/checkout@v4`. Every other workflow moved to `v6` in #18411. This bumps it to match.

### Description
Update `actions/checkout` from `v4` to `v6` in `.github/workflows/checkstyle.yaml`.

### How Has This Been Tested?
CI will tell :)

### Types of changes
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code follows the OpenZFS code style requirements.
- [x] I have read the contributing document.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.