### PR TITLE
Fix uninitialized variable warning in zil_parse()

### DIFF
--- a/module/zfs/zil.c
+++ b/module/zfs/zil.c
@@ -499,7 +499,7 @@ zil_parse(zilog_t *zilog, zil_parse_blk_func_t *parse_blk_func,
 	for (blk = zh->zh_log; !BP_IS_HOLE(&blk); blk = next_blk) {
 		uint64_t blk_seq = blk.blk_cksum.zc_word[ZIL_ZC_SEQ];
 		int reclen;
-		char *lrp, *end;
+		char *lrp = NULL, *end = NULL;
 		arc_buf_t *abuf = NULL;
 
 		if (blk_seq > claim_blk_seq)


### PR DESCRIPTION
### Motivation and Context

Observed when locally compiling with gcc 8.5.0.  I'm not sure why this wasn't noticed before it's not wrong, so let's fix it.

### Description

This resolves the following possible uninitialized variable warning.

    module/zfs/zil.c: In function ‘zil_parse’:
    module/zfs/zil.c:549:47: warning: ‘end’ may be used uninitialized
    in this function [-Wmaybe-uninitialized]

### How Has This Been Tested?

Locally compiled.  Will be tested by the CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)
