### PR TITLE
CI: skip smatch, zloop, and zfs-arm for documentation-only changes

### DIFF
--- a/.github/workflows/smatch.yml
+++ b/.github/workflows/smatch.yml
@@ -3,6 +3,14 @@ name: smatch
 on:
   push:
   pull_request:
+    paths-ignore:
+      - 'man/**'
+      - '**.md'
+      - 'AUTHORS'
+      - 'COPYRIGHT'
+      - 'LICENSE'
+      - 'NOTICE'
+      - '.gitignore'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/zfs-arm.yml
+++ b/.github/workflows/zfs-arm.yml
@@ -3,6 +3,14 @@ name: zfs-arm
 on:
   push:
   pull_request:
+    paths-ignore:
+      - 'man/**'
+      - '**.md'
+      - 'AUTHORS'
+      - 'COPYRIGHT'
+      - 'LICENSE'
+      - 'NOTICE'
+      - '.gitignore'
   workflow_dispatch:
     inputs:
       gcc_ver:

--- a/.github/workflows/zloop.yml
+++ b/.github/workflows/zloop.yml
@@ -3,6 +3,14 @@ name: zloop
 on:
   push:
   pull_request:
+    paths-ignore:
+      - 'man/**'
+      - '**.md'
+      - 'AUTHORS'
+      - 'COPYRIGHT'
+      - 'LICENSE'
+      - 'NOTICE'
+      - '.gitignore'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
### Motivation and Context
Follow-up to #18518, which skipped the qemu matrix on documentation-only PRs. The `smatch`, `zloop`, and `zfs-arm` workflows are irrelevant for doc only changes.

### Description
Add a `paths-ignore` filter to the `pull_request` trigger of those 3 workflows.

### How Has This Been Tested?
Not tested yet.

### Types of changes
- [x] Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code follows the OpenZFS code style requirements.
- [x] I have read the contributing document.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.