### PR TITLE
ZTS: fix mktemp usage on FreeBSD

### DIFF
--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -256,7 +256,6 @@ maybe = {
     'send_xdr_encoding/xdr_bookmark_raw_with_write': ['FAIL', 18491],
     'send_xdr_encoding/xdr_resume_bookmark_raw_with_write': ['FAIL', 18491],
     'snapshot/clone_001_pos': ['FAIL', known_reason],
-    'snapshot/snapshot_006_pos': ['FAIL', known_reason],
     'snapshot/snapshot_009_pos': ['FAIL', 7961],
     'snapshot/snapshot_010_pos': ['FAIL', 7961],
     'snapused/snapused_004_pos': ['FAIL', 5513],
@@ -279,7 +278,6 @@ if sys.platform.startswith('freebsd'):
         'pool_checkpoint/checkpoint_big_rewind': ['FAIL', 12622],
         'pool_checkpoint/checkpoint_indirect': ['FAIL', 12623],
         'resilver/resilver_restart_001': ['FAIL', known_reason],
-        'snapshot/snapshot_002_pos': ['FAIL', 14831],
         'zvol/zvol_misc/zvol_misc_volmode': ['FAIL', 16668],
         'bclone/bclone_crossfs_corner_cases': ['SKIP', cfr_cross_reason],
         'bclone/bclone_crossfs_corner_cases_limited':

--- a/tests/zfs-tests/tests/functional/snapshot/snapshot_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/snapshot/snapshot_002_pos.ksh
@@ -64,7 +64,7 @@ function cleanup
 log_assert "Verify an archive of a file system is identical to " \
     "an archive of its snapshot."
 
-SNAPSHOT_TARDIR="$(mktemp -t -d zfstests_snapshot_002.XXXXXX)"
+SNAPSHOT_TARDIR="$(mktemp -d "$TEST_BASE_DIR/zfstests_snapshot_002.XXXXXX")"
 log_onexit cleanup
 
 typeset -i COUNT=21

--- a/tests/zfs-tests/tests/functional/snapshot/snapshot_006_pos.ksh
+++ b/tests/zfs-tests/tests/functional/snapshot/snapshot_006_pos.ksh
@@ -73,7 +73,7 @@ function cleanup
 log_assert "Verify that an archive of a dataset is identical to " \
    "an archive of the dataset's snapshot."
 
-SNAPSHOT_TARDIR="$(mktemp -t -d zfstests_snapshot_006.XXXXXX)"
+SNAPSHOT_TARDIR="$(mktemp -d "$TEST_BASE_DIR/zfstests_snapshot_006.XXXXXX")"
 log_onexit cleanup
 
 typeset -i COUNT=21

--- a/tests/zfs-tests/tests/functional/zvol/zvol_stress/zvol_stress.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_stress/zvol_stress.ksh
@@ -58,7 +58,7 @@ biggest_zvol_size_possible=$(largest_volsize_from_pool $TESTPOOL)
 typeset -f each_zvol_size=$(( floor($biggest_zvol_size_possible * 0.9 / \
 	$num_zvols )))
 
-typeset tmpdir="$(mktemp -t -d zvol_stress_fio_state.XXXXXX)"
+typeset tmpdir="$(mktemp -d "$TEST_BASE_DIR/zvol_stress_fio_state.XXXXXX")"
 
 log_must save_tunable VOL_USE_BLK_MQ
 log_must save_tunable VOL_REQUEST_SYNC


### PR DESCRIPTION
### Motivation and Context

`snapshot_002_pos`, `snapshot_006_pos`, and `zvol_stress` fail on FreeBSD. They use a GNU variant of mktemp: `mktemp -t -d NAME.XXXXXX`, which on FreeBSD `-t` takes a required prefix argument instead.

### Description

On FreeBSD -t takes a required prefix argument. Use "mktemp -d $TEST_BASE_DIR/..." instead.

### How Has This Been Tested?

FreeBSD 16.0-CURRENT and qemu CI (freebsd16-0c, freebsd14-4r): both snapshot tests PASS. No change on Linux.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).