### PR TITLE
documentation too general.

### DIFF
--- a/man/man8/zfs.8
+++ b/man/man8/zfs.8
@@ -174,7 +174,7 @@ Creates a new ZFS file system or volume.
 .It Xr zfs-destroy 8
 Destroys the given dataset(s), snapshot(s), or bookmark.
 .It Xr zfs-rename 8
-Renames the given dataset (filesystem or snapshot).
+Renames the given filesystem, volume or snapshot.
 .It Xr zfs-upgrade 8
 Manage upgrading the on-disk version of filesystems.
 .El


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
Hann lá svo vel við höggi.

### Description
Early in ZFS(8), a dataset is defined as an umbrella term containing:
- file system,
- volume,
- snapshot, and
- bookmark.

zfs rename does not work on bookmarks. The general term 'dataset' is ok to use, but only after it has been explicitly restricted.

### How Has This Been Tested?
man the man page.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
~~- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.~~
~~- [ ] I have run the ZFS Test Suite with this change applied.~~
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
