### PR TITLE
Update ztest.1

### DIFF
--- a/man/man1/ztest.1
+++ b/man/man1/ztest.1
@@ -67,7 +67,7 @@
 .Nm
 was written by the ZFS Developers as a ZFS unit test.
 The tool was developed in tandem with the ZFS functionality and was
-executed nightly as one of the many regression test against the daily build.
+executed nightly as one of the many regression tests against the daily build.
 As features were added to ZFS, unit tests were also added to
 .Nm .
 In addition, a separate test development team wrote and


### PR DESCRIPTION
Fixed grammatical error

### Motivation and Context
This change simply makes the word 'test' into the plural 'tests'

### Description
The original wording "The tool was developed in tandem with the ZFS functionality and was
executed nightly as one of the many regression test against the daily build" doesn't make sense as the word 'many' implies tests (plural). 

### Types of changes
- [ X] Documentation (a change to man pages or other documentation)

### Checklist:
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [X] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

Signed-off-by: Zachary Sandberg <zachary.sandberg@gmail.com>