### PR TITLE
CI: Re-allow workflow_dispatch on zfs-qemu

### DIFF
--- a/.github/workflows/zfs-qemu.yml
+++ b/.github/workflows/zfs-qemu.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   test-config:
     name: Setup
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'|| github.repository != 'openzfs/zfs'
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || github.repository != 'openzfs/zfs'
     runs-on: ubuntu-24.04
     outputs:
       test_os: ${{ steps.os.outputs.os }}

--- a/.github/workflows/zfs-qemu.yml
+++ b/.github/workflows/zfs-qemu.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   test-config:
     name: Setup
-    if: github.event_name == 'pull_request' || github.repository != 'openzfs/zfs'
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'|| github.repository != 'openzfs/zfs'
     runs-on: ubuntu-24.04
     outputs:
       test_os: ${{ steps.os.outputs.os }}


### PR DESCRIPTION
### Motivation and Context
Allow workflow_dispatch events to trigger zfs-qemu workflow

### Description
Allow zfs-qemu to be invoked from a workflow_dispatch event (a.k.a, manually running a workflow).  This may have been accidentally disabled in 1916c2c55.

### How Has This Been Tested?
Local CI run invoked though workflow_dispatch

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
