### PR TITLE
initramfs-zfs should not try to copy directories

### DIFF
--- a/contrib/initramfs/hooks/zfs.in
+++ b/contrib/initramfs/hooks/zfs.in
@@ -31,7 +31,7 @@ done
 
 # shellcheck disable=SC2050
 if [ @LIBFETCH_DYNAMIC@ -gt 0 ]; then
-	find /lib/ -name "@LIBFETCH_SONAME@" | while read -r libfetch; do
+	find /lib/ -type f -name "@LIBFETCH_SONAME@" | while read -r libfetch; do
 		copy_exec "$libfetch"
 	done
 fi


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
We had find only return files from the beginning for libgcc.so, but not libfetch/libcurl. This oversight affected a user when vmware installed its own libcurl.so.4 in a directory called libcurl.so.4, since our code then tried to copy a directory, which fails. This fixes #18582.

### Description
We add `-type f` to find so it stops returning directories.

### How Has This Been Tested?
It has not been tested. This is a trivial change whose correctness is obvious since the find command must never return non-files in this context. If we need to test it, a Debian user could reproduce #18582 and verify that it resolves the problem.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
