### PR TITLE
remove lock for spa_update_config

### DIFF
--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -7564,7 +7564,9 @@ spa_import(char *pool, nvlist_t *config, nvlist_t *props, uint64_t flags)
 		/*
 		 * Update the config cache to include the newly-imported pool.
 		 */
+		spa_namespace_exit(FTAG);
 		spa_config_update(spa, SPA_CONFIG_UPDATE_POOL);
+		spa_namespace_enter(FTAG);
 	}
 
 	/*
@@ -8156,10 +8158,8 @@ spa_vdev_add(spa_t *spa, nvlist_t *nvroot, boolean_t check_ashift)
 	 */
 	(void) spa_vdev_exit(spa, vd, txg, 0);
 
-	spa_namespace_enter(FTAG);
 	spa_config_update(spa, SPA_CONFIG_UPDATE_POOL);
 	spa_event_notify(spa, NULL, NULL, ESC_ZFS_VDEV_ADD);
-	spa_namespace_exit(FTAG);
 
 	return (0);
 }
@@ -9837,7 +9837,6 @@ spa_async_thread(void *arg)
 	if (tasks & SPA_ASYNC_CONFIG_UPDATE) {
 		uint64_t old_space, new_space;
 
-		spa_namespace_enter(FTAG);
 		old_space = metaslab_class_get_space(spa_normal_class(spa));
 		old_space += metaslab_class_get_space(spa_special_class(spa));
 		old_space += metaslab_class_get_space(spa_dedup_class(spa));
@@ -9855,7 +9854,6 @@ spa_async_thread(void *arg)
 		    spa_embedded_log_class(spa));
 		new_space += metaslab_class_get_space(
 		    spa_special_embedded_log_class(spa));
-		spa_namespace_exit(FTAG);
 
 		/*
 		 * If the pool grew as a result of the config update,

--- a/module/zfs/spa_config.c
+++ b/module/zfs/spa_config.c
@@ -483,7 +483,7 @@ spa_config_update(spa_t *spa, int what)
 	uint64_t txg;
 	int c;
 
-	ASSERT(spa_namespace_held());
+	ASSERT(!spa_namespace_held());
 
 	spa_config_enter(spa, SCL_ALL, FTAG, RW_WRITER);
 	txg = spa_last_synced_txg(spa) + 1;
@@ -527,9 +527,11 @@ spa_config_update(spa_t *spa, int what)
 	 * Update the global config cache to reflect the new mosconfig.
 	 */
 	if (!spa->spa_is_root) {
+		spa_namespace_enter(FTAG);
 		spa_write_cachefile(spa, B_FALSE,
 		    what != SPA_CONFIG_UPDATE_POOL,
 		    what != SPA_CONFIG_UPDATE_POOL);
+		spa_namespace_exit(FTAG);
 	}
 
 	if (what == SPA_CONFIG_UPDATE_POOL)

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -4526,6 +4526,7 @@ vdev_online(spa_t *spa, uint64_t guid, uint64_t flags, vdev_state_t *newstate)
 	vdev_t *vd, *tvd, *pvd, *rvd = spa->spa_root_vdev;
 	boolean_t wasoffline;
 	vdev_state_t oldstate;
+	boolean_t do_expand = B_FALSE;
 
 	spa_vdev_state_enter(spa, SCL_NONE);
 
@@ -4571,7 +4572,7 @@ vdev_online(spa_t *spa, uint64_t guid, uint64_t flags, vdev_state_t *newstate)
 		if (vd->vdev_aux)
 			return (spa_vdev_state_exit(spa, vd, ENOTSUP));
 		spa->spa_ccw_fail_time = 0;
-		spa_async_request(spa, SPA_ASYNC_CONFIG_UPDATE);
+		do_expand = B_TRUE;
 	}
 
 	/* Restart initializing if necessary */
@@ -4614,7 +4615,57 @@ vdev_online(spa_t *spa, uint64_t guid, uint64_t flags, vdev_state_t *newstate)
 		    !vdev_rebuild_active(tvd))
 			spa_async_request(spa, SPA_ASYNC_DETACH_SPARE);
 	}
-	return (spa_vdev_state_exit(spa, vd, 0));
+
+	int error = spa_vdev_state_exit(spa, vd, 0);
+
+	/*
+	 * Perform the config update synchronously so that the pool
+	 * expansion is visible to userspace as soon as zpool online -e
+	 * returns.  We do this outside of spa_vdev_state_enter/exit to
+	 * avoid lock ordering issues, and without the spa_namespace lock
+	 * held to avoid deadlocking the namespace when txg_wait_synced()
+	 * blocks.
+	 */
+	if (do_expand) {
+		uint64_t old_space, new_space;
+
+		old_space = metaslab_class_get_space(
+		    spa_normal_class(spa));
+		old_space += metaslab_class_get_space(
+		    spa_special_class(spa));
+		old_space += metaslab_class_get_space(
+		    spa_dedup_class(spa));
+		old_space += metaslab_class_get_space(
+		    spa_embedded_log_class(spa));
+		old_space += metaslab_class_get_space(
+		    spa_special_embedded_log_class(spa));
+
+		spa_config_update(spa, SPA_CONFIG_UPDATE_POOL);
+
+		new_space = metaslab_class_get_space(
+		    spa_normal_class(spa));
+		new_space += metaslab_class_get_space(
+		    spa_special_class(spa));
+		new_space += metaslab_class_get_space(
+		    spa_dedup_class(spa));
+		new_space += metaslab_class_get_space(
+		    spa_embedded_log_class(spa));
+		new_space += metaslab_class_get_space(
+		    spa_special_embedded_log_class(spa));
+
+		/*
+		 * If the pool grew as a result of the config update,
+		 * then log an internal history event.
+		 */
+		if (new_space != old_space) {
+			spa_history_log_internal(spa, "vdev online", NULL,
+			    "pool '%s' size: %llu(+%llu)",
+			    spa_name(spa), (u_longlong_t)new_space,
+			    (u_longlong_t)(new_space - old_space));
+		}
+	}
+
+	return (error);
 }
 
 static int

--- a/module/zfs/vdev_raidz.c
+++ b/module/zfs/vdev_raidz.c
@@ -4268,6 +4268,7 @@ raidz_reflow_complete_sync(void *arg, dmu_tx_t *tx)
 	spa->spa_raidz_expand = NULL;
 	raidvd->vdev_rz_expanding = B_FALSE;
 
+	spa_async_request(spa, SPA_ASYNC_CONFIG_UPDATE);
 	spa_async_request(spa, SPA_ASYNC_INITIALIZE_RESTART);
 	spa_async_request(spa, SPA_ASYNC_TRIM_RESTART);
 	spa_async_request(spa, SPA_ASYNC_AUTOTRIM_RESTART);

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -3550,6 +3550,21 @@ zfs_ioc_pool_set_props(zfs_cmd_t *zc)
 	error = spa_prop_set(spa, props);
 
 	nvlist_free(props);
+
+	/*
+	 * For properties stored in the pool config object (e.g.
+	 * compatibility, comment), the MOS copy was updated by the
+	 * sync task above.  Update the config and cache file
+	 * synchronously so that the change is visible before we
+	 * return to userspace.
+	 *
+	 * spa_config_update() must be called without the namespace
+	 * held so that txg_wait_synced() does not block other
+	 * namespace operations.
+	 */
+	if (error == 0)
+		spa_config_update(spa, SPA_CONFIG_UPDATE_POOL);
+
 	spa_close(spa, FTAG);
 
 	return (error);


### PR DESCRIPTION
### Motivation and Context
This is another PR which try to solve #18648 , which is very clear, that spa_config_update holds a namespace lock, and calls txg_sync_wait. If txg_sync_wait blocks or hangs, the spa is in deadlock, no return, no other commands are available.

### Description
spa_config_update has two-pass, all in a namespace lock, with two txg_wait_sync. The approach of this PR is bluntly remove namespace lock for spa_config_update. Inside it, when update vdev or cachefile, related lock are acquired. So the process relates to spa_config_update are retained.

However, when doing so, a lot of regression happens in CI, so my previous PR is dropped, and I make this PR from master branch again. Now most of OSs in CI pass all tests.

This PR must be carefully reviewed. spa_config_update is changed without namespace lock, and added two more calling site. In the other side, we are sure, no deadlock in spa update and txg wait, and this PR does not touch data read/write path, only the spa config update.

### How Has This Been Tested?
Tested in local ubuntu26, freebsd15, and CI in my personal zfs repo.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
spa_config_update now can not be called inside a namespace lock which is a big change.
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [X] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
