### PR TITLE
unit/zap: uint64 keys

### DIFF
--- a/tests/unit/test_zap.c
+++ b/tests/unit/test_zap.c
@@ -1505,6 +1505,75 @@ test_norm_remove(const MunitParameter params[], void *data)
 
 /* ========== */
 
+/*
+ * Binary uint64-array keys (ZAP_FLAG_UINT64_KEY), as used by the dedup table
+ * and the block reference table.  Such a ZAP is always a fatzap.  Covers the
+ * uint64-key by-dnode operations: add, lookup, length, lookup_length, update
+ * and remove.
+ */
+static MunitResult
+test_zap_uint64_keys(const MunitParameter params[], void *data)
+{
+	(void) params, (void) data;
+
+	mock_dnode_t *mdn = mock_dnode_create(512, DMU_OTN_ZAP_DATA);
+	dnode_t *dn = (dnode_t *)mdn;
+	dmu_tx_t *tx = (dmu_tx_t *)mock_tx_create();
+	mzap_create_impl(dn, 0, ZAP_FLAG_HASH64 | ZAP_FLAG_UINT64_KEY, tx);
+	unit_true(mock_zap_is_fatzap(dn));
+
+	/* A two-word binary key, as used by the dedup and clone tables. */
+	uint64_t key[2] = { unit_rand_uint64(), unit_rand_uint64() };
+	uint64_t val = 1;
+
+	/* Store a value, then read it back by the same key. */
+	unit_ok(zap_add_uint64_by_dnode(dn, key, 2, sizeof (uint64_t), 1,
+	    &val, tx));
+	uint64_t out = 0;
+	unit_ok(zap_lookup_uint64_by_dnode(dn, key, 2, sizeof (uint64_t), 1,
+	    &out));
+	unit_eq(out, 1);
+
+	/* zap_length reports a value's size without reading it. */
+	uint64_t isz = 0, nint = 0;
+	unit_ok(zap_length_uint64_by_dnode(dn, key, 2, &isz, &nint));
+	unit_eq(isz, sizeof (uint64_t));
+	unit_eq(nint, 1);
+
+	/* zap_lookup_length: the value plus its real element count. */
+	out = 0;
+	uint64_t actual = 0;
+	unit_ok(zap_lookup_length_uint64_by_dnode(dn, key, 2,
+	    sizeof (uint64_t), 1, &out, &actual));
+	unit_eq(out, 1);
+	unit_eq(actual, 1);
+
+	/* zap_update replaces the value for an existing key. */
+	val = 2;
+	unit_ok(zap_update_uint64_by_dnode(dn, key, 2, sizeof (uint64_t), 1,
+	    &val, tx));
+	unit_ok(zap_lookup_uint64_by_dnode(dn, key, 2, sizeof (uint64_t), 1,
+	    &out));
+	unit_eq(out, 2);
+
+	/* A key that was never added is not found. */
+	uint64_t key2[2] = { unit_rand_uint64(), unit_rand_uint64() };
+	unit_err(zap_lookup_uint64_by_dnode(dn, key2, 2, sizeof (uint64_t), 1,
+	    &out), ENOENT);
+
+	/* After removal, the key can no longer be looked up. */
+	unit_ok(zap_remove_uint64_by_dnode(dn, key, 2, tx));
+	unit_err(zap_lookup_uint64_by_dnode(dn, key, 2, sizeof (uint64_t), 1,
+	    &out), ENOENT);
+
+	mock_tx_destroy((mock_dmu_tx_t *)tx);
+	mock_zap_destroy(dn);
+
+	return (MUNIT_OK);
+}
+
+/* ========== */
+
 /* Test suite definition and boilerplate. */
 
 #define	UNIT_PARAM_ZAP_TYPES(p)	\
@@ -1538,6 +1607,8 @@ static const MunitTest zap_tests[] = {
 
 	UNIT_TEST("microzap_stats",		test_microzap_stats),
 	UNIT_TEST("fatzap_stats",		test_fatzap_stats),
+
+	UNIT_TEST("uint64_keys",		test_zap_uint64_keys),
 
 	UNIT_TEST_ZAP_TYPES("cursor",		test_cursor),
 	UNIT_TEST_ZAP_TYPES("cursor_serialize",	test_cursor_serialize),


### PR DESCRIPTION
### Motivation and Context

ZAP unit test that adds coverage for binary uint64-array keys (`ZAP_FLAG_UINT64_KEY`), as used by the dedup table (DDT) and the block reference table (BRT).

### Description

Adds `test_zap_uint64_keys`. It creates a `ZAP_FLAG_UINT64_KEY` ZAP (always a fatzap) and runs dnode operations:

- `add` then `lookup` — add a value and then look it up based on the key.
- `length` — reports the value's size.
- `lookup_length` — returns the value and its count.
- `update` — replaces the value for an existing key.
- `remove` — after which the key is no longer found.

### How Has This Been Tested?

Built `tests/unit/test_zap` and ran the suite:
```
>   make unit T=zap

Running test suite with seed 0x8d74dd63...
zap.mock_microzap_sanity             [ OK    ] [ 0.00000743 / 0.00000665 CPU ]
zap.mock_fatzap_sanity               [ OK    ] [ 0.00003343 / 0.00003276 CPU ]
zap.zap_basic
  type=micro                         [ OK    ] [ 0.00001833 / 0.00001798 CPU ]
  type=fat                           [ OK    ] [ 0.00004697 / 0.00004631 CPU ]
zap.zap_add
  type=micro                         [ OK    ] [ 0.00001692 / 0.00001684 CPU ]
  type=fat                           [ OK    ] [ 0.00002890 / 0.00002889 CPU ]
zap.zap_update
  type=micro                         [ OK    ] [ 0.00001720 / 0.00001672 CPU ]
  type=fat                           [ OK    ] [ 0.00002462 / 0.00002462 CPU ]
zap.zap_remove
  type=micro                         [ OK    ] [ 0.00001514 / 0.00001478 CPU ]
  type=fat                           [ OK    ] [ 0.00002335 / 0.00002295 CPU ]
zap.zap_count
  type=micro                         [ OK    ] [ 0.00001221 / 0.00001223 CPU ]
  type=fat                           [ OK    ] [ 0.00001342 / 0.00001340 CPU ]
zap.zap_contains
  type=micro                         [ OK    ] [ 0.00000910 / 0.00000910 CPU ]
  type=fat                           [ OK    ] [ 0.00001333 / 0.00001333 CPU ]
zap.zap_length
  type=micro                         [ OK    ] [ 0.00000675 / 0.00000675 CPU ]
  type=fat                           [ OK    ] [ 0.00001119 / 0.00001120 CPU ]
zap.zap_increment
  type=micro                         [ OK    ] [ 0.00000781 / 0.00000782 CPU ]
  type=fat                           [ OK    ] [ 0.00001350 / 0.00001349 CPU ]
zap.zap_int
  type=micro                         [ OK    ] [ 0.00001516 / 0.00001512 CPU ]
  type=fat                           [ OK    ] [ 0.00001482 / 0.00001482 CPU ]
zap.zap_int_keys
  type=micro                         [ OK    ] [ 0.00000933 / 0.00000934 CPU ]
  type=fat                           [ OK    ] [ 0.00001411 / 0.00001411 CPU ]
zap.microzap_stats                   [ OK    ] [ 0.00001393 / 0.00001355 CPU ]
zap.fatzap_stats                     [ OK    ] [ 0.00001486 / 0.00001486 CPU ]
zap.uint64_keys                      [ OK    ] [ 0.00002066 / 0.00002039 CPU ]
zap.cursor
  type=micro                         [ OK    ] [ 0.00002114 / 0.00002087 CPU ]
  type=fat                           [ OK    ] [ 0.00002527 / 0.00002520 CPU ]
zap.cursor_serialize
  type=micro                         [ OK    ] [ 0.00001880 / 0.00001866 CPU ]
  type=fat                           [ OK    ] [ 0.00002643 / 0.00002614 CPU ]
zap.cursor_release_unused
  type=micro                         [ OK    ] [ 0.00001209 / 0.00001209 CPU ]
  type=fat                           [ OK    ] [ 0.00001635 / 0.00001633 CPU ]
zap.cursor_release_advance
  type=micro                         [ OK    ] [ 0.00000973 / 0.00000968 CPU ]
  type=fat                           [ OK    ] [ 0.00001369 / 0.00001364 CPU ]
zap.cursor_release_empty
  type=micro                         [ OK    ] [ 0.00000623 / 0.00000622 CPU ]
  type=fat                           [ OK    ] [ 0.00001187 / 0.00001188 CPU ]
zap.cursor_release_one
  type=micro                         [ OK    ] [ 0.00000896 / 0.00000897 CPU ]
  type=fat                           [ OK    ] [ 0.00001837 / 0.00001836 CPU ]
zap.zap_value_search
  type=micro                         [ OK    ] [ 0.00000798 / 0.00000799 CPU ]
  type=fat                           [ OK    ] [ 0.00001460 / 0.00001461 CPU ]
zap.zap_value_search_mask
  type=micro                         [ OK    ] [ 0.00000843 / 0.00000841 CPU ]
  type=fat                           [ OK    ] [ 0.00002130 / 0.00002130 CPU ]
41 of 41 (100%) tests successful, 0 (0%) test skipped.
```

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Tests (a change to the test suite that does not modify production code)

### Checklist:

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [contributing document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
