### PR TITLE
CI: Have zfs-build-packages workflow build tarballs on Alma

### DIFF
--- a/.github/workflows/scripts/qemu-4-build-vm.sh
+++ b/.github/workflows/scripts/qemu-4-build-vm.sh
@@ -400,13 +400,12 @@ case "$OS" in
     ;;
   alma*|centos*)
     rpm_build_and_install "--with-spec=redhat $extra"
+    if [ -n "$TARBALL" ] ; then
+        build_tarball
+    fi
     ;;
   fedora*)
     rpm_build_and_install "$extra"
-
-    # Historically, we've always built the release tarballs on Fedora, since
-    # there was one instance long ago where we built them on CentOS 7, and they
-    # didn't work correctly for everyone.
     if [ -n "$TARBALL" ] ; then
         build_tarball
     fi


### PR DESCRIPTION
### Motivation and Context
Have zfs-build-packages workflow also build tarballs on Almalinux.

### Description
Previously, zfs-build-packages would only build source tarballs on Fedora due to problems with building them on RHEL 7.  That's a relic of the past now, as we haven't supported RHEL 7 since it went EOL in 2024.  With this change, we now build the tarballs on both Alma and Fedora.

### How Has This Been Tested?
Ran zfs-build-packages workflow Almalinux build tarballs.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
