### PR TITLE
Fix handling of _PC_HAS_HIDDENSYSTEM for FreeBSD

### DIFF
--- a/module/os/freebsd/zfs/zfs_vnops_os.c
+++ b/module/os/freebsd/zfs/zfs_vnops_os.c
@@ -5751,7 +5751,8 @@ zfs_freebsd_pathconf(struct vop_pathconf_args *ap)
 {
 	ulong_t val;
 	int error;
-#if defined(_PC_CLONE_BLKSIZE) || defined(_PC_CASE_INSENSITIVE)
+#if defined(_PC_CLONE_BLKSIZE) || defined(_PC_CASE_INSENSITIVE) || \
+	defined(_PC_HAS_HIDDENSYSTEM)
 	zfsvfs_t *zfsvfs;
 #endif
 
@@ -5797,7 +5798,11 @@ zfs_freebsd_pathconf(struct vop_pathconf_args *ap)
 #endif
 #ifdef _PC_HAS_HIDDENSYSTEM
 	case _PC_HAS_HIDDENSYSTEM:
-		*ap->a_retval = 1;
+		zfsvfs = (zfsvfs_t *)ap->a_vp->v_mount->mnt_data;
+		if (zfsvfs->z_use_fuids == B_TRUE)
+			*ap->a_retval = 1;
+		else
+			*ap->a_retval = 0;
 		return (0);
 #endif
 #ifdef _PC_CLONE_BLKSIZE


### PR DESCRIPTION

### Motivation and Context
Without this patch zfs_freebsd_pathconf() will erroneoously
report that hidden/system flags are supported for ZFS pools
where z_use_fuids == B_FALSE.

### Description
This patch adds a check for z_use_fuids to the _PC_HAS_HIDDENSYSTEM
case in zfs_freebsd_pathconf().

### How Has This Been Tested?
Tested by me in FreeBSD for a ZFS pool where z_use_fiuds == B_TRUE.

Tested by a reporter of a FreeBSD bug, where they use a ZFS pool of
version 1 (z_use_fuids == B_FALSE). For their setup, a MacOS NFSv4
client attempts to set hidden/system and gets a reply of EINVAL from
the NFSv4 server, because the NFSv4 server erroneously reported that
hidden/system attributes were supported, without this patch.
With this patch, the MacOS NFSv4 mount to the FreeBSD server
exporting a ZFS version 1 file system works correctly.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
