### PR TITLE
release range lock after freed in dmu.

### DIFF
--- a/module/os/linux/zfs/zfs_znode_os.c
+++ b/module/os/linux/zfs/zfs_znode_os.c
@@ -1664,9 +1664,13 @@ zfs_free_range(znode_t *zp, uint64_t off, uint64_t len)
 	error = dmu_free_long_range(zfsvfs->z_os, zp->z_id, off, len);
 
 	/*
-	 * Zero partial page cache entries.  This must be done under a
-	 * range lock in order to keep the ARC and page cache in sync.
+	 * Once freed in dmu, release the range lock, otherwise,
+	 * there may be dead lock if concurrent
+	 * unlink/fsync/ftruncate/msync happens.
 	 */
+	zfs_rangelock_exit(lr);
+	lr = NULL;
+
 	if (zn_has_cached_data(zp, off, off + len - 1)) {
 		loff_t first_page, last_page, page_len;
 		loff_t first_page_offset, last_page_offset;
@@ -1704,7 +1708,6 @@ zfs_free_range(znode_t *zp, uint64_t off, uint64_t len)
 				    page_len);
 		}
 	}
-	zfs_rangelock_exit(lr);
 
 	return (error);
 }


### PR DESCRIPTION
### Motivation and Context
While working on issue #18454 , a test c program is written to reproduce the issue, however, failed. But a dead lock problem is found. And this is the fix. This deadlock is very similar to the one reported in #18454 , relates to PG_writeback, and triggered by unlink/fsync/ftruncate, and my testing env is aligned with it. It will be good if the issuer can verify this PR.

### Description
After free a range in dmu, we should immediately release the range lock. In the original code, the comments stress that following:
"Zero partial page cache entries.  This must be done under a range lock in order to keep the ARC and page cache in sync."

The test progam indeed shows deadlock here. The program and deadlock trace will be appended in this PR. The root cause is that we have double pass in fsync/msync, the second pass try to acquire range lock while still holds PG_writeback, then it is blocked by range lock in another thread. The thread has range lock is block by PG_writeback in folio_wait_writeback.

We may need more tests here to ensure ARC and page cache has no problem.

### How Has This Been Tested?
run the test program, and watch dmesg.

ubuntu 26.04 amd64/arm64 ext4: fine
debian 13.4  amd64/arm64 ext4: fine

## amd64:
ubuntu 26.04 7.0.0-22-generic + 2.3.7 + writeback_iter: deadlock 
--- this configuration is to verify if writeback_iter is the root cause, refer to PR #18625

ubuntu 26.04 7.0.0-22-generic + 2.3.7: deadlock
ubuntu 26.04 7.0.0-22-generic + 2.4.99-1: deadlock
ubuntu 26.04 7.0.0-22-generic + 2.4.99-1 + this PR: fixed

6.12.74+deb13-amd64 + zfs-2.3.2-1 : deadlock
6.12.74+deb13-amd64 + zfs-2.3.2-1 + this PR: fixed

## arm64:
6.12.74+deb13-arm64 + zfs-2.3.2-1: hang
6.12.74+deb13-arm64 + zfs-2.3.2-1 + this PR: fixed
ubuntu 26.04 7.0.0-22-generic + 2.4.99-1: deadlock
ubuntu 26.04 7.0.0-22-generic + 2.4.99-1 + this PR: fixed

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).