### PR TITLE
keep txg_wait_synced outside of namespace lock

### DIFF
--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -876,19 +876,12 @@ extern boolean_t spa_namespace_held(void);
 extern void spa_namespace_wait(void);
 extern void spa_namespace_broadcast(void);
 
-/*
- * SPA configuration functions in spa_config.c
- */
-
-#define	SPA_CONFIG_UPDATE_POOL	0
-#define	SPA_CONFIG_UPDATE_VDEVS	1
-
 extern void spa_write_cachefile(spa_t *, boolean_t, boolean_t, boolean_t);
 extern int spa_all_configs(uint64_t *generation, nvlist_t **pools);
 extern void spa_config_set(spa_t *spa, nvlist_t *config);
 extern nvlist_t *spa_config_generate(spa_t *spa, vdev_t *vd, uint64_t txg,
     int getstats);
-extern void spa_config_update(spa_t *spa, int what);
+extern void spa_config_update(spa_t *spa);
 extern int spa_config_parse(spa_t *spa, vdev_t **vdp, nvlist_t *nv,
     vdev_t *parent, uint_t id, int atype);
 

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -7558,7 +7558,7 @@ spa_import(char *pool, nvlist_t *config, nvlist_t *props, uint64_t flags)
 		/*
 		 * Update the config cache to include the newly-imported pool.
 		 */
-		spa_config_update(spa, SPA_CONFIG_UPDATE_POOL);
+		spa_config_update(spa);
 	}
 
 	/*
@@ -8131,22 +8131,16 @@ spa_vdev_add(spa_t *spa, nvlist_t *nvroot, boolean_t check_ashift)
 	}
 
 	/*
-	 * We have to be careful when adding new vdevs to an existing pool.
-	 * If other threads start allocating from these vdevs before we
-	 * sync the config cache, and we lose power, then upon reboot we may
-	 * fail to open the pool because there are DVAs that the config cache
-	 * can't translate.  Therefore, we first add the vdevs without
-	 * initializing metaslabs; sync the config cache (via spa_vdev_exit());
-	 * and then let spa_config_update() initialize the new metaslabs.
-	 *
-	 * spa_load() checks for added-but-not-initialized vdevs, so that
-	 * if we lose power at any point in this sequence, the remaining
-	 * steps will be completed the next time we load the pool.
+	 * In spa_config_update, we will sync new vdevs, and write
+	 * to cache file. If sync fails, next sync may succeed,
+	 * if lose power, all will be fine, becuase txg commits
+	 * atomically. If lose power after txg commit, before
+	 * cache file update, the cache file is updated when importing.
 	 */
 	(void) spa_vdev_exit(spa, vd, txg, 0);
 
 	spa_namespace_enter(FTAG);
-	spa_config_update(spa, SPA_CONFIG_UPDATE_POOL);
+	spa_config_update(spa);
 	spa_event_notify(spa, NULL, NULL, ESC_ZFS_VDEV_ADD);
 	spa_namespace_exit(FTAG);
 
@@ -9830,7 +9824,7 @@ spa_async_thread(void *arg)
 		old_space += metaslab_class_get_space(
 		    spa_special_embedded_log_class(spa));
 
-		spa_config_update(spa, SPA_CONFIG_UPDATE_POOL);
+		spa_config_update(spa);
 
 		new_space = metaslab_class_get_space(spa_normal_class(spa));
 		new_space += metaslab_class_get_space(spa_special_class(spa));

--- a/module/zfs/spa_config.c
+++ b/module/zfs/spa_config.c
@@ -477,63 +477,80 @@ spa_config_generate(spa_t *spa, vdev_t *vd, uint64_t txg, int getstats)
  * cache if this is a booting rootpool).
  */
 void
-spa_config_update(spa_t *spa, int what)
+spa_config_update(spa_t *spa)
 {
 	vdev_t *rvd = spa->spa_root_vdev;
 	uint64_t txg;
 	int c;
+	boolean_t ns_locked = spa_namespace_held();
+	boolean_t need_sync = B_FALSE;
 
-	ASSERT(spa_namespace_held());
-
+	/*
+	 * Regenerate and sync the MOS config.
+	 */
 	spa_config_enter(spa, SCL_ALL, FTAG, RW_WRITER);
 	txg = spa_last_synced_txg(spa) + 1;
-	if (what == SPA_CONFIG_UPDATE_POOL) {
-		vdev_config_dirty(rvd);
-	} else {
-		/*
-		 * If we have top-level vdevs that were added but have
-		 * not yet been prepared for allocation, do that now.
-		 * (It's safe now because the config cache is up to date,
-		 * so it will be able to translate the new DVAs.)
-		 * See comments in spa_vdev_add() for full details.
-		 */
-		for (c = 0; c < rvd->vdev_children; c++) {
-			vdev_t *tvd = rvd->vdev_child[c];
+	vdev_config_dirty(rvd);
+	spa_config_exit(spa, SCL_ALL, FTAG);
 
-			/*
-			 * Explicitly skip vdevs that are indirect or
-			 * log vdevs that are being removed. The reason
-			 * is that both of those can have vdev_ms_array
-			 * set to 0 and we wouldn't want to change their
-			 * metaslab size nor call vdev_expand() on them.
-			 */
-			if (!vdev_is_concrete(tvd) ||
-			    (tvd->vdev_islog && tvd->vdev_removing))
-				continue;
+	if (ns_locked) {
+		spa_open_ref(spa, FTAG);
+		spa_namespace_exit(FTAG);
+	}
+	txg_wait_synced(spa->spa_dsl_pool, txg);
+	if (ns_locked) {
+		spa_namespace_enter(FTAG);
+		spa_close(spa, FTAG);
+	}
 
-			if (tvd->vdev_ms_array == 0)
-				vdev_metaslab_set_size(tvd);
-			vdev_expand(tvd, txg);
+	/*
+	 * Write the cache file to reflect the updated MOS config.
+	 * This must precede the vdev expansion below so that config
+	 * changes (e.g. property updates) are visible promptly.
+	 */
+	if (!spa->spa_is_root)
+		spa_write_cachefile(spa, B_FALSE, B_FALSE, B_FALSE);
+
+	/*
+	 * Prepare any new top-level vdevs for allocation in a separate
+	 * txg so that metaslab initialization does not interfere with
+	 * other operations in the same txg (e.g. DDT log flush during
+	 * pool import).
+	 */
+	spa_config_enter(spa, SCL_ALL, FTAG, RW_WRITER);
+	txg = spa_last_synced_txg(spa) + 1;
+	for (c = 0; c < rvd->vdev_children; c++) {
+		vdev_t *tvd = rvd->vdev_child[c];
+
+		if (!vdev_is_concrete(tvd) ||
+		    (tvd->vdev_islog && tvd->vdev_removing))
+			continue;
+
+		if (tvd->vdev_ms_array == 0) {
+			vdev_metaslab_set_size(tvd);
+			need_sync = B_TRUE;
+		} else if (tvd->vdev_ms_shift != 0 &&
+		    (tvd->vdev_asize >> tvd->vdev_ms_shift) >
+		    tvd->vdev_ms_count) {
+			need_sync = B_TRUE;
 		}
+		vdev_expand(tvd, txg);
 	}
 	spa_config_exit(spa, SCL_ALL, FTAG);
 
-	/*
-	 * Wait for the mosconfig to be regenerated and synced.
-	 */
-	txg_wait_synced(spa->spa_dsl_pool, txg);
-
-	/*
-	 * Update the global config cache to reflect the new mosconfig.
-	 */
-	if (!spa->spa_is_root) {
-		spa_write_cachefile(spa, B_FALSE,
-		    what != SPA_CONFIG_UPDATE_POOL,
-		    what != SPA_CONFIG_UPDATE_POOL);
+	if (need_sync) {
+		if (ns_locked) {
+			spa_open_ref(spa, FTAG);
+			spa_namespace_exit(FTAG);
+		}
+		txg_wait_synced(spa->spa_dsl_pool, txg);
+		if (ns_locked) {
+			spa_namespace_enter(FTAG);
+			spa_close(spa, FTAG);
+		}
+		if (!spa->spa_is_root)
+			spa_write_cachefile(spa, B_FALSE, B_TRUE, B_TRUE);
 	}
-
-	if (what == SPA_CONFIG_UPDATE_POOL)
-		spa_config_update(spa, SPA_CONFIG_UPDATE_VDEVS);
 }
 
 EXPORT_SYMBOL(spa_all_configs);

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -3386,6 +3386,20 @@ zfs_ioc_pool_set_props(zfs_cmd_t *zc)
 	error = spa_prop_set(spa, props);
 
 	nvlist_free(props);
+
+	/*
+	 * For properties stored in the pool config object (e.g.
+	 * compatibility, comment), the MOS copy was updated by the
+	 * sync task above.  Update the cache file synchronously
+	 * so that it reflects the change before we return to
+	 * userspace.
+	 */
+	if (error == 0) {
+		spa_namespace_enter(FTAG);
+		spa_write_cachefile(spa, B_FALSE, B_TRUE, B_TRUE);
+		spa_namespace_exit(FTAG);
+	}
+
 	spa_close(spa, FTAG);
 
 	return (error);


### PR DESCRIPTION
### Motivation and Context
We should always make lock as narrow as possible, and here is for #18648 . A lock of whole namespace is waiting for zio which is hang, that makes all other threads hang.

Another PR should be created for vdev failed: avoiding hang as much as possible.

### Description
keep txg_wait_synced outside of namespace lock.

### How Has This Been Tested?
Local zfs-test.sh, plus coming CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).