### PR TITLE
Reorder dsl_prop_set_hasrecvd() checks

### DIFF
--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -3234,13 +3234,14 @@ zfs_ioc_set_prop(zfs_cmd_t *zc)
 			    origprops, nvl);
 			nvlist_free(origprops);
 		}
-
-		error = dsl_prop_set_hasrecvd(zc->zc_name);
 	}
 
 	errors = fnvlist_alloc();
 	if (error == 0)
 		error = zfs_set_prop_nvlist(zc->zc_name, source, nvl, errors);
+
+	if (error == 0 && received)
+		error = dsl_prop_set_hasrecvd(zc->zc_name);
 
 	if (zc->zc_nvlist_dst != 0 && errors != NULL) {
 		(void) put_nvlist(zc, errors);


### PR DESCRIPTION
### Motivation and Context

Spruce up the `dsl_prop_set_hasrecvd()` handling in `zfs_ioc_set_prop()`.

### Description

Reorder the dsl_prop_set_hasrecvd() check to be a little more efficient.  Only call it when needed.

### How Has This Been Tested?

Will be tested by the CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)