### PR TITLE
Improve performance of "zpool offline" for log devices

### DIFF
--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -4663,7 +4663,8 @@ top:
 		 */
 		if (tvd->vdev_islog && mg != NULL && dtl_required) {
 			/*
-			 * Prevent any future allocations.
+			 * Prevent future allocations unless the log device is
+			 * redundant.
 			 */
 			ASSERT0P(tvd->vdev_log_mg);
 			metaslab_group_passivate(mg);

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -4622,6 +4622,7 @@ vdev_offline_locked(spa_t *spa, uint64_t guid, uint64_t flags)
 	int error = 0;
 	uint64_t generation;
 	metaslab_group_t *mg;
+	boolean_t dtl_required;
 
 top:
 	spa_vdev_state_enter(spa, SCL_ALLOC);
@@ -4643,13 +4644,14 @@ top:
 	 * If the device isn't already offline, try to offline it.
 	 */
 	if (!vd->vdev_offline) {
+		dtl_required = vdev_dtl_required(vd);
+
 		/*
 		 * If this device has the only valid copy of some data,
 		 * don't allow it to be offlined. Log devices are always
 		 * expendable.
 		 */
-		if (!tvd->vdev_islog && vd->vdev_aux == NULL &&
-		    vdev_dtl_required(vd))
+		if (!tvd->vdev_islog && vd->vdev_aux == NULL && dtl_required)
 			return (spa_vdev_state_exit(spa, NULL,
 			    SET_ERROR(EBUSY)));
 
@@ -4659,7 +4661,7 @@ top:
 		 * is not NULL since it's possible that we may have just
 		 * added this vdev but not yet initialized its metaslabs.
 		 */
-		if (tvd->vdev_islog && mg != NULL) {
+		if (tvd->vdev_islog && mg != NULL && dtl_required) {
 			/*
 			 * Prevent any future allocations.
 			 */
@@ -4717,7 +4719,7 @@ top:
 		 * Add the device back into the metaslab rotor so that
 		 * once we online the device it's open for business.
 		 */
-		if (tvd->vdev_islog && mg != NULL)
+		if (tvd->vdev_islog && mg != NULL && dtl_required)
 			metaslab_group_activate(mg);
 	}
 


### PR DESCRIPTION
When offlining a log device, if it's part of a mirror that would still be available after the offline operation, skip replaying the ZIL for every dataset.  This drastically improves the performance of "zpool offline" for one log device of a mirrored pair.

Sponsored by:   ConnectWise

### Motivation and Context
`zpool offline` on a log device can be extremely slow.  Sometimes it takes multiple hours.  That's an impediment for our maintenance.  But there's no good reason for it to be so slow, if the log device is redundant.

### Description
When offlining log device, if there is redundancy, skip `spa_reset_logs`.  That function flushes every ZIL for every dataset on the pool, which entails multiple transaction syncs per dataset.  And there's no good reason to do it if the log device is part of a healthy mirror.

### How Has This Been Tested?
Tested on FreeBSD 16.0-CURRENT on a pool with 4 5-disk RAIDZ2 vdevs, plus a 2-disk mirrored log device.  I created 1000 datasets and wrote many ZIL records to each, using `dd oflag=sync`.  With this patch, `zpool offline` takes about 0.25 seconds for the first log device, compared to 88 minutes for the second.  Performance is worse while `dd` is running, but it still takes less than two minutes.  Without the patch, `zpool offline` took more than 45 minutes for the first log device, even with no I/O running, at which point I got impatient and rebooted.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
