### PR TITLE
CI: add concurrency support to zfs-arm

### DIFF
--- a/.github/workflows/zfs-arm.yml
+++ b/.github/workflows/zfs-arm.yml
@@ -19,6 +19,10 @@ on:
         default: ""
         description: "(optional) install specific GCC version, like '16'"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   zfs-arm:
     name: ZFS ARM build


### PR DESCRIPTION
### Motivation and Context

The `zfs-arm` workflow was the only build/test workflow without a `concurrency` block. `zfs-qemu`, `zfs-qemu-packages`, `zloop`, `codeql`, `smatch`, and `checkstyle` all define one; `zfs-arm` did not, so superseded runs on a branch were not cancelled when a new commit was pushed.

### Description

Add the same `concurrency` block the other workflows use, so a new push to a branch cancels the in-progress ARM run instead of leaving both to finish:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
  cancel-in-progress: true
```

### How Has This Been Tested?

Workflow-only change. CI will tell.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [contributing document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#testing) to cover my changes. *(N/A — CI config)*
- [ ] I have run the ZFS Test Suite with this change applied. *(N/A — CI config)*
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
