### PR TITLE
test_zap: correct duplicate words

### DIFF
--- a/tests/unit/test_zap.c
+++ b/tests/unit/test_zap.c
@@ -234,7 +234,7 @@ test_zap_basic(const MunitParameter params[], void *data)
 /* ========== */
 
 /*
- * "Core" ZAP API tests. Covers the most basic functionality upon which which
+ * "Core" ZAP API tests. Covers the most basic functionality upon which
  * everything else is built.
  *
  * Note that to avoid microzap upgrade here, we only short keys and
@@ -687,7 +687,7 @@ test_cursor(const MunitParameter params[], void *data)
 	unit_ok(zap_cursor_init_by_dnode(&zc, dn));
 
 	/*
-	 * Cursors don't guarantee an order, so we run over them them all,
+	 * Cursors don't guarantee an order, so we run over them all,
 	 * confirm the key matches the value, and then set a bit for each
 	 * one we've seen. By the end, we should have seen them all.
 	 */


### PR DESCRIPTION
### Motivation and Context

Skimming through the code I came across 2 comments containing the same word twice.

### Description

Correct: "which which" to "which" and "them them" to "them".

### How Has This Been Tested?

Checkstyle passes.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
