### PR TITLE
unit/namecheck: test name validation

### DIFF
--- a/tests/unit/.gitignore
+++ b/tests/unit/.gitignore
@@ -2,3 +2,4 @@
 /test_*_coverage
 
 /test_zap
+/test_namecheck

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -15,7 +15,8 @@ libunit_la_SOURCES = \
 
 # all test binaries
 UNIT_TESTS = \
-	%D%/test_zap
+	%D%/test_zap \
+	%D%/test_namecheck
 noinst_PROGRAMS = $(UNIT_TESTS)
 
 
@@ -35,6 +36,19 @@ nodist_%C%_test_zap_SOURCES = \
 %C%_test_zap_LDADD = \
 	libspl.la \
 	libbtree.la \
+	libunit.la
+
+
+%C%_test_namecheck_CFLAGS = $(AM_CFLAGS)
+
+nodist_%C%_test_namecheck_SOURCES = \
+	module/zcommon/zfs_namecheck.c
+
+%C%_test_namecheck_SOURCES = \
+	%D%/test_namecheck.c
+
+%C%_test_namecheck_LDADD = \
+	libspl.la \
 	libunit.la
 
 

--- a/tests/unit/test_namecheck.c
+++ b/tests/unit/test_namecheck.c
@@ -1,0 +1,321 @@
+// SPDX-License-Identifier: CDDL-1.0
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2026, Christos Longros.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include <sys/fs/zfs.h>
+#include "zfs_namecheck.h"
+
+#include "unit.h"
+
+/* ========== */
+
+/*
+ * The namecheck routines validate a name and report, via namecheck_err_t,
+ * exactly why it failed.  We test them in two directions:
+ *
+ *   - Validity path: randomly generated names from unit_rand_str(), which
+ *     give only 'a'-'z' characters.
+ *
+ *   - Invalidity path: explicit names, each tested against their specific
+ *     error code since the rejection reason depends on the exact characters
+ *     used.
+ */
+typedef int (*namecheck_f)(const char *, namecheck_err_t *, char *);
+
+/* Confirm 'name' is accepted by 'fn'. */
+static void
+check_valid(namecheck_f fn, const char *name)
+{
+	namecheck_err_t why = (namecheck_err_t)-1;
+	char what = '\0';
+	unit_ok(fn(name, &why, &what));
+}
+
+/* Confirm 'name' is rejected by 'fn' with the 'why' we expected. */
+static void
+check_invalid(namecheck_f fn, const char *name, namecheck_err_t expected)
+{
+	namecheck_err_t why = (namecheck_err_t)-1;
+	char what = '\0';
+	unit_err(fn(name, &why, &what), -1);
+	unit_eq(why, expected);
+}
+
+/* A name longer than every namecheck length limit, for the TOOLONG checks. */
+static char *
+long_char(void)
+{
+	static char buf[ZFS_MAX_DATASET_NAME_LEN + 16];
+	(void) memset(buf, 'a', sizeof (buf) - 1);
+	buf[sizeof (buf) - 1] = '\0';
+	return (buf);
+}
+
+/* ========== */
+
+/* pool_namecheck: dataset character set that must begin with a letter. */
+static MunitResult
+test_pool_namecheck(const MunitParameter params[], void *data)
+{
+	(void) params, (void) data;
+
+	/* A random array of letters is always a valid pool name. */
+	char pool[16];
+	check_valid(pool_namecheck, unit_rand_str(pool, sizeof (pool)));
+
+	/* Fixed names cover the rest of the allowed character set. */
+	check_valid(pool_namecheck, "tank_01");
+	check_valid(pool_namecheck, "Pool-2.0:label");
+
+	/* A pool name has to start with a letter. */
+	check_invalid(pool_namecheck, "0tank", NAME_ERR_NOLETTER);
+	check_invalid(pool_namecheck, "_tank", NAME_ERR_NOLETTER);
+
+	/* These pool names are reserved. */
+	check_invalid(pool_namecheck, "mirror", NAME_ERR_RESERVED);
+	check_invalid(pool_namecheck, "raidz", NAME_ERR_RESERVED);
+	check_invalid(pool_namecheck, "draid", NAME_ERR_RESERVED);
+
+	/* A pool name carries no hierarchy or snapshot delimiter. */
+	check_invalid(pool_namecheck, "tank/fs", NAME_ERR_INVALCHAR);
+	check_invalid(pool_namecheck, "tank@snap", NAME_ERR_INVALCHAR);
+
+	check_invalid(pool_namecheck, long_char(), NAME_ERR_TOOLONG);
+
+	return (MUNIT_OK);
+}
+
+/* dataset_namecheck: any entity except a bookmark. */
+static MunitResult
+test_dataset_namecheck(const MunitParameter params[], void *data)
+{
+	(void) params, (void) data;
+
+	/* A path of random, independently-valid components is accepted. */
+	char a[16], b[16], c[16], path[64];
+	(void) snprintf(path, sizeof (path), "%s/%s/%s",
+	    unit_rand_str(a, sizeof (a)), unit_rand_str(b, sizeof (b)),
+	    unit_rand_str(c, sizeof (c)));
+	check_valid(dataset_namecheck, path);
+
+	/* A trailing snapshot is still a valid dataset name. */
+	check_valid(dataset_namecheck, "tank/home@snap");
+
+	/* '%' is allowed, for temporary clone names (online recv). */
+	check_valid(dataset_namecheck, "tank/%recv");
+
+	check_invalid(dataset_namecheck, "/tank", NAME_ERR_LEADING_SLASH);
+	check_invalid(dataset_namecheck, "tank/", NAME_ERR_TRAILING_SLASH);
+	check_invalid(dataset_namecheck, "tank//home",
+	    NAME_ERR_EMPTY_COMPONENT);
+	check_invalid(dataset_namecheck, "", NAME_ERR_EMPTY_COMPONENT);
+	check_invalid(dataset_namecheck, "tank/./home", NAME_ERR_SELF_REF);
+	check_invalid(dataset_namecheck, "tank/../home", NAME_ERR_PARENT_REF);
+	check_invalid(dataset_namecheck, "tank/fs!", NAME_ERR_INVALCHAR);
+
+	/* A bookmark delimiter does not belong in a dataset name. */
+	check_invalid(dataset_namecheck, "tank/fs#bm", NAME_ERR_INVALCHAR);
+
+	check_invalid(dataset_namecheck, long_char(), NAME_ERR_TOOLONG);
+
+	return (MUNIT_OK);
+}
+
+/* snapshot_namecheck: a valid snapshot name (an entity with '@'). */
+static MunitResult
+test_snapshot_namecheck(const MunitParameter params[], void *data)
+{
+	(void) params, (void) data;
+
+	/* A random "filesystem@snapshot" pair is valid. */
+	char fs[16], snap[16], path[64];
+	(void) snprintf(path, sizeof (path), "%s@%s",
+	    unit_rand_str(fs, sizeof (fs)), unit_rand_str(snap, sizeof (snap)));
+	check_valid(snapshot_namecheck, path);
+
+	/* Without an '@' it is not a snapshot. */
+	check_invalid(snapshot_namecheck, "tank/home", NAME_ERR_NO_AT);
+
+	/* Only one delimiter is allowed. */
+	check_invalid(snapshot_namecheck, "tank@a@b",
+	    NAME_ERR_MULTIPLE_DELIMITERS);
+
+	/* Nothing may follow the snapshot name with a '/'. */
+	check_invalid(snapshot_namecheck, "tank@snap/x",
+	    NAME_ERR_TRAILING_SLASH);
+
+	return (MUNIT_OK);
+}
+
+/* bookmark_namecheck: a valid bookmark name (an entity with '#'). */
+static MunitResult
+test_bookmark_namecheck(const MunitParameter params[], void *data)
+{
+	(void) params, (void) data;
+
+	/* A random "filesystem#bookmark" pair is valid. */
+	char fs[16], mark[16], path[64];
+	(void) snprintf(path, sizeof (path), "%s#%s",
+	    unit_rand_str(fs, sizeof (fs)), unit_rand_str(mark, sizeof (mark)));
+	check_valid(bookmark_namecheck, path);
+
+	/* Without a '#' it is not a bookmark. */
+	check_invalid(bookmark_namecheck, "tank/home", NAME_ERR_NO_POUND);
+
+	return (MUNIT_OK);
+}
+
+/* zfs_component_namecheck: one component; alphanumeric plus [-_.: ]. */
+static MunitResult
+test_component_namecheck(const MunitParameter params[], void *data)
+{
+	(void) params, (void) data;
+
+	/* A bare random component is valid. */
+	char comp[16];
+	unit_rand_str(comp, sizeof (comp));
+	check_valid(zfs_component_namecheck, comp);
+
+	/* An empty component is not valid. */
+	check_invalid(zfs_component_namecheck, "", NAME_ERR_EMPTY_COMPONENT);
+
+	/* A single component cannot contain a path separator. */
+	check_invalid(zfs_component_namecheck, "a/b", NAME_ERR_INVALCHAR);
+
+	check_invalid(zfs_component_namecheck, long_char(),
+	    NAME_ERR_TOOLONG);
+
+	return (MUNIT_OK);
+}
+
+/* permset_namecheck: a permission set name, starting with '@'. */
+static MunitResult
+test_permset_namecheck(const MunitParameter params[], void *data)
+{
+	(void) params, (void) data;
+
+	/* A random name behind a leading '@' is a valid permission set. */
+	char set[16];
+	set[0] = '@';
+	unit_rand_str(set + 1, sizeof (set) - 1);
+	check_valid(permset_namecheck, set);
+
+	/* It has to start with '@'. */
+	check_invalid(permset_namecheck, "backup", NAME_ERR_NO_AT);
+
+	/* The text after '@' follows the component rules. */
+	check_invalid(permset_namecheck, "@bad/name", NAME_ERR_INVALCHAR);
+
+	/* The length upper limit is checked ahead of everything else. */
+	check_invalid(permset_namecheck, long_char(), NAME_ERR_TOOLONG);
+
+	return (MUNIT_OK);
+}
+
+/* mountpoint_namecheck: a mountpoint path, /[component][/]*. */
+static MunitResult
+test_mountpoint_namecheck(const MunitParameter params[], void *data)
+{
+	(void) params, (void) data;
+
+	namecheck_err_t why = (namecheck_err_t)-1;
+
+	/* An absolute path with a random component is accepted. */
+	char comp[16], path[64];
+	(void) snprintf(path, sizeof (path), "/%s",
+	    unit_rand_str(comp, sizeof (comp)));
+	unit_ok(mountpoint_namecheck(path, &why));
+
+	/* The root mountpoint is valid. */
+	unit_ok(mountpoint_namecheck("/", &why));
+
+	/* A mountpoint must be absolute. */
+	unit_err(mountpoint_namecheck("relative/path", &why), -1);
+	unit_eq(why, NAME_ERR_LEADING_SLASH);
+
+	/* A NULL path counts as missing the leading slash. */
+	unit_err(mountpoint_namecheck(NULL, &why), -1);
+	unit_eq(why, NAME_ERR_LEADING_SLASH);
+
+	/* A long path component is rejected. */
+	char buf[ZFS_MAX_DATASET_NAME_LEN + 4];
+	buf[0] = '/';
+	(void) memset(buf + 1, 'a', sizeof (buf) - 2);
+	buf[sizeof (buf) - 1] = '\0';
+	unit_err(mountpoint_namecheck(buf, &why), -1);
+	unit_eq(why, NAME_ERR_TOOLONG);
+
+	return (MUNIT_OK);
+}
+
+/* get_dataset_depth: a path's level of nesting (depth). */
+static MunitResult
+test_dataset_depth(const MunitParameter params[], void *data)
+{
+	(void) params, (void) data;
+
+	/* Depth is the number of '/' separators in the path. */
+	unit_eq(get_dataset_depth("tank"), 0);
+	unit_eq(get_dataset_depth("tank/home"), 1);
+	unit_eq(get_dataset_depth("tank/home/user"), 2);
+
+	/* Counting stops at the snapshot or bookmark delimiter. */
+	unit_eq(get_dataset_depth("tank/home@snap"), 1);
+	unit_eq(get_dataset_depth("tank/home#bm"), 1);
+
+	/*
+	 * dataset_nestcheck() passes while the depth is under the limit and
+	 * fails once it reaches it.  We drop the limit to a small value so we
+	 * can test it and then restore it.
+	 */
+	int limit = zfs_max_dataset_nesting;
+	zfs_max_dataset_nesting = 2;
+	unit_ok(dataset_nestcheck("a/b"));		/* depth 1, under 2 */
+	unit_err(dataset_nestcheck("a/b/c"), -1);	/* depth 2, at 2   */
+	zfs_max_dataset_nesting = limit;
+
+	return (MUNIT_OK);
+}
+
+/* ========== */
+
+static const MunitTest namecheck_tests[] = {
+	UNIT_TEST("pool",	test_pool_namecheck),
+	UNIT_TEST("dataset",	test_dataset_namecheck),
+	UNIT_TEST("snapshot",	test_snapshot_namecheck),
+	UNIT_TEST("bookmark",	test_bookmark_namecheck),
+	UNIT_TEST("component",	test_component_namecheck),
+	UNIT_TEST("permset",	test_permset_namecheck),
+	UNIT_TEST("mountpoint",	test_mountpoint_namecheck),
+	UNIT_TEST("depth",	test_dataset_depth),
+	{ 0 },
+};
+
+static const MunitSuite namecheck_test_suite = {
+	"namecheck.",
+	namecheck_tests,
+	NULL,
+	1,
+	MUNIT_SUITE_OPTION_NONE,
+};
+
+int
+main(int argc, char **argv)
+{
+	return (munit_suite_main(&namecheck_test_suite, NULL, argc, argv));
+}

--- a/tests/unit/test_namecheck.c
+++ b/tests/unit/test_namecheck.c
@@ -14,7 +14,6 @@
  * Copyright (c) 2026, Christos Longros.
  */
 
-#include <stdio.h>
 #include <string.h>
 
 #include <sys/fs/zfs.h>
@@ -56,14 +55,12 @@ check_invalid(namecheck_f fn, const char *name, namecheck_err_t expected)
 	unit_eq(why, expected);
 }
 
-/* A name longer than every namecheck length limit, for the TOOLONG checks. */
-static char *
-long_char(void)
+/* Confirm 'fn' rejects a lengthy name and returns NAME_ERR_TOOLONG. */
+static void
+check_longname_invalid(namecheck_f fn)
 {
-	static char buf[ZFS_MAX_DATASET_NAME_LEN + 16];
-	(void) memset(buf, 'a', sizeof (buf) - 1);
-	buf[sizeof (buf) - 1] = '\0';
-	return (buf);
+	char buf[ZFS_MAX_DATASET_NAME_LEN + 16];
+	check_invalid(fn, unit_rand_str(buf, sizeof (buf)), NAME_ERR_TOOLONG);
 }
 
 /* ========== */
@@ -95,7 +92,7 @@ test_pool_namecheck(const MunitParameter params[], void *data)
 	check_invalid(pool_namecheck, "tank/fs", NAME_ERR_INVALCHAR);
 	check_invalid(pool_namecheck, "tank@snap", NAME_ERR_INVALCHAR);
 
-	check_invalid(pool_namecheck, long_char(), NAME_ERR_TOOLONG);
+	check_longname_invalid(pool_namecheck);
 
 	return (MUNIT_OK);
 }
@@ -107,10 +104,9 @@ test_dataset_namecheck(const MunitParameter params[], void *data)
 	(void) params, (void) data;
 
 	/* A path of random, independently-valid components is accepted. */
-	char a[16], b[16], c[16], path[64];
-	(void) snprintf(path, sizeof (path), "%s/%s/%s",
-	    unit_rand_str(a, sizeof (a)), unit_rand_str(b, sizeof (b)),
-	    unit_rand_str(c, sizeof (c)));
+	char path[64];
+	unit_rand_str(path, sizeof (path));
+	path[20] = path[40] = '/';
 	check_valid(dataset_namecheck, path);
 
 	/* A trailing snapshot is still a valid dataset name. */
@@ -131,7 +127,7 @@ test_dataset_namecheck(const MunitParameter params[], void *data)
 	/* A bookmark delimiter does not belong in a dataset name. */
 	check_invalid(dataset_namecheck, "tank/fs#bm", NAME_ERR_INVALCHAR);
 
-	check_invalid(dataset_namecheck, long_char(), NAME_ERR_TOOLONG);
+	check_longname_invalid(dataset_namecheck);
 
 	return (MUNIT_OK);
 }
@@ -143,9 +139,9 @@ test_snapshot_namecheck(const MunitParameter params[], void *data)
 	(void) params, (void) data;
 
 	/* A random "filesystem@snapshot" pair is valid. */
-	char fs[16], snap[16], path[64];
-	(void) snprintf(path, sizeof (path), "%s@%s",
-	    unit_rand_str(fs, sizeof (fs)), unit_rand_str(snap, sizeof (snap)));
+	char path[64];
+	unit_rand_str(path, sizeof (path));
+	path[40] = '@';
 	check_valid(snapshot_namecheck, path);
 
 	/* Without an '@' it is not a snapshot. */
@@ -169,9 +165,9 @@ test_bookmark_namecheck(const MunitParameter params[], void *data)
 	(void) params, (void) data;
 
 	/* A random "filesystem#bookmark" pair is valid. */
-	char fs[16], mark[16], path[64];
-	(void) snprintf(path, sizeof (path), "%s#%s",
-	    unit_rand_str(fs, sizeof (fs)), unit_rand_str(mark, sizeof (mark)));
+	char path[64];
+	unit_rand_str(path, sizeof (path));
+	path[40] = '#';
 	check_valid(bookmark_namecheck, path);
 
 	/* Without a '#' it is not a bookmark. */
@@ -197,8 +193,7 @@ test_component_namecheck(const MunitParameter params[], void *data)
 	/* A single component cannot contain a path separator. */
 	check_invalid(zfs_component_namecheck, "a/b", NAME_ERR_INVALCHAR);
 
-	check_invalid(zfs_component_namecheck, long_char(),
-	    NAME_ERR_TOOLONG);
+	check_longname_invalid(zfs_component_namecheck);
 
 	return (MUNIT_OK);
 }
@@ -222,7 +217,7 @@ test_permset_namecheck(const MunitParameter params[], void *data)
 	check_invalid(permset_namecheck, "@bad/name", NAME_ERR_INVALCHAR);
 
 	/* The length upper limit is checked ahead of everything else. */
-	check_invalid(permset_namecheck, long_char(), NAME_ERR_TOOLONG);
+	check_longname_invalid(permset_namecheck);
 
 	return (MUNIT_OK);
 }
@@ -236,9 +231,9 @@ test_mountpoint_namecheck(const MunitParameter params[], void *data)
 	namecheck_err_t why = (namecheck_err_t)-1;
 
 	/* An absolute path with a random component is accepted. */
-	char comp[16], path[64];
-	(void) snprintf(path, sizeof (path), "/%s",
-	    unit_rand_str(comp, sizeof (comp)));
+	char path[64];
+	unit_rand_str(path, sizeof (path));
+	path[0] = '/';
 	unit_ok(mountpoint_namecheck(path, &why));
 
 	/* The root mountpoint is valid. */
@@ -280,14 +275,12 @@ test_dataset_depth(const MunitParameter params[], void *data)
 
 	/*
 	 * dataset_nestcheck() passes while the depth is under the limit and
-	 * fails once it reaches it.  We drop the limit to a small value so we
-	 * can test it and then restore it.
+	 * fails once it reaches it.  zfs_max_dataset_nesting is a tunable that
+	 * can be adjusted to the desired nesting.
 	 */
-	int limit = zfs_max_dataset_nesting;
 	zfs_max_dataset_nesting = 2;
 	unit_ok(dataset_nestcheck("a/b"));		/* depth 1, under 2 */
 	unit_err(dataset_nestcheck("a/b/c"), -1);	/* depth 2, at 2   */
-	zfs_max_dataset_nesting = limit;
 
 	return (MUNIT_OK);
 }


### PR DESCRIPTION
### Motivation and Context
`tests/unit/` currently has only `test_zap.c`. This adds a second suite, `test_namecheck`, that explicitly tests the name-validation routines in `zfs_namecheck.c`.

### Description
Adds a `test_namecheck` suite calling namecheck functions:
- Covers `pool`, `dataset`, `snapshot`, `bookmark`, `zfs_component`, `permset`, `mountpoint`, `get_dataset_depth`, `dataset_nestcheck` (`entity_namecheck` via its wrappers).
- Each routine tested two ways: random valid names from `unit_rand_str()`, and explicit invalid names tested against their error codes.

### How Has This Been Tested?
`make unit T=namecheck`:

```
> make unit T=namecheck
  UNITTEST tests/unit/test_namecheck
Running test suite with seed 0x5842ef3e...
namecheck.pool                       [ OK    ] [ 0.00000954 / 0.00000873 CPU ]
namecheck.dataset                    [ OK    ] [ 0.00001064 / 0.00000984 CPU ]
namecheck.snapshot                   [ OK    ] [ 0.00000589 / 0.00000590 CPU ]
namecheck.bookmark                   [ OK    ] [ 0.00000654 / 0.00000605 CPU ]
namecheck.component                  [ OK    ] [ 0.00000508 / 0.00000508 CPU ]
namecheck.permset                    [ OK    ] [ 0.00000608 / 0.00000561 CPU ]
namecheck.mountpoint                 [ OK    ] [ 0.00000337 / 0.00000329 CPU ]
namecheck.depth                      [ OK    ] [ 0.00000204 / 0.00000159 CPU ]
8 of 8 (100%) tests successful, 0 (0%) test skipped.
```

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the contributing document.
- [x] I have added tests to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain Signed-off-by.
