### PR TITLE
Fix uninitialized variable warning in vdev_prop_get()

### DIFF
--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -460,6 +460,7 @@ vdev_prop_get_objid(vdev_t *vd, uint64_t *objid)
 	} else if (vd->vdev_leaf_zap != 0) {
 		*objid = vd->vdev_leaf_zap;
 	} else {
+		*objid = 0;
 		return (EINVAL);
 	}
 
@@ -6444,7 +6445,7 @@ vdev_prop_get(vdev_t *vd, nvlist_t *innvl, nvlist_t *outnvl)
 	spa_t *spa = vd->vdev_spa;
 	objset_t *mos = spa->spa_meta_objset;
 	int err = 0;
-	uint64_t objid;
+	uint64_t objid = 0;
 	uint64_t vdev_guid;
 	nvpair_t *elem = NULL;
 	nvlist_t *nvprops = NULL;


### PR DESCRIPTION
### Motivation and Context

Build failure.

```
module/zfs/vdev.c: In function ‘vdev_prop_get’:
module/zfs/vdev.c:6913:12: error: ‘objid’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
```

I'm surprised the CI never hit this warning, but I did when building locally.  This accidentally snuck in with #18597.

### Description

Make the code match the comment.  Update `vdev_prop_get_objid()` to set `objid` on error as the comment in `vdev_prop_get()` describes.

```c
       /*
        * A missing ZAP is normal for spare and L2ARC vdevs, which are
        * not part of the main vdev tree and never get ZAPs allocated.
        * Many properties are sourced directly from vdev_t fields and
        * work fine without one; ZAP-backed properties will return their
        * default values.  objid is set to 0 when absent and the few
        * cases that call zap_lookup directly guard against this below.
        */
       (void) vdev_prop_get_objid(vd, &objid);
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)