### PR TITLE
ZTS: add coverage for the "allocating" vdev property

### DIFF
--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -3473,15 +3473,26 @@ zfs_ioc_vdev_set_props(const char *poolname, nvlist_t *innvl, nvlist_t *outnvl)
 
 	ASSERT(spa_writeable(spa));
 
+	/*
+	 * Hold SCL_CONFIG as a reader only across the guid lookup.  It must
+	 * NOT be held across vdev_prop_set(): setting the "allocating" property
+	 * calls spa_vdev_noalloc()/spa_vdev_alloc() -> spa_vdev_enter() ->
+	 * spa_config_enter(spa, SCL_ALL, RW_WRITER).  Acquiring SCL_CONFIG as a
+	 * writer while this same thread already holds it as a reader is a
+	 * self-deadlock: the writer waits for scl_count to drain to 0, but
+	 * scl_count is this thread's own reader, which is never released.
+	 * vdev_prop_set() re-resolves the vdev by guid under its own locking,
+	 * so the reader does not need to span it.
+	 */
 	spa_config_enter(spa, SCL_CONFIG, FTAG, RW_READER);
-	if ((vd = spa_lookup_by_guid(spa, vdev_guid, B_TRUE)) == NULL) {
-		spa_config_exit(spa, SCL_CONFIG, FTAG);
+	vd = spa_lookup_by_guid(spa, vdev_guid, B_TRUE);
+	spa_config_exit(spa, SCL_CONFIG, FTAG);
+	if (vd == NULL) {
 		spa_close(spa, FTAG);
 		return (SET_ERROR(ENOENT));
 	}
 
 	error = vdev_prop_set(vd, innvl, outnvl);
-	spa_config_exit(spa, SCL_CONFIG, FTAG);
 
 	spa_close(spa, FTAG);
 


### PR DESCRIPTION
### Motivation and Context

There is no test coverage that *sets* the `allocating` vdev property;
`vdev_get.cfg` lists it only for the read path. That set path self-deadlocks:
`zfs_ioc_vdev_set_props()` holds `SCL_CONFIG` as a reader across
`vdev_prop_set()`, and for `allocating` that descends into
`spa_vdev_noalloc()`/`spa_vdev_alloc()` -> `spa_vdev_enter()` ->
`spa_config_enter(spa, SCL_ALL, RW_WRITER)`. Taking `SCL_CONFIG` as a writer
while the same thread already holds it as a reader self-deadlocks the calling
thread. The reader was added by d65015938e19 ("Vdev allocation bias/class
change", #18493).

### Description

Adds `cli_root/zpool_set/vdev_set_allocating`, which creates a pool with two
top-level vdevs, sets `allocating=off` then `allocating=on` on one vdev, and
verifies each command returns and the property reads back as expected.

This test is submitted separately from the fix on purpose, so CI exercises it
against current master, where it is expected to hang at
`zpool set allocating=off`. The fix is in a companion PR; with that change
applied the test passes.

### How Has This Been Tested?

A/B on a debug build. With the deadlock present the test hangs at
`zpool set allocating=off`: the `zpool` thread parks in `spa_config_enter()`
via `zfs_ioc_vdev_set_props -> vdev_prop_set -> spa_vdev_noalloc ->
spa_vdev_enter`, and the pool's `spa_config_lock[0]` reads
`scl_writer=NULL, scl_count=1, scl_write_wanted=1`. With the companion fix
applied the test completes (allocating toggles off, then on).

### Types of changes
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)

### Checklist:
- [x] My code follows the OpenZFS code style requirements.
- [x] I have read the **contributing** document.
- [x] I have added tests to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain Signed-off-by.