### PR TITLE
Remove /etc/sudoers.d/zfs

### DIFF
--- a/contrib/debian/not-installed
+++ b/contrib/debian/not-installed
@@ -2,7 +2,6 @@ usr/bin/zarcsummary.py
 usr/share/zfs/zfs-helpers.sh
 etc/default/zfs
 etc/init.d
-etc/sudoers.d
 etc/zfs/vdev_id.conf.alias.example
 etc/zfs/vdev_id.conf.multipath.example
 etc/zfs/vdev_id.conf.sas_direct.example

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -1,10 +1,4 @@
 # SPDX-License-Identifier: CDDL-1.0
-sudoersddir = $(sysconfdir)/sudoers.d
-sudoersd_DATA = \
-	%D%/sudoers.d/zfs
-
-dist_noinst_DATA += $(sudoersd_DATA)
-
 
 sysconf_zfsdir = $(sysconfdir)/zfs
 

--- a/etc/sudoers.d/zfs
+++ b/etc/sudoers.d/zfs
@@ -1,9 +1,0 @@
-##
-## Allow any user to run `zpool iostat/status -c smart` in order
-## to read basic SMART health statistics for a pool.
-##
-## CAUTION: Any syntax error introduced here will break sudo.
-## Editing with 'visudo' is recommended: visudo -f  /etc/sudoers.d/zfs 
-##
-
-# ALL ALL = (root) NOPASSWD: /usr/sbin/smartctl -a /dev/[hsv]d[a-z0-9]*

--- a/man/man8/zpool-iostat.8
+++ b/man/man8/zpool-iostat.8
@@ -109,10 +109,7 @@ environment variable set.
 If a script requires the use of a privileged command, like
 .Xr smartctl 8 ,
 then it's recommended you allow the user access to it in
-.Pa /etc/sudoers
-or add the user to the
-.Pa /etc/sudoers.d/zfs
-file.
+.Pa /etc/sudoers .
 .Pp
 If
 .Fl c

--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -525,7 +525,6 @@ systemctl --system daemon-reload >/dev/null || true
 %config(noreplace) %{_sysconfdir}/%{name}/zed.d/*
 %config(noreplace) %{_sysconfdir}/%{name}/zpool.d/*
 %config(noreplace) %{_sysconfdir}/%{name}/vdev_id.conf.*.example
-%attr(440, root, root) %config(noreplace) %{_sysconfdir}/sudoers.d/*
 
 %config(noreplace) %{_bashcompletiondir}/zfs
 %config(noreplace) %{_bashcompletiondir}/zpool


### PR DESCRIPTION
### Motivation and Context
Remove `/etc/sudoers.d/zfs`.  

### Description
The smartctl exception in /etc/sudoers.d/zfs doesn't cover devices like NVMe or symlinked devices.  Just get rid of it rather than keep maintaining it.

### How Has This Been Tested?
CI passed locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
