### PR TITLE
Add anon_size to the overflow tolerance to avoid deadlock.

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -5152,8 +5152,25 @@ arc_is_overflowing(boolean_t lax, boolean_t use_reserve)
 
 	/* We are not under pressure, so be more or less relaxed. */
 	int64_t overflow = (arc_c >> zfs_arc_overflow_shift) / 2;
-	if (use_reserve)
+	if (use_reserve) {
 		overflow *= 3;
+
+		/*
+		 * Add anon_size to the overflow tolerance: dirty
+		 * anonymous data is unevictable until txg_sync
+		 * completes, so the portion of overflow caused by
+		 * anon data cannot be resolved by eviction.  Without
+		 * this, when the shrinker pushes arc_c down while
+		 * anon_size is large, sync-context writes block
+		 * waiting for eviction that can never free enough
+		 * space — a self-sustaining deadlock with txg_sync.
+		 * Refer to issue #18426 in github.
+		 */
+		uint64_t anon =
+		    zfs_refcount_count(&arc_anon->arcs_size[ARC_BUFC_DATA]) +
+		    zfs_refcount_count(&arc_anon->arcs_size[ARC_BUFC_METADATA]);
+		overflow += anon;
+	}
 	return (arc_over < overflow ? ARC_OVF_SOME : ARC_OVF_SEVERE);
 }
 


### PR DESCRIPTION
### Motivation and Context
This is for another deadlock in #18426 . In some edge case, anon_size could be GBs, if return ARC_OVF_SEVERE which make txg_sync_thread blocked, there will be deadlock risk. In most of cases, ARC_OVF_SOME should be good for txg_sync_thread. 

### Description
When doing overflow check which may block txg_sync_thread, always adding anon_size.

### How Has This Been Tested?
Local test and coming CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
