### PR TITLE
Add a unit-tests workflow to our CI infrastructure

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,29 @@
+name: unit-tests
+
+on:
+  push:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+    - name: Install dependencies
+      run: |
+        ONLY_DEPS=1 .github/workflows/scripts/qemu-3-deps-vm.sh ubuntu24
+    - name: Autogen
+      run: |
+        ./autogen.sh
+    - name: Configure
+      run: |
+        ./configure --with-config=user --enable-debug --enable-debuginfo
+    - name: Unit tests
+      run: |
+        make -j$(nproc) unit


### PR DESCRIPTION
### Motivation and Context

Add a separate GitHub workflow for our unit-test suite. The suite currently includes 64 tests, so it will become more handy as we build it out further.

### Description

Add `.github/workflows/unit-tests.yml`

### How Has This Been Tested?

CI completed successfully on my fork.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [contributing document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#testing) to cover my changes.
- [ ] I have run the test suite using `make checkstyle`.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
