### PR TITLE
unit/zap: add MT_MATCH_CASE mixed-case test

### DIFF
--- a/tests/unit/test_zap.c
+++ b/tests/unit/test_zap.c
@@ -1156,6 +1156,47 @@ test_norm_toupper(const MunitParameter params[], void *data)
 }
 
 /*
+ * MT_MATCH_CASE forces an exact-case match on a normalizing (TOUPPER) ZAP.
+ */
+static MunitResult
+test_norm_match_case(const MunitParameter params[], void *data)
+{
+	(void) data;
+
+	dnode_t *dn =
+	    mock_zap_create_norm_params(params, "type", U8_TEXTPREP_TOUPPER);
+	dmu_tx_t *tx = (dmu_tx_t *)mock_tx_create();
+
+	uint64_t val = 42;
+	unit_ok(zap_add_by_dnode(dn, "Hello",
+	    sizeof (uint64_t), 1, &val, tx));
+
+	/* MT_NORMALIZE alone matches any casing. */
+	uint64_t result = 0;
+	unit_ok(zap_lookup_norm_by_dnode(dn, "hello",
+	    sizeof (uint64_t), 1, &result, MT_NORMALIZE, NULL, 0, NULL));
+	unit_eq(result, 42);
+
+	/* Adding MT_MATCH_CASE rejects a case variant name. */
+	unit_err(zap_lookup_norm_by_dnode(dn, "hello",
+	    sizeof (uint64_t), 1, &result, MT_NORMALIZE | MT_MATCH_CASE,
+	    NULL, 0, NULL), ENOENT);
+
+	/* The exact-case name still matches under MT_MATCH_CASE. */
+	result = 0;
+	unit_ok(zap_lookup_norm_by_dnode(dn, "Hello",
+	    sizeof (uint64_t), 1, &result, MT_NORMALIZE | MT_MATCH_CASE,
+	    NULL, 0, NULL));
+	unit_eq(result, 42);
+
+	mock_tx_destroy((mock_dmu_tx_t *)tx);
+	unit_true(mock_zap_is_params(dn, params, "type"));
+	mock_zap_destroy(dn);
+
+	return (MUNIT_OK);
+}
+
+/*
  * NFC: canonical decomposition + canonical recomposition.
  *
  * NFC-normalized keys are stored in their original encoding but match but
@@ -1516,6 +1557,7 @@ static const MunitTest zap_tests[] = {
 	    "zap_value_search_mask",	test_zap_value_search_mask),
 
 	UNIT_TEST("norm_toupper",	test_norm_toupper, zap_type_params),
+	UNIT_TEST("norm_match_case",	test_norm_match_case, zap_type_params),
 	UNIT_TEST("norm_nfc",		test_norm_nfc, zap_type_params),
 	UNIT_TEST("norm_nfd",		test_norm_nfd, zap_type_params),
 	UNIT_TEST("norm_nfkc",		test_norm_nfkc, zap_type_params),


### PR DESCRIPTION
### Motivation and Context

Adds `MT_MATCH_CASE` coverage for `MT_NORMALIZE` lookups that miss from #18654

### Description

Adds `test_norm_match_case`, run against a normalizing microzap and fatzap. 

- `MT_NORMALIZE`: a differently-cased name matches.
- `MT_NORMALIZE | MT_MATCH_CASE`: only the stored casing matches; differently-cased name does not.

### How Has This Been Tested?

Built `tests/unit/test_zap` and ran the suite:

```
>  make unit T=zap TOPT='zap.norm_match_case'
  UNITTEST tests/unit/test_zap
Running test suite with seed 0x071ebff6...
zap.norm_match_case
  type=micro                         [ OK    ] [ 0.00002834 / 0.00002752 CPU ]
  type=fat                           [ OK    ] [ 0.00003386 / 0.00003302 CPU ]
2 of 2 (100%) tests successful, 0 (0%) test skipped.
```

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [contributing document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
