### PR TITLE
Fix race between device removal completion and pool export

### DIFF
--- a/module/zfs/vdev_removal.c
+++ b/module/zfs/vdev_removal.c
@@ -1432,14 +1432,17 @@ vdev_remove_complete(spa_t *spa)
 	vdev_remove_replace_with_indirect(vd, txg);
 
 	/*
-	 * We now release the locks, allowing spa_sync to run and finish the
+	 * Release the config lock and allow spa_sync to run and finish the
 	 * removal via vdev_remove_complete_sync in syncing context.
+	 *
+	 * Retain the namespace lock to prevent the pool from being exported
+	 * or destroyed before completion of the device removal.
 	 *
 	 * Note that we hold on to the vdev_t that has been replaced.  Since
 	 * it isn't part of the vdev tree any longer, it can't be concurrently
 	 * manipulated, even while we don't have the config lock.
 	 */
-	(void) spa_vdev_exit(spa, NULL, txg, 0);
+	(void) spa_vdev_config_exit(spa, NULL, txg, 0, FTAG);
 
 	/*
 	 * Top ZAP should have been transferred to the indirect vdev in
@@ -1452,7 +1455,8 @@ vdev_remove_complete(spa_t *spa)
 	 */
 	ASSERT0(vd->vdev_leaf_zap);
 
-	txg = spa_vdev_enter(spa);
+	/* Update the vdev labels and dirty the config. */
+	txg = spa_vdev_config_enter(spa);
 	(void) vdev_label_init(vd, 0, VDEV_LABEL_REMOVE);
 	/*
 	 * Request to update the config and the config cachefile.


### PR DESCRIPTION
### Motivation and Context

`vdev_remove_complete()` finalizes a device removal in two phases under the spa
lock framework. Between the two phases it calls `spa_vdev_exit()`, which drops
**both** the config locks (`SCL_ALL`) **and** `spa_namespace_lock`, and blocks
on a txg sync. By that point `vdev_remove_replace_with_indirect()` has already
set `svr->svr_thread = NULL`, and that is the only thing the export path
(`spa_export_common()` → `spa_async_suspend()` → `spa_vdev_remove_suspend()`)
waits on. So once the namespace lock is dropped, a concurrent export/destroy
can acquire it and set `spa->spa_export_thread`. When the removal thread
re-enters for its second phase via `spa_vdev_enter()`, it trips the assertion:

```
VERIFY0P(spa->spa_export_thread) failed
PANIC at spa_misc.c:spa_vdev_enter()
  spl_panic
  spa_vdev_enter
  vdev_remove_complete
  spa_vdev_remove_thread
```

The window only opens when a removal finishes on its own as the pool is being
destroyed or exported, so it surfaces flakily. The contributing pieces are all
pre-existing: the two `spa_vdev_enter()` calls and the early `svr_thread` clear
date back to the original device-removal work, and the `spa_export_thread`
assertion came in with parallel pool exports. Neither side accounted for the
gap between the two phases.

### Description

Hold `spa_namespace_lock` across the two phases instead of dropping and
re-taking it:

- The intermediate `spa_vdev_exit()` becomes `spa_vdev_config_exit()`, which
  drops only `SCL_ALL` and syncs the txg, but keeps `spa_namespace_lock` and
  `spa_vdev_top_lock` held.
- The second `spa_vdev_enter()` becomes `spa_vdev_config_enter()`, which
  re-takes `SCL_ALL` (the namespace lock is already held).
- The final `spa_vdev_exit()` releases everything and frees the removed vdev,
  as before.

Because `spa_namespace_lock` is never dropped between the phases, a concurrent
export blocks in `spa_namespace_enter()` and cannot set `spa_export_thread`
until removal finalization is done, so the second config-enter never observes
it. This mirrors the multi-phase locking pattern already used by the
attach/detach and split paths in `spa.c` (e.g. the raidz-attach path), which
likewise hold the namespace lock across a `spa_vdev_config_exit()` /
`spa_vdev_config_enter()` pair and a txg sync — so there is no new
lock-ordering hazard (the syncing context does not take the namespace lock).

### How Has This Been Tested?

Tested on a debug (`--enable-debug`) build on an Ubuntu 24.04 VM.

The race is too narrow to hit reliably from userland, so it was reproduced
deterministically with temporary, debug-only injection points that parked the
removal thread between its two config-lock phases and held
`spa_export_common()` across that window:

- Without the fix, parking a removal mid-finalize and then destroying the pool
  panics in `spa_vdev_enter()` on every run (on a debug build, where the
  assertion is compiled in).
- With the fix, the `zpool destroy` blocks until removal finalization completes
  and then succeeds.
- `removal/removal_resume_export` and `removal/removal_sanity` continue to pass.

The injection scaffolding was used only to validate the fix and is not part of
this change. For reviewers who want to run the deterministic repro, a companion
branch [`projects/export-removal-race-test`](https://github.com/prakashsurya/zfs/tree/projects/export-removal-race-test)
carries the `removal_complete_export.ksh` ZTS test plus the debug-only
injection tunables it needs, stacked on top of this fix.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [contributing document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.