### PR TITLE
dsl_scan_prefetch: don't prefetch `ZB_ROOT_LEVEL` bookmarks

### DIFF
--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -1956,6 +1956,9 @@ dsl_scan_prefetch(scan_prefetch_ctx_t *spc, blkptr_t *bp, zbookmark_phys_t *zb)
 	    BP_GET_TYPE(bp) != DMU_OT_OBJSET))
 		return;
 
+	if (zb->zb_level == ZB_ROOT_LEVEL)
+		return;
+
 	if (dsl_scan_check_prefetch_resume(spc, zb))
 		return;
 

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -6002,6 +6002,13 @@ zbookmark_compare(uint16_t dbss1, uint8_t ibs1, uint16_t dbss2, uint8_t ibs2,
 	    zb1->zb_blkid == zb2->zb_blkid)
 		return (0);
 
+	/*
+	 * Only real blocks here; the magic ZB_*_LEVEL markers are for
+	 * caller housekeeping and shouldn't have made it this far.
+	 */
+	ASSERT3S(zb1->zb_level, >=, 0);
+	ASSERT3S(zb2->zb_level, >=, 0);
+
 	IMPLY(zb1->zb_level > 0, ibs1 >= SPA_MINBLOCKSHIFT);
 	IMPLY(zb2->zb_level > 0, ibs2 >= SPA_MINBLOCKSHIFT);
 


### PR DESCRIPTION
_[Sponsors: TrueNAS]_

### Motivation and Context

Fixes: #14777 
Previously: #18598

### Description

`dsl_scan_visit_rootbp()` creates a "marker" bookmark representing the dataset head, with `level == ZB_ROOT_LEVEL`. That is handed down to `dsl_scan_prefetch()` to add the bookmark to the prefetch list. That list is sorted via `zbookmark_compare()`.

`ZB_ROOT_LEVEL` is `-1`. If it makes it into `zbookmark_compare(), it ends up in `BP_SPANB()`. The negative level is used as a multiplier for the shift. A negative shift is invalid, and UBSAN yells about it (#14777). See [#18598 (comment)](https://github.com/openzfs/zfs/pull/18598#issuecomment-4589249613) for the math.

The fix is simple: just don't try to prefetch a `ZB_ROOT_LEVEL` block. I don't think it makes sense to try to make `zbookmark_compare()` handle these; I don't think there's an obvious ordering and in this case, there's nothing to prefetch anyway. I think there's prior art we can appeal to too: `traverse_prefetcher()` tests `level == ZB_DNODE_LEVEL` and does nothing if its true.

Finally, assert in `zbookmark_compare()` that `level >= 0`, which will hopefully catch any misuses in the future.

### How Has This Been Tested?

Full ZTS run completed, no new assertion trips.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
