### PR TITLE
CI: Re-enable CodeQL workflows on push

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,7 +11,6 @@ concurrency:
 jobs:
   analyze:
     name: Analyze
-    if: github.event_name == 'pull_request' || github.repository != 'openzfs/zfs'
     runs-on: ubuntu-22.04
     permissions:
       actions: read


### PR DESCRIPTION
### Motivation and Context

Selectively re-enable CodeQL so it runs against all pushes and pull requests.

### Description

This workflow was disabled 'on push' recently in commit 1916c2c5 to reduce redundant CI runs.  However, this check is fairly quick (20m) and I'd like it to run regularly against the branches.  Enable it.

### How Has This Been Tested?

Will be tested by the CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

\