### PR TITLE
ZTS: relax zpool_import_parallel_pos.ksh timing

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_parallel_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_parallel_pos.ksh
@@ -114,7 +114,7 @@ wait
 parallel_time=$SECONDS
 log_note "asyncronously imported 4 pools in $parallel_time seconds"
 
-log_must test $parallel_time -lt $(($sequential_time / 2))
+log_must test $parallel_time -lt $(($sequential_time * 3 / 4))
 
 #
 # export pools with import delay injectors
@@ -133,6 +133,6 @@ log_must zpool import -a -d $DEVICE_DIR -f
 parallel_time=$SECONDS
 log_note "asyncronously imported 4 pools in $parallel_time seconds"
 
-log_must test $parallel_time -lt $(($sequential_time / 2))
+log_must test $parallel_time -lt $(($sequential_time * 3 / 4))
 
 log_pass "Pool imports occur in parallel"


### PR DESCRIPTION
### Motivation and Context

Follow up to #16638.  I'm still seeing too much of this:

```
  04:42:29.00 SUCCESS: zpool import -d /var/tmp/dev_import-test -f import_pool-7
  04:42:29.00 NOTE: asyncronously imported 4 pools in 24.300 seconds
  04:42:29.00 ERROR: test 24.300 -lt 24.2255 exited 1
```

https://github.com/openzfs/zfs/actions/runs/26955923650/job/79660844449?pr=18611

### Description

Occasionally in the CI this test will fail because the parallel import took longer than half of the serial time (but still less than the full serial time).  Increase the cutoff to 3/4 of the serial time to preserve the intent yet try and avoid these false positive failures.

### How Has This Been Tested?

It has not.  Will be tested by the CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)