### PR TITLE
zdb -l should not call libzfs_core_init

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -10230,7 +10230,7 @@ main(int argc, char **argv)
 	 * Automate cachefile
 	 */
 	if (!spa_config_path_env && !config_path_console && target &&
-	    libzfs_core_init() == 0) {
+	    !dump_opt['l'] && libzfs_core_init() == 0) {
 		char *pname = strdup(target);
 		const char *value;
 		nvlist_t *pnvl = NULL;


### PR DESCRIPTION
when reading vdev, it is not necessary to call libzfs_core_init. And even call it, the following code is not benefit, because the vdev name begins with "/", pname is empty when calling lzc_get_props.

### Motivation and Context
zpool status will try to auto-load zfs.ko, and issue #18593 asking for not auto-load. zdb is "most of" user space tool, which should be consider if does not like to auto-load in zpool. This PR will ensure when "-l" is specified, no kernel invocation, e.g. not accessing /dev/zfs, and no ioctl.


### Description
Just add more condition for calling libzfs_core_init.

### How Has This Been Tested?
Test local with strace to ensure no more /dev/zfs, no ioctl.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [X] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
