### PR TITLE
ZTS: add coverage for the "allocating" vdev property

### DIFF
--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -575,7 +575,7 @@ tags = ['functional', 'cli_root', 'zpool_scrub']
 tests = ['zpool_set_001_pos', 'zpool_set_002_neg', 'zpool_set_003_neg',
     'zpool_set_ashift', 'zpool_set_features', 'zpool_set_inherit',
     'vdev_set_001_pos', 'user_property_001_pos', 'user_property_002_neg',
-    'zpool_set_clear_userprop','vdev_set_scheduler']
+    'zpool_set_clear_userprop','vdev_set_scheduler', 'vdev_set_allocating']
 tags = ['functional', 'cli_root', 'zpool_set']
 
 [tests/functional/cli_root/zpool_split]

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1299,6 +1299,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zpool/setup.ksh \
 	functional/cli_root/zpool_set/vdev_set_001_pos.ksh \
 	functional/cli_root/zpool_set/vdev_set_scheduler.ksh \
+	functional/cli_root/zpool_set/vdev_set_allocating.ksh \
 	functional/cli_root/zpool_set/zpool_set_common.kshlib \
 	functional/cli_root/zpool_set/zpool_set_001_pos.ksh \
 	functional/cli_root/zpool_set/zpool_set_002_neg.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_set/vdev_set_allocating.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_set/vdev_set_allocating.ksh
@@ -1,0 +1,80 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2026 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+#	Toggling the "allocating" vdev property completes and takes effect.
+#
+#	When zfs_ioc_vdev_set_props() holds SCL_CONFIG as a reader across
+#	vdev_prop_set(), setting "allocating" re-enters
+#	spa_config_enter(spa, SCL_ALL, RW_WRITER) via
+#	spa_vdev_noalloc()/spa_vdev_alloc(); taking SCL_CONFIG as a writer
+#	while the same thread already holds it as a reader self-deadlocks the
+#	calling thread, so "zpool set allocating=off" hangs in
+#	spa_config_enter().
+#
+# STRATEGY:
+#	1. Create a pool with two top-level vdevs (so one can stop allocating
+#	   while a normal vdev remains).
+#	2. Set allocating=off on the first vdev; verify the command returns and
+#	   the property reads back "off".
+#	3. Set allocating=on; verify it reads back "on".
+#
+
+verify_runnable "global"
+
+typeset POOL=alloc_testpool
+typeset VDEV0=$TEST_BASE_DIR/vdev_alloc0.$$
+typeset VDEV1=$TEST_BASE_DIR/vdev_alloc1.$$
+
+function cleanup
+{
+	poolexists $POOL && destroy_pool $POOL
+	rm -f $VDEV0 $VDEV1
+}
+
+log_onexit cleanup
+
+log_assert "toggling the allocating vdev property completes and takes effect"
+
+log_must truncate -s $MINVDEVSIZE $VDEV0 $VDEV1
+log_must zpool create $POOL $VDEV0 $VDEV1
+
+# Both top-level vdevs allocate by default.
+log_must test "$(zpool get -H -o value allocating $POOL $VDEV0)" = "on"
+
+# The operation that previously deadlocked.
+log_must zpool set allocating=off $POOL $VDEV0
+log_must test "$(zpool get -H -o value allocating $POOL $VDEV0)" = "off"
+
+# And back on.
+log_must zpool set allocating=on $POOL $VDEV0
+log_must test "$(zpool get -H -o value allocating $POOL $VDEV0)" = "on"
+
+log_pass "toggling the allocating vdev property completes and takes effect"


### PR DESCRIPTION
### Motivation and Context

There is no test coverage that *sets* the `allocating` vdev property;
`vdev_get.cfg` lists it only for the read path. That set path self-deadlocks:
`zfs_ioc_vdev_set_props()` holds `SCL_CONFIG` as a reader across
`vdev_prop_set()`, and for `allocating` that descends into
`spa_vdev_noalloc()`/`spa_vdev_alloc()` -> `spa_vdev_enter()` ->
`spa_config_enter(spa, SCL_ALL, RW_WRITER)`. Taking `SCL_CONFIG` as a writer
while the same thread already holds it as a reader self-deadlocks the calling
thread. The reader was added by d65015938e19 ("Vdev allocation bias/class
change", #18493).

### Description

Adds `cli_root/zpool_set/vdev_set_allocating`, which creates a pool with two
top-level vdevs, sets `allocating=off` then `allocating=on` on one vdev, and
verifies each command returns and the property reads back as expected.

This test is submitted separately from the fix on purpose, so CI exercises it
against current master, where it is expected to hang at
`zpool set allocating=off`. The fix is in a companion PR; with that change
applied the test passes.

### How Has This Been Tested?

A/B on a debug build. With the deadlock present the test hangs at
`zpool set allocating=off`: the `zpool` thread parks in `spa_config_enter()`
via `zfs_ioc_vdev_set_props -> vdev_prop_set -> spa_vdev_noalloc ->
spa_vdev_enter`, and the pool's `spa_config_lock[0]` reads
`scl_writer=NULL, scl_count=1, scl_write_wanted=1`. With the companion fix
applied the test completes (allocating toggles off, then on).

### Types of changes
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)

### Checklist:
- [x] My code follows the OpenZFS code style requirements.
- [x] I have read the **contributing** document.
- [x] I have added tests to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain Signed-off-by.