### PR TITLE
metaslab: expose df_alloc_threshold and df_free_pct on Linux

### DIFF
--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -390,6 +390,18 @@ this is
 or
 .Em 2*1024 Pq with Sy ashift Ns = Ns Sy 12 .
 .
+.It Sy metaslab_df_alloc_threshold Ns = Ns Sy 131072 Ns B Po 128 KiB Pc Pq u64
+Minimum size which forces the dynamic allocator to change its allocation
+strategy.
+Once the space map cannot satisfy an allocation of this size, it switches to a
+more aggressive strategy (searching by size rather than offset).
+.
+.It Sy metaslab_df_free_pct Ns = Ns Sy 4 Ns % Pq uint
+The minimum free space, in percent, which must be available in a space map to
+continue allocations in a first-fit fashion.
+Once free space drops below this level, allocations switch to a best-fit
+strategy.
+.
 .It Sy metaslab_df_use_largest_segment Ns = Ns Sy 0 Ns | Ns 1 Pq int
 If not searching forward (due to
 .Sy metaslab_df_max_search , metaslab_df_free_pct ,

--- a/module/os/freebsd/zfs/sysctl_os.c
+++ b/module/os/freebsd/zfs/sysctl_os.c
@@ -289,32 +289,6 @@ param_set_active_allocator(SYSCTL_HANDLER_ARGS)
 	return (param_set_active_allocator_common(buf));
 }
 
-/*
- * Minimum size which forces the dynamic allocator to change
- * it's allocation strategy.  Once the space map cannot satisfy
- * an allocation of this size then it switches to using more
- * aggressive strategy (i.e search by size rather than offset).
- */
-extern uint64_t metaslab_df_alloc_threshold;
-
-SYSCTL_QUAD(_vfs_zfs_metaslab, OID_AUTO, df_alloc_threshold,
-	CTLFLAG_RWTUN, &metaslab_df_alloc_threshold, 0,
-	"Minimum size which forces the dynamic allocator to change its"
-	" allocation strategy");
-
-/*
- * The minimum free space, in percent, which must be available
- * in a space map to continue allocations in a first-fit fashion.
- * Once the space map's free space drops below this level we dynamically
- * switch to using best-fit allocations.
- */
-extern uint_t metaslab_df_free_pct;
-
-SYSCTL_UINT(_vfs_zfs_metaslab, OID_AUTO, df_free_pct,
-	CTLFLAG_RWTUN, &metaslab_df_free_pct, 0,
-	"The minimum free space, in percent, which must be available in a"
-	" space map to continue allocations in a first-fit fashion");
-
 /* mmp.c */
 
 int

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -6443,6 +6443,14 @@ ZFS_MODULE_PARAM(zfs_metaslab, metaslab_, df_max_search, UINT, ZMOD_RW,
 ZFS_MODULE_PARAM(zfs_metaslab, metaslab_, df_use_largest_segment, INT, ZMOD_RW,
 	"When looking in size tree, use largest segment instead of exact fit");
 
+ZFS_MODULE_PARAM(zfs_metaslab, metaslab_, df_alloc_threshold, U64, ZMOD_RW,
+	"Minimum size which forces the dynamic allocator to change its "
+	"allocation strategy");
+
+ZFS_MODULE_PARAM(zfs_metaslab, metaslab_, df_free_pct, UINT, ZMOD_RW,
+	"The minimum free space, in percent, to continue allocations in a "
+	"first-fit fashion");
+
 ZFS_MODULE_PARAM(zfs_metaslab, zfs_metaslab_, max_size_cache_sec, U64,
 	ZMOD_RW, "How long to trust the cached max chunk size of a metaslab");
 


### PR DESCRIPTION
### Motivation and Context

`metaslab_df_alloc_threshold` and `metaslab_df_free_pct` control when the dynamic-fit metaslab allocator switches from first-fit to best-fit, but they are only tunable on FreeBSD (`vfs.zfs.metaslab.df_*` sysctls). Expose them on Linux
as module parameters for parity.

### Description

- `module/zfs/metaslab.c`: register both via `ZFS_MODULE_PARAM` 
- `module/os/freebsd/zfs/sysctl_os.c`: remove the FreeBSD-only sysctl definitions.
- `man/man4/zfs.4`: document both tunables.

### How Has This Been Tested?

Built on Arch Linux (kernel 7.0.10) with the patched module. Both parameters appear under `/sys/module/zfs/parameters/` as RW with defaults `131072` / `4`

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [contributing document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
