### PR TITLE
CI: Lustre 6.16 kernel compatibility fix

### DIFF
--- a/.github/workflows/scripts/qemu-6-lustre-tests-vm.sh
+++ b/.github/workflows/scripts/qemu-6-lustre-tests-vm.sh
@@ -25,8 +25,14 @@ cd lustre-release
 
 # Include Lustre patches to build against master/zfs-2.4.x.  Once these
 # patches are merged we can remove these lines.
+#
+# LU-19539 osd-zfs: use osd_dmu_write() wrapper for xattrs
+# LU-19761 osd-zfs: Build against ZFS 2.4.0
+# LU-19249 build: Compatibility updates for kernel v6.16
+#
 patches=('https://review.whamcloud.com/changes/fs%2Flustre-release~62101/revisions/2/patch?download'
-	'https://review.whamcloud.com/changes/fs%2Flustre-release~63267/revisions/9/patch?download')
+	'https://review.whamcloud.com/changes/fs%2Flustre-release~63267/revisions/9/patch?download'
+	'https://review.whamcloud.com/changes/fs%2Flustre-release~60619/revisions/13/patch?download')
 
 for p in "${patches[@]}" ; do
 	curl $p | base64 -d > patch


### PR DESCRIPTION
### Motivation and Context

Fix the build.  Lustre fails to build on AlmaLinux due to an updated kernel.

### Description

AlmaLinux 9,10 kernels now include a backport of Linux commit v6.15-13744-g41cb08555c41 which renames the from_timer() function to timer_container_of().  Apply the upstream Lustre compatibility patch to our builds.  This patch should be included in the next Lustre release and can be dropped then.

### How Has This Been Tested?

Manually tested the build.  Will be verified by CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)
