### PR TITLE
spa: make ccw_retry_interval tunable on Linux

### DIFF
--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -1090,6 +1090,10 @@ and uses pages, unlike the Linux-specific
 .Sy zfs_arc_sys_free
 which is measured in bytes.
 .
+.It Sy zfs_ccw_retry_interval Ns = Ns Sy 300 Ns s Pq int
+Interval, in seconds, at which a failed write of the configuration cache file
+is retried.
+.
 .It Sy zfs_checksum_events_per_second Ns = Ns Sy 20 Ns /s Pq uint
 Rate limit checksum events to this many per second.
 Note that this should not be set below the ZED thresholds

--- a/module/os/freebsd/zfs/sysctl_os.c
+++ b/module/os/freebsd/zfs/sysctl_os.c
@@ -306,15 +306,6 @@ param_set_multihost_interval(SYSCTL_HANDLER_ARGS)
 	return (0);
 }
 
-/* spa.c */
-
-extern int zfs_ccw_retry_interval;
-
-SYSCTL_INT(_vfs_zfs, OID_AUTO, ccw_retry_interval,
-	CTLFLAG_RWTUN, &zfs_ccw_retry_interval, 0,
-	"Configuration cache file write, retry after failure, interval"
-	" (seconds)");
-
 /* spa_misc.c */
 
 extern int zfs_flags;

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -11866,3 +11866,7 @@ ZFS_MODULE_VIRTUAL_PARAM_CALL(zfs_zio, zio_, taskq_free,
 
 ZFS_MODULE_PARAM(zfs_zio, zio_, taskq_write_tpq, UINT, ZMOD_RW,
 	"Number of CPUs per write issue taskq");
+
+ZFS_MODULE_PARAM(zfs, zfs_, ccw_retry_interval, INT, ZMOD_RW,
+	"Configuration cache file write, retry after failure, interval "
+	"(seconds)");


### PR DESCRIPTION
### Motivation and Context

_A step towards full Linux/FreeBSD tunable parity._

`zfs_ccw_retry_interval` sets the time interval after which a retry of a failed write of the configuration cache file is attempted. It was only exposed on FreeBSD as a `SYSCTL_INT` tunable, but not on Linux.

### Description

Register the variable on Linux via `ZFS_MODULE_PARAM`, drop the FreeBSD `SYSCTL_INT` declaration and document it in `zfs.4`.

### How Has This Been Tested?

- Arch Linux, 7.0.10 kernel:  after building the patched module `/sys/module/zfs/parameters/zfs_ccw_retry_interval` reads the expected default of `300` and is also **RW**.

- FreeBSD (16.0-CURRENT): the full module builds cleanly with `gmake`/clang

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [contributing document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
