### PR TITLE
unit/zap: key case normalization tests

### DIFF
--- a/include/sys/zap.h
+++ b/include/sys/zap.h
@@ -349,6 +349,8 @@ int zap_remove(objset_t *os, uint64_t zapobj, const char *name, dmu_tx_t *tx);
 int zap_remove_by_dnode(dnode_t *dn, const char *name, dmu_tx_t *tx);
 int zap_remove_norm(objset_t *os, uint64_t zapobj, const char *name,
     matchtype_t mt, dmu_tx_t *tx);
+int zap_remove_norm_by_dnode(dnode_t *dn, const char *name,
+    matchtype_t mt, dmu_tx_t *tx);
 
 /* Remove by uint64_t[] key. */
 int zap_remove_uint64(objset_t *os, uint64_t zapobj, const uint64_t *key,

--- a/module/zfs/zap.c
+++ b/module/zfs/zap.c
@@ -744,7 +744,7 @@ zap_length_uint64(objset_t *os, uint64_t zapobj, const uint64_t *key,
 
 /* zap_remove */
 
-static int
+int
 zap_remove_norm_by_dnode(dnode_t *dn, const char *name, matchtype_t mt,
     dmu_tx_t *tx)
 {

--- a/tests/unit/test_zap.c
+++ b/tests/unit/test_zap.c
@@ -53,7 +53,7 @@ mock_crc64_init(void)
 
 /* Create a microzap backed by a mock dnode. */
 static dnode_t *
-mock_zap_create_microzap(void) {
+mock_zap_create_norm_microzap(int normflags) {
 	/*
 	 * We use DMU_OTN_ZAP_DATA so that DMU_OT_BYTESWAP() returns
 	 * DMU_BSWAP_ZAP without consulting dmu_ot[], which is not currently
@@ -62,20 +62,20 @@ mock_zap_create_microzap(void) {
 	mock_dnode_t *mdn = mock_dnode_create(512, DMU_OTN_ZAP_DATA);
 	dnode_t *dn = (dnode_t *)mdn;
 	dmu_tx_t *tx = (dmu_tx_t *)mock_tx_create();
-	mzap_create_impl(dn, 0, 0, tx);
+	mzap_create_impl(dn, normflags, 0, tx);
 	mock_tx_destroy((mock_dmu_tx_t *)tx);
 	return (dn);
 }
 
 /* Create a fatzap backed by a mock dnode. */
 static dnode_t *
-mock_zap_create_fatzap(void)
+mock_zap_create_norm_fatzap(int normflags)
 {
 	/*
 	 * We can only create microzaps directly. They only take u64s as a
 	 * value, so we add a u16 to trigger an upgrade to fatzap.
 	 */
-	dnode_t *dn = mock_zap_create_microzap();
+	dnode_t *dn = mock_zap_create_norm_microzap(normflags);
 	dmu_tx_t *tx = (dmu_tx_t *)mock_tx_create();
 	uint16_t upgrade = 0;
 	zap_add_by_dnode(dn, "_upgrade", sizeof (uint16_t), 1, &upgrade, tx);
@@ -83,6 +83,10 @@ mock_zap_create_fatzap(void)
 	mock_tx_destroy((mock_dmu_tx_t *)tx);
 	return (dn);
 }
+
+/* Shortcuts for ZAPs with no normalization flags set. */
+#define	mock_zap_create_microzap()	mock_zap_create_norm_microzap(0)
+#define	mock_zap_create_fatzap()	mock_zap_create_norm_fatzap(0)
 
 static bool
 mock_zap_is_microzap(dnode_t *dn)
@@ -110,18 +114,22 @@ mock_zap_destroy(dnode_t *dn)
 
 /* Create a ZAP of the type named in the given test params. */
 static dnode_t *
-mock_zap_create_params(const MunitParameter params[], const char *key) {
+mock_zap_create_norm_params(const MunitParameter params[], const char *key,
+    int normflags) {
 	const char *type = munit_parameters_get(params, key);
 	if (type == NULL)
 		munit_error("mock_zap_create_params: missing type param");
 	else if (strcmp(type, "micro") == 0)
-		return (mock_zap_create_microzap());
+		return (mock_zap_create_norm_microzap(normflags));
 	else if (strcmp(type, "fat") == 0)
-		return (mock_zap_create_fatzap());
+		return (mock_zap_create_norm_fatzap(normflags));
 	else
 		munit_errorf("mock_zap_create_params: invalid type '%s'", type);
 	__builtin_unreachable();
 }
+
+/* Shortcuts for ZAPs with no normalization flags set. */
+#define	mock_zap_create_params(p, k)	mock_zap_create_norm_params(p, k, 0)
 
 /*
  * Confirm the stored ZAP is of the type named in the given test params. This
@@ -1093,6 +1101,369 @@ test_zap_value_search_mask(const MunitParameter params[], void *data)
 
 /* ========== */
 
+/* Key case normalization. */
+
+/*
+ * A TOUPPER ZAP hashes and matches keys by their uppercase form, ie a
+ * case-insensitive match.
+ */
+static MunitResult
+test_norm_toupper(const MunitParameter params[], void *data)
+{
+	(void) data;
+
+	dnode_t *dn =
+	    mock_zap_create_norm_params(params, "type", U8_TEXTPREP_TOUPPER);
+	dmu_tx_t *tx = (dmu_tx_t *)mock_tx_create();
+
+	uint64_t val = 42;
+	unit_ok(zap_add_by_dnode(dn, "Hello",
+	    sizeof (uint64_t), 1, &val, tx));
+
+	/* MT_NORMALIZE finds any casing. */
+	uint64_t result = 0;
+	unit_ok(zap_lookup_norm_by_dnode(dn, "hello",
+	    sizeof (uint64_t), 1, &result, MT_NORMALIZE, NULL, 0, NULL));
+	unit_eq(result, 42);
+
+	result = 0;
+	unit_ok(zap_lookup_norm_by_dnode(dn, "HELLO",
+	    sizeof (uint64_t), 1, &result, MT_NORMALIZE, NULL, 0, NULL));
+	unit_eq(result, 42);
+
+	result = 0;
+	unit_ok(zap_lookup_norm_by_dnode(dn, "HeLlO",
+	    sizeof (uint64_t), 1, &result, MT_NORMALIZE, NULL, 0, NULL));
+	unit_eq(result, 42);
+
+	/* Exact lookup finds the stored form. */
+	result = 0;
+	unit_ok(zap_lookup_by_dnode(dn, "Hello",
+	    sizeof (uint64_t), 1, &result));
+	unit_eq(result, 42);
+
+	/* Exact lookup misses other casings. */
+	unit_err(zap_lookup_by_dnode(dn, "hello",
+	    sizeof (uint64_t), 1, &result), ENOENT);
+	unit_err(zap_lookup_by_dnode(dn, "HeLlO",
+	    sizeof (uint64_t), 1, &result), ENOENT);
+
+	mock_tx_destroy((mock_dmu_tx_t *)tx);
+	unit_true(mock_zap_is_params(dn, params, "type"));
+	mock_zap_destroy(dn);
+
+	return (MUNIT_OK);
+}
+
+/*
+ * NFC: canonical decomposition + canonical recomposition.
+ *
+ * NFC-normalized keys are stored in their original encoding but match but
+ * match by canonical composed form.
+ */
+static MunitResult
+test_norm_nfc(const MunitParameter params[], void *data)
+{
+	(void) data;
+
+	/*
+	 * "café" in NFC: "caf\xc3\xa9"  (U+00E9, e-acute precomposed)
+	 * "café" in NFD: "cafe\xcc\x81" (U+0065 + U+0301, e + combining acute)
+	 */
+	static const char nfc_key[] = "caf\xc3\xa9";
+	static const char nfd_key[] = "cafe\xcc\x81";
+
+	dnode_t *dn =
+	    mock_zap_create_norm_params(params, "type", U8_TEXTPREP_NFC);
+	dmu_tx_t *tx = (dmu_tx_t *)mock_tx_create();
+
+	/* Insert the NFD form. */
+	uint64_t val = 42;
+	unit_ok(zap_add_by_dnode(dn, nfd_key, sizeof (uint64_t), 1, &val, tx));
+
+	/* Normalized lookup with NFC form finds it. */
+	uint64_t result = 0;
+	unit_ok(zap_lookup_norm_by_dnode(dn, nfc_key,
+	    sizeof (uint64_t), 1, &result, MT_NORMALIZE, NULL, 0, NULL));
+	unit_eq(result, 42);
+
+	/* Normalized lookup with NFD form also finds it. */
+	result = 0;
+	unit_ok(zap_lookup_norm_by_dnode(dn, nfd_key,
+	    sizeof (uint64_t), 1, &result, MT_NORMALIZE, NULL, 0, NULL));
+	unit_eq(result, 42);
+
+	mock_tx_destroy((mock_dmu_tx_t *)tx);
+	unit_true(mock_zap_is_params(dn, params, "type"));
+	mock_zap_destroy(dn);
+
+	return (MUNIT_OK);
+}
+
+/*
+ * NFD: canonical decomposition without recomposition.
+ *
+ * NFD and NFC define the same canonical equivalence class, so this test uses
+ * the same pair as test_norm_nfc (NFC) and would pass under NFC too. Together
+ * the two tests verify the flags are independently wired.
+ */
+static MunitResult
+test_norm_nfd(const MunitParameter params[], void *data)
+{
+	(void) data;
+
+	/*
+	 * "café" in NFC: "caf\xc3\xa9"  (U+00E9, e-acute precomposed)
+	 * "café" in NFD: "cafe\xcc\x81" (U+0065 + U+0301, e + combining acute)
+	 */
+	static const char nfc_key[] = "caf\xc3\xa9";
+	static const char nfd_key[] = "cafe\xcc\x81";
+
+	dnode_t *dn =
+	    mock_zap_create_norm_params(params, "type", U8_TEXTPREP_NFD);
+	dmu_tx_t *tx = (dmu_tx_t *)mock_tx_create();
+
+	/* Insert the NFC form. */
+	uint64_t val = 42;
+	unit_ok(zap_add_by_dnode(dn, nfc_key, sizeof (uint64_t), 1, &val, tx));
+
+	/* Normalized lookup with NFC form finds it. */
+	uint64_t result = 0;
+	unit_ok(zap_lookup_norm_by_dnode(dn, nfc_key,
+	    sizeof (uint64_t), 1, &result, MT_NORMALIZE, NULL, 0, NULL));
+	unit_eq(result, 42);
+
+	/* Normalized lookup with NFD form also finds it. */
+	result = 0;
+	unit_ok(zap_lookup_norm_by_dnode(dn, nfd_key,
+	    sizeof (uint64_t), 1, &result, MT_NORMALIZE, NULL, 0, NULL));
+	unit_eq(result, 42);
+
+	mock_tx_destroy((mock_dmu_tx_t *)tx);
+	unit_true(mock_zap_is_params(dn, params, "type"));
+	mock_zap_destroy(dn);
+
+	return (MUNIT_OK);
+}
+
+/*
+ * NFKC: compatibility decomposition + canonical recomposition.
+ *
+ * Compatibility characters (e.g. the fi ligature U+FB01 ~~ "fi") are only
+ * recognised as equivalent under the K forms (NFKC/NFKD). They are NOT
+ * folded by NFC, NFD, or TOUPPER — so this pair is wrong under all of those.
+ */
+static MunitResult
+test_norm_nfkc(const MunitParameter params[], void *data)
+{
+	(void) data;
+
+	/*
+	 * "ﬁle": fi ligature (U+FB01 = \xef\xac\x81) + "le".
+	 * Normalizes to plain "file".
+	 */
+	static const char ligature_key[] = "\xef\xac\x81le";
+	static const char plain_key[] = "file";
+
+	dnode_t *dn =
+	    mock_zap_create_norm_params(params, "type", U8_TEXTPREP_NFKC);
+	dmu_tx_t *tx = (dmu_tx_t *)mock_tx_create();
+
+	/* Insert the ligature. */
+	uint64_t val = 42;
+	unit_ok(zap_add_by_dnode(dn, ligature_key,
+	    sizeof (uint64_t), 1, &val, tx));
+
+	/* NFKC lookup with the plain form finds it. */
+	uint64_t result = 0;
+	unit_ok(zap_lookup_norm_by_dnode(dn, plain_key,
+	    sizeof (uint64_t), 1, &result, MT_NORMALIZE, NULL, 0, NULL));
+	unit_eq(result, 42);
+
+	/* NFKC lookup with the ligature also finds it */
+	result = 0;
+	unit_ok(zap_lookup_norm_by_dnode(dn, ligature_key,
+	    sizeof (uint64_t), 1, &result, MT_NORMALIZE, NULL, 0, NULL));
+	unit_eq(result, 42);
+
+	mock_tx_destroy((mock_dmu_tx_t *)tx);
+	unit_true(mock_zap_is_params(dn, params, "type"));
+	mock_zap_destroy(dn);
+
+	return (MUNIT_OK);
+}
+
+/*
+ * NFKD: compatibility decomposition without recomposition.
+ *
+ * NFKC and NFKD define the same compatibility equivalence class, so this test
+ * uses the same pair as test_norm_nfkc. Together they verify the flags are
+ * independently wired.
+ */
+static MunitResult
+test_norm_nfkd(const MunitParameter params[], void *data)
+{
+	(void) data;
+
+	/*
+	 * "ﬁle": fi ligature (U+FB01 = \xef\xac\x81) + "le".
+	 * Normalizes to plain "file".
+	 */
+	static const char ligature_key[] = "\xef\xac\x81le";
+	static const char plain_key[] = "file";
+
+	dnode_t *dn =
+	    mock_zap_create_norm_params(params, "type", U8_TEXTPREP_NFKC);
+	dmu_tx_t *tx = (dmu_tx_t *)mock_tx_create();
+
+	/* Insert the plain form. */
+	uint64_t val = 42;
+	unit_ok(zap_add_by_dnode(dn, plain_key,
+	    sizeof (uint64_t), 1, &val, tx));
+
+	/* NFKD lookup with the ligature finds it. */
+	uint64_t result = 0;
+	unit_ok(zap_lookup_norm_by_dnode(dn, ligature_key,
+	    sizeof (uint64_t), 1, &result, MT_NORMALIZE, NULL, 0, NULL));
+	unit_eq(result, 42);
+
+	/* NFKD lookup with plain form also finds it. */
+	result = 0;
+	unit_ok(zap_lookup_norm_by_dnode(dn, plain_key,
+	    sizeof (uint64_t), 1, &result, MT_NORMALIZE, NULL, 0, NULL));
+	unit_eq(result, 42);
+
+	mock_tx_destroy((mock_dmu_tx_t *)tx);
+	unit_true(mock_zap_is_params(dn, params, "type"));
+	mock_zap_destroy(dn);
+
+	return (MUNIT_OK);
+}
+
+/*
+ * A ZAP does not enforce normalization uniqueness on insert - two keys that
+ * normalize to the same form can coexist. A normalized lookup detects the
+ * conflict and flags it for the caller on request.
+ */
+static MunitResult
+test_norm_conflict(const MunitParameter params[], void *data)
+{
+	(void) data;
+
+	dnode_t *dn =
+	    mock_zap_create_norm_params(params, "type", U8_TEXTPREP_TOUPPER);
+	dmu_tx_t *tx = (dmu_tx_t *)mock_tx_create();
+
+	/* Insert two distinct keys that normalize to the same form. */
+	uint64_t v1 = 1, v2 = 2;
+	unit_ok(zap_add_by_dnode(dn, "Hello", sizeof (uint64_t), 1, &v1, tx));
+	unit_ok(zap_add_by_dnode(dn, "hello", sizeof (uint64_t), 1, &v2, tx));
+
+	/* Confirm both stored. */
+	uint64_t count = 0;
+	unit_ok(zap_count_by_dnode(dn, &count));
+	unit_eq(count, 2);
+
+	/*
+	 * Three different normalized lookups all return the first match for
+	 * the normalized form, but signal that a normalization conflict
+	 * occurred.
+	 */
+	uint64_t result = 0;
+	boolean_t conflict = B_FALSE;
+	unit_ok(zap_lookup_norm_by_dnode(dn, "Hello",
+	    sizeof (uint64_t), 1, &result, MT_NORMALIZE, NULL, 0, &conflict));
+	unit_true(conflict);
+	unit_eq(result, 1);
+
+	result = 0;
+	conflict = B_FALSE;
+	unit_ok(zap_lookup_norm_by_dnode(dn, "hello",
+	    sizeof (uint64_t), 1, &result, MT_NORMALIZE, NULL, 0, &conflict));
+	unit_true(conflict);
+	unit_eq(result, 1);
+
+	result = 0;
+	conflict = B_FALSE;
+	unit_ok(zap_lookup_norm_by_dnode(dn, "HELLO",
+	    sizeof (uint64_t), 1, &result, MT_NORMALIZE, NULL, 0, &conflict));
+	unit_true(conflict);
+	unit_eq(result, 1);
+
+	mock_tx_destroy((mock_dmu_tx_t *)tx);
+	unit_true(mock_zap_is_params(dn, params, "type"));
+	mock_zap_destroy(dn);
+
+	return (MUNIT_OK);
+}
+
+/* A normalized lookup can return the original name form on request. */
+static MunitResult
+test_norm_realname(const MunitParameter params[], void *data)
+{
+	(void) data;
+
+	dnode_t *dn =
+	    mock_zap_create_norm_params(params, "type", U8_TEXTPREP_TOUPPER);
+	dmu_tx_t *tx = (dmu_tx_t *)mock_tx_create();
+
+	uint64_t v = 1;
+	unit_ok(zap_add_by_dnode(dn, "HeLlO", sizeof (uint64_t), 1, &v, tx));
+
+	char realname[ZAP_MAXNAMELEN];
+	uint64_t result = 0;
+	unit_ok(zap_lookup_norm_by_dnode(dn, "hello",
+	    sizeof (uint64_t), 1, &result, MT_NORMALIZE,
+	    realname, sizeof (realname), NULL));
+	unit_eq(result, 1);
+	unit_str_eq(realname, "HeLlO");
+
+	mock_tx_destroy((mock_dmu_tx_t *)tx);
+	unit_true(mock_zap_is_params(dn, params, "type"));
+	mock_zap_destroy(dn);
+
+	return (MUNIT_OK);
+}
+
+/* zap_remove_norm: remove by normalized name. */
+static MunitResult
+test_norm_remove(const MunitParameter params[], void *data)
+{
+	(void) data;
+
+	dnode_t *dn =
+	    mock_zap_create_norm_params(params, "type", U8_TEXTPREP_TOUPPER);
+	dmu_tx_t *tx = (dmu_tx_t *)mock_tx_create();
+
+	/* Add two items with mixed-case keys. */
+	uint64_t v = 1;
+	unit_ok(zap_add_by_dnode(dn, "Hello", sizeof (uint64_t), 1, &v, tx));
+	unit_ok(zap_add_by_dnode(dn, "World", sizeof (uint64_t), 1, &v, tx));
+
+	/*
+	 * Removing with MT_NORMALIZE normalizes both the requested and stored
+	 * keys before comparison.
+	 */
+	unit_ok(zap_remove_norm_by_dnode(dn, "HELLO", MT_NORMALIZE, tx));
+	unit_err(zap_lookup_by_dnode(dn, "Hello",
+	    sizeof (uint64_t), 1, &v), ENOENT);
+
+	/* Must use exact case to remove without MT_NORMALIZE. */
+	unit_eq(zap_remove_norm_by_dnode(dn, "world", 0, tx), ENOENT);
+	unit_ok(zap_lookup_by_dnode(dn, "World", sizeof (uint64_t), 1, &v));
+	unit_ok(zap_remove_norm_by_dnode(dn, "World", 0, tx));
+	unit_eq(zap_lookup_by_dnode(dn, "World",
+	    sizeof (uint64_t), 1, &v), ENOENT);
+
+	mock_tx_destroy((mock_dmu_tx_t *)tx);
+	unit_true(mock_zap_is_params(dn, params, "type"));
+	mock_zap_destroy(dn);
+
+	return (MUNIT_OK);
+}
+
+/* ========== */
+
 /* Test suite definition and boilerplate. */
 
 #define	UNIT_PARAM_ZAP_TYPES(p)	\
@@ -1143,6 +1514,16 @@ static const MunitTest zap_tests[] = {
 	    "zap_value_search",		test_zap_value_search),
 	UNIT_TEST_ZAP_TYPES(
 	    "zap_value_search_mask",	test_zap_value_search_mask),
+
+	UNIT_TEST("norm_toupper",	test_norm_toupper, zap_type_params),
+	UNIT_TEST("norm_nfc",		test_norm_nfc, zap_type_params),
+	UNIT_TEST("norm_nfd",		test_norm_nfd, zap_type_params),
+	UNIT_TEST("norm_nfkc",		test_norm_nfkc, zap_type_params),
+	UNIT_TEST("norm_nfkd",		test_norm_nfkd, zap_type_params),
+
+	UNIT_TEST("norm_conflict",	test_norm_conflict, zap_type_params),
+	UNIT_TEST("norm_realname",	test_norm_realname, zap_type_params),
+	UNIT_TEST("norm_remove",	test_norm_remove, zap_type_params),
 
 	{ 0 },
 };


### PR DESCRIPTION
_[Sponsors: TrueNAS]_

### Motivation and Context

The ZAP tests will continue until interest and confidence in ZAPs improve.

### Description

- Extend the mock ZAP creation functions to allow normalization flags to be provided.
- Tests to ensure that `MT_NORMALIZE` lookups can correctly find items for inputs that, once normalized, match stored keys in the the normalized form (one each for `U8_TEXTPREP_TOUPPER`, `_NFC`, _NFD`, `_NKFC`, `_NFKD`)
- Tests to verify that the conflict flag and "real name" returns on `zap_lookup_norm_by_dnode()` work
- Test to verify `zap_remove_norm_by_dnode()` does the right thing.

Note, not testing `MT_MATCH_CASE` (ie "mixed-case" lookups) here. @chrislongros has followup work in progress (#18638) that will tackle that.

### How Has This Been Tested?

It's only tests. Ran them!

```
Coverage: test_zap       | By line         | By branch       | By function
                         | Rate% Total Hit | Rate% Total Hit | Rate% Total Hit
module/zfs/u8_textprep.c | 41.8%   802 335 | 33.5%   510 171 | 50.0%    12   6
module/zfs/zap.c         | 43.7%   581 254 | 41.6%   214  89 | 32.9%    79  26
module/zfs/zap_fat.c     | 47.4%   665 315 | 30.0%   446 134 | 62.2%    37  23
module/zfs/zap_impl.c    | 66.8%   232 155 | 47.3%   146  69 | 80.0%    25  20
module/zfs/zap_leaf.c    | 70.0%   466 326 | 54.6%   216 118 | 82.6%    23  19
module/zfs/zap_micro.c   | 73.9%   238 176 | 49.3%   142  70 | 92.9%    14  13
```

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
