### PR TITLE
CI: Increase default RCU stall timeout on Linux

### DIFF
--- a/.github/workflows/scripts/qemu-6-tests.sh
+++ b/.github/workflows/scripts/qemu-6-tests.sh
@@ -186,6 +186,13 @@ case "$OS" in
     sudo mount -o noatime /dev/vdb /var/tmp
     sudo chmod 1777 /var/tmp
     sudo mv -f /tmp/*.txt /var/tmp
+
+    # Allow for longer RCU timeouts due to the heavily virtualized and
+    # potentially oversubscribed nature of the CI environment.
+    rcu_cpu_stall_timeout="/sys/module/rcupdate/parameters/rcu_cpu_stall_timeout"
+    if test -f $rcu_cpu_stall_timeout; then
+        echo 120 | sudo sh -c "cat > '$rcu_cpu_stall_timeout'"
+    fi
     ;;
 esac
 


### PR DESCRIPTION
### Motivation and Context

I've observed some RCU stalls in the CI where the dumped stacks show no indication of a problem with ZFS.  Let's see if increasing the default timeout lets us ride through these stalls.

https://github.com/openzfs/zfs/actions/runs/26742198361/job/78809319967?pr=18568

```
 [ 2728.622324] watchdog: BUG: soft lockup - CPU#1 stuck for 26s! [kworker/1:2:952642]
  [ 2729.194861] rcu: INFO: rcu_preempt self-detected stall on CPU
  [ 2730.255382] rcu: 	0-...!: (1 GPs behind) idle=5b44/1/0x4000000000000000 softirq=2021377/2021378 fqs=1
  [ 2730.266595] 	(t=8108 jiffies g=890401 q=7 ncpus=2)
  [ 2730.297437] rcu: rcu_preempt kthread starved for 8106 jiffies! g890401 f0x0 RCU_GP_WAIT_FQS(5) ->state=0x0 ->cpu=1
  [ 2731.311899] rcu: 	Unless rcu_preempt kthread gets sufficient CPU time, OOM is now expected behavior.
  [ 2731.384696] Modules linked in:
  [ 2731.392446] rcu: RCU grace-period kthread stack dump:
  [ 2731.392463] task:rcu_preempt     state:R
  [ 2731.396166]  sd_mod
  [ 2731.400424]   running task     stack:0     pid:15    ppid:2      flags:0x00004000
  [ 2731.400454] Call Trace:
  [ 2731.400456]  <TASK>
  [ 2731.437879]  t10_pi crc64_rocksoft_generic crc64_rocksoft crc64 crc_t10dif crct10dif_generic xfs zfs(POE) spl(OE) cfg80211 rfkill isofs intel_rapl_msr intel_rapl_common binfmt_misc nls_ascii kvm_amd nls_cp437 ccp vfat fat kvm irqbypass ghash_clmulni_intel sha512_ssse3 sha512_generic sha256_ssse3 sha1_ssse3 iTCO_wdt intel_pmc_bxt aesni_intel crypto_simd
  [ 2731.433072]  __schedule+0x34d/0x9e0
  [ 2731.776844]  iTCO_vendor_support
  [ 2731.785234]  ? rcu_gp_cleanup+0x460/0x460
  [ 2731.798113]  cryptd watchdog virtio_balloon
  [ 2731.816140]  schedule+0x5a/0xd0
  [ 2731.822165]  virtio_console
  [ 2731.827420]  schedule_timeout+0x94/0x150
  [ 2731.847628]  button
  [ 2731.863174]  ? __bpf_trace_tick_stop+0x10/0x10
  [ 2731.877251]  joydev
  [ 2731.883628]  rcu_gp_fqs_loop+0x141/0x550
  [ 2731.885840]  evdev serio_raw sg nfsd
  [ 2731.893920]  ? srso_alias_return_thunk+0x5/0x7f
  [ 2731.909139]  auth_rpcgss
  [ 2731.909729]  rcu_gp_kthread+0xd4/0x190
  [ 2731.971168]  kthread+0xda/0x100
  [ 2732.005387]  nfs_acl
  [ 2732.034217]  ? kthread_complete_and_exit+0x20/0x20
  [ 2732.035593]  lockd fuse grace loop efi_pstore
  [ 2732.036056]  ret_from_fork+0x22/0x30
  [ 2732.084335]  </TASK>
  [ 2732.084445]  drm
  [ 2732.084845] rcu: Stack dump where RCU GP kthread last ran:
  [ 2732.094157] Sending NMI from CPU 0 to CPUs 1:
```

### Description

When CONFIG_RCU_CPU_STALL_TIMEOUT is configured an RCU stall which exceeds the default timeout will trigger an NMI and panic the VM. Given the heavily virtualized nature of the CI environment we want to make sure to only trigger this due to a real deadlock and not due to oversubscription of the systems resources.  This timeout normally defaults to 20-30 seconds and this change increases it to 120 seconds.

### How Has This Been Tested?

The only way to really test this is to see if it resolves this type of CI failure.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)
