### PR TITLE
zap: misc function removal / uplift / tests

### DIFF
--- a/include/sys/zap.h
+++ b/include/sys/zap.h
@@ -370,6 +370,8 @@ int zap_count_by_dnode(dnode_t *dn, uint64_t *count);
  */
 int zap_increment(objset_t *os, uint64_t obj, const char *name, int64_t delta,
     dmu_tx_t *tx);
+int zap_increment_by_dnode(dnode_t *dn, const char *name, int64_t delta,
+    dmu_tx_t *tx);
 
 /*
  * Returns (in name) the name of the entry whose (value & mask)

--- a/include/sys/zap.h
+++ b/include/sys/zap.h
@@ -390,12 +390,23 @@ int zap_add_int(objset_t *os, uint64_t obj, uint64_t value, dmu_tx_t *tx);
 int zap_remove_int(objset_t *os, uint64_t obj, uint64_t value, dmu_tx_t *tx);
 int zap_lookup_int(objset_t *os, uint64_t obj, uint64_t value);
 
+int zap_add_int_by_dnode(dnode_t *dn, uint64_t value, dmu_tx_t *tx);
+int zap_remove_int_by_dnode(dnode_t *dn, uint64_t value, dmu_tx_t *tx);
+int zap_lookup_int_by_dnode(dnode_t *dn, uint64_t value);
+
 /* Here the key is an int and the value is a different int. */
 int zap_add_int_key(objset_t *os, uint64_t obj,
     uint64_t key, uint64_t value, dmu_tx_t *tx);
 int zap_update_int_key(objset_t *os, uint64_t obj,
     uint64_t key, uint64_t value, dmu_tx_t *tx);
 int zap_lookup_int_key(objset_t *os, uint64_t obj,
+    uint64_t key, uint64_t *valuep);
+
+int zap_add_int_key_by_dnode(dnode_t *dn,
+    uint64_t key, uint64_t value, dmu_tx_t *tx);
+int zap_update_int_key_by_dnode(dnode_t *dn,
+    uint64_t key, uint64_t value, dmu_tx_t *tx);
+int zap_lookup_int_key_by_dnode(dnode_t *dn,
     uint64_t key, uint64_t *valuep);
 
 /*

--- a/include/sys/zap.h
+++ b/include/sys/zap.h
@@ -381,21 +381,6 @@ int zap_value_search(objset_t *os, uint64_t zapobj,
     uint64_t value, uint64_t mask, char *name, uint64_t namelen);
 
 /*
- * Transfer all the entries from fromobj into intoobj.  Only works on
- * int_size=8 num_integers=1 values.  Fails if there are any duplicated
- * entries.
- */
-int zap_join(objset_t *os, uint64_t fromobj, uint64_t intoobj, dmu_tx_t *tx);
-
-/* Same as zap_join, but set the values to 'value'. */
-int zap_join_key(objset_t *os, uint64_t fromobj, uint64_t intoobj,
-    uint64_t value, dmu_tx_t *tx);
-
-/* Same as zap_join, but add together any duplicated entries. */
-int zap_join_increment(objset_t *os, uint64_t fromobj, uint64_t intoobj,
-    dmu_tx_t *tx);
-
-/*
  * Manipulate entries where the name + value are the "same" (the name is
  * a stringified version of the value).
  */

--- a/include/sys/zap.h
+++ b/include/sys/zap.h
@@ -402,8 +402,6 @@ int zap_join_increment(objset_t *os, uint64_t fromobj, uint64_t intoobj,
 int zap_add_int(objset_t *os, uint64_t obj, uint64_t value, dmu_tx_t *tx);
 int zap_remove_int(objset_t *os, uint64_t obj, uint64_t value, dmu_tx_t *tx);
 int zap_lookup_int(objset_t *os, uint64_t obj, uint64_t value);
-int zap_increment_int(objset_t *os, uint64_t obj, uint64_t key, int64_t delta,
-    dmu_tx_t *tx);
 
 /* Here the key is an int and the value is a different int. */
 int zap_add_int_key(objset_t *os, uint64_t obj,

--- a/include/sys/zap.h
+++ b/include/sys/zap.h
@@ -381,6 +381,8 @@ int zap_increment_by_dnode(dnode_t *dn, const char *name, int64_t delta,
  */
 int zap_value_search(objset_t *os, uint64_t zapobj,
     uint64_t value, uint64_t mask, char *name, uint64_t namelen);
+int zap_value_search_by_dnode(dnode_t *dn,
+    uint64_t value, uint64_t mask, char *name, uint64_t namelen);
 
 /*
  * Manipulate entries where the name + value are the "same" (the name is

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -1859,7 +1859,7 @@ do_userquota_cacheflush(objset_t *os, userquota_cache_t *cache, dmu_tx_t *tx)
 	    &cookie)) != NULL) {
 		/*
 		 * os_userused_lock protects against concurrent calls to
-		 * zap_increment_int().  It's needed because zap_increment_int()
+		 * zap_increment().  It's needed because zap_increment()
 		 * is not thread-safe (i.e. not atomic).
 		 */
 		mutex_enter(&os->os_userused_lock);

--- a/module/zfs/zap.c
+++ b/module/zfs/zap.c
@@ -918,88 +918,6 @@ zap_value_search(objset_t *os, uint64_t zapobj, uint64_t value, uint64_t mask,
 	return (err);
 }
 
-/* zap_join */
-
-int
-zap_join(objset_t *os, uint64_t fromobj, uint64_t intoobj, dmu_tx_t *tx)
-{
-	zap_cursor_t zc;
-	int err = 0;
-
-	zap_attribute_t *za = zap_attribute_long_alloc();
-	for (zap_cursor_init(&zc, os, fromobj);
-	    zap_cursor_retrieve(&zc, za) == 0;
-	    (void) zap_cursor_advance(&zc)) {
-		if (za->za_integer_length != 8 || za->za_num_integers != 1) {
-			err = SET_ERROR(EINVAL);
-			break;
-		}
-		err = zap_add(os, intoobj, za->za_name,
-		    8, 1, &za->za_first_integer, tx);
-		if (err != 0)
-			break;
-	}
-	zap_cursor_fini(&zc);
-	zap_attribute_free(za);
-	return (err);
-}
-
-int
-zap_join_key(objset_t *os, uint64_t fromobj, uint64_t intoobj,
-    uint64_t value, dmu_tx_t *tx)
-{
-	zap_cursor_t zc;
-	int err = 0;
-
-	zap_attribute_t *za = zap_attribute_long_alloc();
-	for (zap_cursor_init(&zc, os, fromobj);
-	    zap_cursor_retrieve(&zc, za) == 0;
-	    (void) zap_cursor_advance(&zc)) {
-		if (za->za_integer_length != 8 || za->za_num_integers != 1) {
-			err = SET_ERROR(EINVAL);
-			break;
-		}
-		err = zap_add(os, intoobj, za->za_name,
-		    8, 1, &value, tx);
-		if (err != 0)
-			break;
-	}
-	zap_cursor_fini(&zc);
-	zap_attribute_free(za);
-	return (err);
-}
-
-int
-zap_join_increment(objset_t *os, uint64_t fromobj, uint64_t intoobj,
-    dmu_tx_t *tx)
-{
-	zap_cursor_t zc;
-	int err = 0;
-
-	zap_attribute_t *za = zap_attribute_long_alloc();
-	for (zap_cursor_init(&zc, os, fromobj);
-	    zap_cursor_retrieve(&zc, za) == 0;
-	    (void) zap_cursor_advance(&zc)) {
-		uint64_t delta = 0;
-
-		if (za->za_integer_length != 8 || za->za_num_integers != 1) {
-			err = SET_ERROR(EINVAL);
-			break;
-		}
-
-		err = zap_lookup(os, intoobj, za->za_name, 8, 1, &delta);
-		if (err != 0 && err != ENOENT)
-			break;
-		delta += za->za_first_integer;
-		err = zap_update(os, intoobj, za->za_name, 8, 1, &delta, tx);
-		if (err != 0)
-			break;
-	}
-	zap_cursor_fini(&zc);
-	zap_attribute_free(za);
-	return (err);
-}
-
 /* zap_*_int */
 
 int
@@ -1314,8 +1232,6 @@ EXPORT_SYMBOL(zap_remove_uint64_by_dnode);
 EXPORT_SYMBOL(zap_count);
 EXPORT_SYMBOL(zap_count_by_dnode);
 EXPORT_SYMBOL(zap_value_search);
-EXPORT_SYMBOL(zap_join);
-EXPORT_SYMBOL(zap_join_increment);
 EXPORT_SYMBOL(zap_add_int);
 EXPORT_SYMBOL(zap_remove_int);
 EXPORT_SYMBOL(zap_lookup_int);

--- a/module/zfs/zap.c
+++ b/module/zfs/zap.c
@@ -933,31 +933,48 @@ zap_value_search(objset_t *os, uint64_t zapobj, uint64_t value, uint64_t mask,
 
 /* zap_*_int */
 
+#define	FORMAT_INT_KEY(name, value)	\
+	char name[20];			\
+	(void) snprintf(name, sizeof (name), "%llx", (longlong_t)value);
+
 int
 zap_add_int(objset_t *os, uint64_t obj, uint64_t value, dmu_tx_t *tx)
 {
-	char name[20];
-
-	(void) snprintf(name, sizeof (name), "%llx", (longlong_t)value);
+	FORMAT_INT_KEY(name, value);
 	return (zap_add(os, obj, name, 8, 1, &value, tx));
+}
+int
+zap_add_int_by_dnode(dnode_t *dn, uint64_t value, dmu_tx_t *tx)
+{
+	FORMAT_INT_KEY(name, value);
+	return (zap_add_by_dnode(dn, name, 8, 1, &value, tx));
 }
 
 int
 zap_remove_int(objset_t *os, uint64_t obj, uint64_t value, dmu_tx_t *tx)
 {
-	char name[20];
-
-	(void) snprintf(name, sizeof (name), "%llx", (longlong_t)value);
+	FORMAT_INT_KEY(name, value);
 	return (zap_remove(os, obj, name, tx));
+}
+int
+zap_remove_int_by_dnode(dnode_t *dn, uint64_t value, dmu_tx_t *tx)
+{
+	FORMAT_INT_KEY(name, value);
+	return (zap_remove_by_dnode(dn, name, tx));
 }
 
 int
 zap_lookup_int(objset_t *os, uint64_t obj, uint64_t value)
 {
-	char name[20];
-
-	(void) snprintf(name, sizeof (name), "%llx", (longlong_t)value);
+	FORMAT_INT_KEY(name, value);
 	return (zap_lookup(os, obj, name, 8, 1, &value));
+}
+
+int
+zap_lookup_int_by_dnode(dnode_t *dn, uint64_t value)
+{
+	FORMAT_INT_KEY(name, value);
+	return (zap_lookup_by_dnode(dn, name, 8, 1, &value));
 }
 
 /* zap_*_int_key */
@@ -966,29 +983,43 @@ int
 zap_add_int_key(objset_t *os, uint64_t obj,
     uint64_t key, uint64_t value, dmu_tx_t *tx)
 {
-	char name[20];
-
-	(void) snprintf(name, sizeof (name), "%llx", (longlong_t)key);
+	FORMAT_INT_KEY(name, key);
 	return (zap_add(os, obj, name, 8, 1, &value, tx));
+}
+int
+zap_add_int_key_by_dnode(dnode_t *dn,
+    uint64_t key, uint64_t value, dmu_tx_t *tx)
+{
+	FORMAT_INT_KEY(name, key);
+	return (zap_add_by_dnode(dn, name, 8, 1, &value, tx));
 }
 
 int
 zap_update_int_key(objset_t *os, uint64_t obj,
     uint64_t key, uint64_t value, dmu_tx_t *tx)
 {
-	char name[20];
-
-	(void) snprintf(name, sizeof (name), "%llx", (longlong_t)key);
+	FORMAT_INT_KEY(name, key);
 	return (zap_update(os, obj, name, 8, 1, &value, tx));
+}
+int
+zap_update_int_key_by_dnode(dnode_t *dn,
+    uint64_t key, uint64_t value, dmu_tx_t *tx)
+{
+	FORMAT_INT_KEY(name, key);
+	return (zap_update_by_dnode(dn, name, 8, 1, &value, tx));
 }
 
 int
 zap_lookup_int_key(objset_t *os, uint64_t obj, uint64_t key, uint64_t *valuep)
 {
-	char name[20];
-
-	(void) snprintf(name, sizeof (name), "%llx", (longlong_t)key);
+	FORMAT_INT_KEY(name, key);
 	return (zap_lookup(os, obj, name, 8, 1, valuep));
+}
+int
+zap_lookup_int_key_by_dnode(dnode_t *dn, uint64_t key, uint64_t *valuep)
+{
+	FORMAT_INT_KEY(name, key);
+	return (zap_lookup_by_dnode(dn, name, 8, 1, valuep));
 }
 
 /* zap_cursor */

--- a/module/zfs/zap.c
+++ b/module/zfs/zap.c
@@ -872,7 +872,7 @@ zap_count(objset_t *os, uint64_t zapobj, uint64_t *count)
 /* zap_increment */
 
 int
-zap_increment(objset_t *os, uint64_t obj, const char *name, int64_t delta,
+zap_increment_by_dnode(dnode_t *dn, const char *name, int64_t delta,
     dmu_tx_t *tx)
 {
 	uint64_t value = 0;
@@ -880,14 +880,27 @@ zap_increment(objset_t *os, uint64_t obj, const char *name, int64_t delta,
 	if (delta == 0)
 		return (0);
 
-	int err = zap_lookup(os, obj, name, 8, 1, &value);
+	int err = zap_lookup_by_dnode(dn, name, 8, 1, &value);
 	if (err != 0 && err != ENOENT)
 		return (err);
 	value += delta;
 	if (value == 0)
-		err = zap_remove(os, obj, name, tx);
+		err = zap_remove_by_dnode(dn, name, tx);
 	else
-		err = zap_update(os, obj, name, 8, 1, &value, tx);
+		err = zap_update_by_dnode(dn, name, 8, 1, &value, tx);
+	return (err);
+}
+
+int
+zap_increment(objset_t *os, uint64_t zapobj, const char *name, int64_t delta,
+    dmu_tx_t *tx)
+{
+	dnode_t *dn;
+	int err = dnode_hold(os, zapobj, FTAG, &dn);
+	if (err != 0)
+		return (err);
+	err = zap_increment_by_dnode(dn, name, delta, tx);
+	dnode_rele(dn, FTAG);
 	return (err);
 }
 

--- a/module/zfs/zap.c
+++ b/module/zfs/zap.c
@@ -1029,16 +1029,6 @@ zap_lookup_int(objset_t *os, uint64_t obj, uint64_t value)
 	return (zap_lookup(os, obj, name, 8, 1, &value));
 }
 
-int
-zap_increment_int(objset_t *os, uint64_t obj, uint64_t key, int64_t delta,
-    dmu_tx_t *tx)
-{
-	char name[20];
-
-	(void) snprintf(name, sizeof (name), "%llx", (longlong_t)key);
-	return (zap_increment(os, obj, name, delta, tx));
-}
-
 /* zap_*_int_key */
 
 int
@@ -1329,7 +1319,6 @@ EXPORT_SYMBOL(zap_join_increment);
 EXPORT_SYMBOL(zap_add_int);
 EXPORT_SYMBOL(zap_remove_int);
 EXPORT_SYMBOL(zap_lookup_int);
-EXPORT_SYMBOL(zap_increment_int);
 EXPORT_SYMBOL(zap_add_int_key);
 EXPORT_SYMBOL(zap_lookup_int_key);
 EXPORT_SYMBOL(zap_increment);

--- a/module/zfs/zap.c
+++ b/module/zfs/zap.c
@@ -906,29 +906,45 @@ zap_increment(objset_t *os, uint64_t zapobj, const char *name, int64_t delta,
 
 /* zap_value_search */
 
-int
-zap_value_search(objset_t *os, uint64_t zapobj, uint64_t value, uint64_t mask,
+static int
+zap_value_search_impl(zap_cursor_t *zc, uint64_t value, uint64_t mask,
     char *name, uint64_t namelen)
 {
-	zap_cursor_t zc;
 	int err;
 
 	if (mask == 0)
 		mask = -1ULL;
 
 	zap_attribute_t *za = zap_attribute_long_alloc();
-	for (zap_cursor_init(&zc, os, zapobj);
-	    (err = zap_cursor_retrieve(&zc, za)) == 0;
-	    zap_cursor_advance(&zc)) {
+	for (; (err = zap_cursor_retrieve(zc, za)) == 0;
+	    zap_cursor_advance(zc)) {
 		if ((za->za_first_integer & mask) == (value & mask)) {
 			if (strlcpy(name, za->za_name, namelen) >= namelen)
 				err = SET_ERROR(ENAMETOOLONG);
 			break;
 		}
 	}
-	zap_cursor_fini(&zc);
+	zap_cursor_fini(zc);
 	zap_attribute_free(za);
 	return (err);
+}
+
+int
+zap_value_search(objset_t *os, uint64_t zapobj, uint64_t value, uint64_t mask,
+    char *name, uint64_t namelen)
+{
+	zap_cursor_t zc;
+	zap_cursor_init(&zc, os, zapobj);
+	return (zap_value_search_impl(&zc, value, mask, name, namelen));
+}
+
+int
+zap_value_search_by_dnode(dnode_t *dn, uint64_t value, uint64_t mask,
+    char *name, uint64_t namelen)
+{
+	zap_cursor_t zc;
+	zap_cursor_init_by_dnode(&zc, dn);
+	return (zap_value_search_impl(&zc, value, mask, name, namelen));
 }
 
 /* zap_*_int */

--- a/tests/unit/test_zap.c
+++ b/tests/unit/test_zap.c
@@ -971,6 +971,128 @@ test_cursor_release_one(const MunitParameter params[], void *data)
 
 /* ========== */
 
+/* zap_value_search: find key with given uint64 value. */
+static MunitResult
+test_zap_value_search(const MunitParameter params[], void *data)
+{
+	(void) data;
+
+	dnode_t *dn = mock_zap_create_params(params, "type");
+	dmu_tx_t *tx = (dmu_tx_t *)mock_tx_create();
+
+	/* Add some items. */
+	uint64_t v1 = 1, v2 = 2, v3 = 3;
+	unit_ok(zap_add_by_dnode(dn, "one", sizeof (uint64_t), 1, &v1, tx));
+	unit_ok(zap_add_by_dnode(dn, "two", sizeof (uint64_t), 1, &v2, tx));
+	unit_ok(zap_add_by_dnode(dn, "three", sizeof (uint64_t), 1, &v3, tx));
+
+	char name[ZAP_MAXNAMELEN];
+
+	/* Find one of them. */
+	unit_ok(zap_value_search_by_dnode(dn, 2, 0, name, sizeof (name)));
+	unit_str_eq(name, "two");
+
+	/* Nonexistent value. */
+	unit_err(zap_value_search_by_dnode(dn, 10, 0,
+	    name, sizeof (name)), ENOENT);
+
+	/* Buffer too small for the key. */
+	unit_err(zap_value_search_by_dnode(dn, 3, 0, name, 2), ENAMETOOLONG);
+
+	mock_tx_destroy((mock_dmu_tx_t *)tx);
+	unit_true(mock_zap_is_params(dn, params, "type"));
+	mock_zap_destroy(dn);
+
+	return (MUNIT_OK);
+}
+
+/* zap_value_search: value masks */
+static MunitResult
+test_zap_value_search_mask(const MunitParameter params[], void *data)
+{
+	(void) data;
+
+	dnode_t *dn = mock_zap_create_params(params, "type");
+	dmu_tx_t *tx = (dmu_tx_t *)mock_tx_create();
+
+	/*
+	 * Add a set of values. These all have the same bottom 16 bits, with
+	 * different upper 48 bits, segmented so we can mask them in different
+	 * and interesting ways.
+	 */
+	uint64_t v1 = 0x000000000000f0f0ull;
+	uint64_t v2 = 0x00000000fffff0f0ull;
+	uint64_t v3 = 0x0000ffff0000f0f0ull;
+	uint64_t v4 = 0xffff00000000f0f0ull;
+
+	/*
+	 * Generate four random keys. We do this because zap_value_search() is
+	 * implemented with a simple cursor walk, so will always return the
+	 * first match in hash order, which with fixed keys will always give
+	 * exactly the same results. Using random keys ensures the test values
+	 * are encountered in different orders between test runs, giving us
+	 * better coverage when there are multiple matches.
+	 */
+
+	char k1[9], k2[9], k3[9], k4[9];
+	unit_rand_str(k1, sizeof (k1));
+	unit_rand_str(k2, sizeof (k2));
+	unit_rand_str(k3, sizeof (k3));
+	unit_rand_str(k4, sizeof (k4));
+
+	unit_ok(zap_add_by_dnode(dn, k1, sizeof (uint64_t), 1, &v1, tx));
+	unit_ok(zap_add_by_dnode(dn, k2, sizeof (uint64_t), 1, &v2, tx));
+	unit_ok(zap_add_by_dnode(dn, k3, sizeof (uint64_t), 1, &v3, tx));
+	unit_ok(zap_add_by_dnode(dn, k4, sizeof (uint64_t), 1, &v4, tx));
+
+	char name[ZAP_MAXNAMELEN];
+
+	/* 0 mask is equivalent to all bits set in mask ie exact match. */
+	unit_ok(zap_value_search_by_dnode(dn,
+	    0xf0f0, 0, name, sizeof (name)));
+	unit_str_eq(name, k1);
+	unit_ok(zap_value_search_by_dnode(dn,
+	    0xf0f0, 0xffffffffffffffffull, name, sizeof (name)));
+	unit_str_eq(name, k1);
+
+	/* Low 16 bits could match any. */
+	unit_ok(zap_value_search_by_dnode(dn,
+	    0xf0f0, 0xffff, name, sizeof (name)));
+
+	/* Low 32 bits, 3/1 matches. */
+	unit_ok(zap_value_search_by_dnode(dn,
+	    0x0000f0f0, 0xffffffff, name, sizeof (name)));
+	unit_true(strcmp(name, k1) == 0 || strcmp(name, k3) == 0 ||
+	    strcmp(name, k4) == 0);
+	unit_ok(zap_value_search_by_dnode(dn,
+	    0xfffff0f0, 0xffffffff, name, sizeof (name)));
+	unit_str_eq(name, k2);
+
+	/* Low 48 bits, 2/1/1 matches */
+	unit_ok(zap_value_search_by_dnode(dn,
+	    0x00000000f0f0ull, 0xffffffffffffull, name, sizeof (name)));
+	unit_true(strcmp(name, k1) == 0 || strcmp(name, k4) == 0);
+	unit_ok(zap_value_search_by_dnode(dn,
+	    0x0000fffff0f0ull, 0xffffffffffffull, name, sizeof (name)));
+	unit_str_eq(name, k2);
+	unit_ok(zap_value_search_by_dnode(dn,
+	    0xffff0000f0f0ull, 0xffffffffffffull, name, sizeof (name)));
+	unit_str_eq(name, k3);
+
+	/* Value doesn't exist directly, but matches when mask applied. */
+	unit_ok(zap_value_search_by_dnode(dn,
+	    0xffffffff, 0xffff0000, name, sizeof (name)));
+	unit_str_eq(name, k2);
+
+	mock_tx_destroy((mock_dmu_tx_t *)tx);
+	unit_true(mock_zap_is_params(dn, params, "type"));
+	mock_zap_destroy(dn);
+
+	return (MUNIT_OK);
+}
+
+/* ========== */
+
 /* Test suite definition and boilerplate. */
 
 #define	UNIT_PARAM_ZAP_TYPES(p)	\
@@ -1016,6 +1138,11 @@ static const MunitTest zap_tests[] = {
 	    "cursor_release_empty",	test_cursor_release_empty),
 	UNIT_TEST_ZAP_TYPES(
 	    "cursor_release_one",	test_cursor_release_one),
+
+	UNIT_TEST_ZAP_TYPES(
+	    "zap_value_search",		test_zap_value_search),
+	UNIT_TEST_ZAP_TYPES(
+	    "zap_value_search_mask",	test_zap_value_search_mask),
 
 	{ 0 },
 };

--- a/tests/unit/test_zap.c
+++ b/tests/unit/test_zap.c
@@ -500,6 +500,94 @@ test_zap_increment(const MunitParameter params[], void *data)
 /* ========== */
 
 /*
+ * zap_add_int/zap_remove_int/zap_lookup_int: single uint64_t value,
+ * stringified to form the key.
+ */
+static MunitResult
+test_zap_int(const MunitParameter params[], void *data)
+{
+	(void) data;
+
+	dnode_t *dn = mock_zap_create_params(params, "type");
+	dmu_tx_t *tx = (dmu_tx_t *)mock_tx_create();
+
+	/* Add some ints. */
+	unit_ok(zap_add_int_by_dnode(dn, 5, tx));
+	unit_ok(zap_add_int_by_dnode(dn, 17, tx));
+
+	/* Confirm they're there. */
+	unit_ok(zap_lookup_int_by_dnode(dn, 17));
+	unit_ok(zap_lookup_int_by_dnode(dn, 5));
+
+	/* But not something we didn't add. */
+	unit_err(zap_lookup_int_by_dnode(dn, 23), ENOENT);
+
+	/* Adding something that already exists fails. */
+	unit_err(zap_add_int_by_dnode(dn, 17, tx), EEXIST);
+
+	/* Removing it works, and then it can't be found. */
+	unit_ok(zap_remove_int_by_dnode(dn, 17, tx));
+	unit_err(zap_lookup_int_by_dnode(dn, 17), ENOENT);
+
+	/* Add it can be added back. */
+	unit_ok(zap_add_int_by_dnode(dn, 17, tx));
+	unit_ok(zap_lookup_int_by_dnode(dn, 17));
+
+	mock_tx_destroy((mock_dmu_tx_t *)tx);
+	unit_true(mock_zap_is_params(dn, params, "type"));
+	mock_zap_destroy(dn);
+
+	return (MUNIT_OK);
+}
+
+/* zap_*_int_key: like zap_*_int, but with separate value. */
+static MunitResult
+test_zap_int_keys(const MunitParameter params[], void *data)
+{
+	(void) data;
+
+	dnode_t *dn = mock_zap_create_params(params, "type");
+	dmu_tx_t *tx = (dmu_tx_t *)mock_tx_create();
+
+	/* Add some ints. */
+	unit_ok(zap_add_int_key_by_dnode(dn, 5, 17, tx));
+	unit_ok(zap_add_int_key_by_dnode(dn, 23, 35, tx));
+
+	/* Confirm they're there. */
+	uint64_t r = 0;
+	unit_ok(zap_lookup_int_key_by_dnode(dn, 5, &r));
+	unit_eq(r, 17);
+	unit_ok(zap_lookup_int_key_by_dnode(dn, 23, &r));
+	unit_eq(r, 35);
+
+	/* But not something we didn't add. */
+	unit_err(zap_lookup_int_key_by_dnode(dn, 79, &r), ENOENT);
+
+	/* Adding something that already exists fails. */
+	unit_err(zap_add_int_key_by_dnode(dn, 23, 51, tx), EEXIST);
+
+	/* Updating it works though. */
+	unit_ok(zap_update_int_key_by_dnode(dn, 23, 51, tx));
+
+	/* Removing it works, and then it can't be found. */
+	unit_ok(zap_remove_int_by_dnode(dn, 23, tx));
+	unit_err(zap_lookup_int_key_by_dnode(dn, 23, &r), ENOENT);
+
+	/* Add it can be added back. */
+	unit_ok(zap_add_int_key_by_dnode(dn, 23, 11, tx));
+	unit_ok(zap_lookup_int_key_by_dnode(dn, 23, &r));
+	unit_eq(r, 11);
+
+	mock_tx_destroy((mock_dmu_tx_t *)tx);
+	unit_true(mock_zap_is_params(dn, params, "type"));
+	mock_zap_destroy(dn);
+
+	return (MUNIT_OK);
+}
+
+/* ========== */
+
+/*
  * Separate stats tests for each ZAP type, since they are about internals and
  * so can and will produce different results.
  */
@@ -910,6 +998,9 @@ static const MunitTest zap_tests[] = {
 	UNIT_TEST_ZAP_TYPES("zap_length",	test_zap_length),
 
 	UNIT_TEST_ZAP_TYPES("zap_increment",	test_zap_increment),
+
+	UNIT_TEST_ZAP_TYPES("zap_int",		test_zap_int),
+	UNIT_TEST_ZAP_TYPES("zap_int_keys",	test_zap_int_keys),
 
 	UNIT_TEST("microzap_stats",		test_microzap_stats),
 	UNIT_TEST("fatzap_stats",		test_fatzap_stats),

--- a/tests/unit/test_zap.c
+++ b/tests/unit/test_zap.c
@@ -448,6 +448,55 @@ test_zap_length(const MunitParameter params[], void *data)
 	return (MUNIT_OK);
 }
 
+/* zap_increment: add integer value to existing integer */
+static MunitResult
+test_zap_increment(const MunitParameter params[], void *data)
+{
+	(void) data;
+
+	dnode_t *dn = mock_zap_create_params(params, "type");
+	dmu_tx_t *tx = (dmu_tx_t *)mock_tx_create();
+
+	uint64_t r = 0;
+
+	/* Increment a missing key creates it with that value. */
+	unit_ok(zap_increment_by_dnode(dn, "a", 5, tx));
+	unit_ok(zap_lookup_by_dnode(dn, "a", sizeof (uint64_t), 1, &r));
+	unit_eq(r, 5);
+
+	/* Further increments accumulate. */
+	unit_ok(zap_increment_by_dnode(dn, "a", 3, tx));
+	unit_ok(zap_lookup_by_dnode(dn, "a", sizeof (uint64_t), 1, &r));
+	unit_eq(r, 8);
+
+	/* Decrement works. */
+	unit_ok(zap_increment_by_dnode(dn, "a", -2, tx));
+	unit_ok(zap_lookup_by_dnode(dn, "a", sizeof (uint64_t), 1, &r));
+	unit_eq(r, 6);
+
+	/* Zero delta leaves it unchanged. */
+	r = 0;
+	unit_ok(zap_increment_by_dnode(dn, "a", 0, tx));
+	unit_ok(zap_lookup_by_dnode(dn, "a", sizeof (uint64_t), 1, &r));
+	unit_eq(r, 6);
+
+	/* Decrementing to zero removes the entry. */
+	unit_ok(zap_increment_by_dnode(dn, "a", -6, tx));
+	unit_err(zap_lookup_by_dnode(dn, "a",
+	    sizeof (uint64_t), 1, &r), ENOENT);
+
+	/* Delta of zero is a no-op even for a missing key. */
+	unit_ok(zap_increment_by_dnode(dn, "a", 0, tx));
+	unit_err(zap_lookup_by_dnode(dn, "a",
+	    sizeof (uint64_t), 1, &r), ENOENT);
+
+	mock_tx_destroy((mock_dmu_tx_t *)tx);
+	unit_true(mock_zap_is_params(dn, params, "type"));
+	mock_zap_destroy(dn);
+
+	return (MUNIT_OK);
+}
+
 /* ========== */
 
 /*
@@ -859,6 +908,8 @@ static const MunitTest zap_tests[] = {
 	UNIT_TEST_ZAP_TYPES("zap_count",	test_zap_count),
 	UNIT_TEST_ZAP_TYPES("zap_contains",	test_zap_contains),
 	UNIT_TEST_ZAP_TYPES("zap_length",	test_zap_length),
+
+	UNIT_TEST_ZAP_TYPES("zap_increment",	test_zap_increment),
 
 	UNIT_TEST("microzap_stats",		test_microzap_stats),
 	UNIT_TEST("fatzap_stats",		test_fatzap_stats),

--- a/tests/unit/unit.c
+++ b/tests/unit/unit.c
@@ -24,6 +24,7 @@
 #include <sys/zfs_debug.h>
 
 #include "munit.h"
+#include "unit.h"
 
 /*
  * SET_ERROR() expands to __set_error() in debug builds. It's an
@@ -82,4 +83,23 @@ cmn_err(int ce, const char *fmt, ...)
 		munit_logf_ex(MUNIT_LOG_INFO, NULL, 0, "%s", buf);
 		break;
 	}
+}
+
+/* helpers to generate useful random data */
+uint64_t
+unit_rand_uint64(void)
+{
+	uint64_t v =
+	    (((uint64_t)munit_rand_uint32()) << 32) |
+	    ((uint64_t)munit_rand_uint32());
+	return (v);
+}
+
+char *
+unit_rand_str(char *buf, size_t bufsz)
+{
+	for (int i = 0; i < bufsz-1; i++)
+		buf[i] = munit_rand_int_range('a', 'z');
+	buf[bufsz-1] = '\0';
+	return (buf);
 }

--- a/tests/unit/unit.h
+++ b/tests/unit/unit.h
@@ -57,4 +57,8 @@
 #define	unit_ok(a)	munit_assert_int((a), ==, 0)
 #define	unit_err(a, e)	munit_assert_int((a), ==, (e))
 
+/* helpers to generate useful random data */
+extern uint64_t unit_rand_uint64(void);
+extern char *unit_rand_str(char *buf, size_t bufsz);
+
 #endif /* UNIT_H */


### PR DESCRIPTION
_[Sponsors: TrueNAS]_

### Motivation and Context

More ZAP refactor, testing and other stuff. Follows #18603.

This PR is focused on the weird and niche functions.

FYI, following this I have two more PRs coming: a big bunch of fatzap-specific tests, and then a test set for key normalization.

### Description

* Remove `zap_increment_int()`. Long unused (if it ever was used), and to the extent that the "stringy int key" set of functions make any sense at all, this one appears buggy.
* Remove `zap_join()`, `zap_join_key()`, `zap_join_increment()`. Long unused (last sighted in 2017 in d4a72f2386), too narrowly focused to be generally useful, and easy to reimplement or restore if ever needed.
* Add `zap_increment_by_dnode()` and make `zap_increment()` a wrapper. Add tests.
* Add `_by_dnode()` variants for the `zap_*_int` and `zap_*_int_key` functions. Add tests.
* Add `zap_value_search_by_dnode()`, make `zap_value_search()` a wrapper. Add tests.
* Add `unit_rand_uint64()` (unused) and `unit_rand_str()` to test framework (used in `zap_value_search` test for random keys).

More notes in commit messages and comments.

All up its a small but fiddly set of changes. There's a lot I don't like about these functions, but they exist and are in use so we do what we must.

### How Has This Been Tested?

ZTS running now, but not expecting any nonsense unless I've messed up the wrappers. Maybe not even then!

We're up to 40 tests in the ZAP suite now.

```
Coverage: test_zap       | By line         | By branch       | By function
                         | Rate% Total Hit | Rate% Total Hit | Rate% Total Hit
module/zfs/u8_textprep.c |  0.0%   802   0 |  0.0%   510   0 |  0.0%    12   0
module/zfs/zap.c         | 43.2%   581 251 | 40.7%   214  87 | 32.9%    79  26
module/zfs/zap_fat.c     | 47.1%   665 313 | 29.8%   446 133 | 62.2%    37  23
module/zfs/zap_impl.c    | 59.5%   232 138 | 42.5%   146  62 | 76.0%    25  19
module/zfs/zap_leaf.c    | 60.7%   466 283 | 41.2%   216  89 | 78.3%    23  18
module/zfs/zap_micro.c   | 68.9%   238 164 | 41.5%   142  59 | 92.9%    14  13
```

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
