### PR TITLE
freebsd: set mnt_time on the rootfs at mountroot time

### DIFF
--- a/include/zfs_crrd.h
+++ b/include/zfs_crrd.h
@@ -71,5 +71,6 @@ void rrd_add(rrd_t *rrd, hrtime_t time, uint64_t txg);
 
 void dbrrd_add(dbrrd_t *db, hrtime_t time, uint64_t txg);
 uint64_t dbrrd_query(dbrrd_t *r, hrtime_t tv, dbrrd_rounding_t rouding);
+hrtime_t dbrrd_latest_time(dbrrd_t *r);
 
 #endif

--- a/include/zfs_crrd.h
+++ b/include/zfs_crrd.h
@@ -60,12 +60,12 @@ typedef struct {
 	rrd_t		dbr_months;
 } dbrrd_t;
 
-size_t rrd_len(rrd_t *rrd);
+size_t rrd_len(const rrd_t *rrd);
 
-const rrd_data_t *rrd_entry(rrd_t *r, size_t i);
+const rrd_data_t *rrd_entry(const rrd_t *r, size_t i);
 rrd_data_t *rrd_tail_entry(rrd_t *rrd);
 uint64_t rrd_tail(rrd_t *rrd);
-uint64_t rrd_get(rrd_t *rrd, size_t i);
+uint64_t rrd_get(const rrd_t *rrd, size_t i);
 
 void rrd_add(rrd_t *rrd, hrtime_t time, uint64_t txg);
 

--- a/module/os/freebsd/zfs/zfs_vfsops.c
+++ b/module/os/freebsd/zfs/zfs_vfsops.c
@@ -51,7 +51,7 @@
 #include <sys/dsl_prop.h>
 #include <sys/dsl_dataset.h>
 #include <sys/dsl_deleg.h>
-#include <sys/spa.h>
+#include <sys/spa_impl.h>
 #include <sys/zap.h>
 #include <sys/sa.h>
 #include <sys/sa_impl.h>
@@ -69,6 +69,7 @@
 #include <sys/zfs_quota.h>
 
 #include "zfs_comutil.h"
+#include "zfs_crrd.h"
 
 #ifndef	MNTK_VMSETSIZE_BUG
 #define	MNTK_VMSETSIZE_BUG	0
@@ -1323,7 +1324,12 @@ out:
 		dmu_objset_disown(zfsvfs->z_os, B_TRUE, zfsvfs);
 		zfsvfs_free(zfsvfs);
 	} else {
+		spa_t *spa = zfsvfs->z_os->os_spa;
+
 		atomic_inc_32(&zfs_active_fs_count);
+
+		vfsp->mnt_time = dbrrd_latest_time(&spa->spa_txg_log_time);
+		vfsp->mnt_time = MAX(vfsp->mnt_time, spa->spa_load_txg_ts);
 	}
 
 	return (error);

--- a/module/zfs/zfs_crrd.c
+++ b/module/zfs/zfs_crrd.c
@@ -226,3 +226,19 @@ dbrrd_query(dbrrd_t *r, hrtime_t tv, dbrrd_rounding_t rounding)
 
 	return (data == NULL ? 0 : data->rrdd_txg);
 }
+
+hrtime_t
+dbrrd_latest_time(dbrrd_t *r)
+{
+	const rrd_data_t *head;
+	const rrd_t *curdb;
+	size_t dblen;
+
+	curdb = &r->dbr_minutes;
+	dblen = rrd_len(curdb);
+	if (dblen == 0)
+		return (0);
+
+	head = rrd_entry(curdb, dblen - 1);
+	return (head->rrdd_time);
+}

--- a/module/zfs/zfs_crrd.c
+++ b/module/zfs/zfs_crrd.c
@@ -99,14 +99,14 @@ rrd_tail(rrd_t *rrd)
  * rrd_get works from 0..rrd_len()-1.
  */
 size_t
-rrd_len(rrd_t *rrd)
+rrd_len(const rrd_t *rrd)
 {
 
 	return (rrd->rrd_length);
 }
 
 const rrd_data_t *
-rrd_entry(rrd_t *rrd, size_t i)
+rrd_entry(const rrd_t *rrd, size_t i)
 {
 	size_t n;
 
@@ -119,7 +119,7 @@ rrd_entry(rrd_t *rrd, size_t i)
 }
 
 uint64_t
-rrd_get(rrd_t *rrd, size_t i)
+rrd_get(const rrd_t *rrd, size_t i)
 {
 	const rrd_data_t *data = rrd_entry(rrd, i);
 


### PR DESCRIPTION
FreeBSD's vfs_mountroot() will collect `mnt_time` from every filesystem that we mounted and use the highest timestamp as a source for the system time if we didn't get anything from an attached RTC.

AFAICT, there's not really a way to set a useful time on *every* ZFS mount, but we can at least set it on the root mount from the timestamp in the uberblock.  spa_uberblock has already been clobbered with a very low epoch value by the time we can observe it, so we use the recorded spa_load_txg_ts.  This doesn't have to be super accurate, we mostly want it to be somewhere in the ballpark of the last timestamp you might oberve from a file on the filesystem's mtime.

Relevant: FreeBSD PR254058[0] reporting the problem downstream

[0] https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=254058

### How Has This Been Tested?
Booted FreeBSD/ZFS in a VM and observed that `spa_load_txg_ts` looked sane.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
