### PR TITLE
unit/btree: test basic B-Tree operations

### DIFF
--- a/tests/unit/.gitignore
+++ b/tests/unit/.gitignore
@@ -3,3 +3,4 @@
 
 /test_zap
 /test_namecheck
+/test_btree

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -56,6 +56,7 @@ nodist_%C%_test_namecheck_SOURCES = \
 %C%_test_btree_CFLAGS = $(AM_CFLAGS)
 
 nodist_%C%_test_btree_SOURCES = \
+	module/avl/avl.c \
 	module/zfs/btree.c
 
 %C%_test_btree_SOURCES = \

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -16,7 +16,8 @@ libunit_la_SOURCES = \
 # all test binaries
 UNIT_TESTS = \
 	%D%/test_zap \
-	%D%/test_namecheck
+	%D%/test_namecheck \
+	%D%/test_btree
 noinst_PROGRAMS = $(UNIT_TESTS)
 
 
@@ -48,6 +49,19 @@ nodist_%C%_test_namecheck_SOURCES = \
 	%D%/test_namecheck.c
 
 %C%_test_namecheck_LDADD = \
+	libspl.la \
+	libunit.la
+
+
+%C%_test_btree_CFLAGS = $(AM_CFLAGS)
+
+nodist_%C%_test_btree_SOURCES = \
+	module/zfs/btree.c
+
+%C%_test_btree_SOURCES = \
+	%D%/test_btree.c
+
+%C%_test_btree_LDADD = \
 	libspl.la \
 	libunit.la
 

--- a/tests/unit/test_btree.c
+++ b/tests/unit/test_btree.c
@@ -37,7 +37,7 @@ u64_compare(const void *a, const void *b)
 		return (-1);
 	if (x > y)
 		return (1);
-	return (0);
+    return (TREE_CMP(x, y));
 }
 
 /*

--- a/tests/unit/test_btree.c
+++ b/tests/unit/test_btree.c
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: CDDL-1.0
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2026, Christos Longros.
+ */
+
+#include <sys/types.h>
+#include <sys/sysmacros.h>
+#include <sys/btree.h>
+
+#include "unit.h"
+
+/* ========== */
+
+/*
+ * The B-Tree stores arbitrary sortable data; these tests use plain uint64_t
+ * values.  Elements are kept in sorted order, so a comparison function must
+ * return -1, 0, or +1 for less-than, equal, and greater-than.
+ */
+static int
+u64_compare(const void *a, const void *b)
+{
+	const uint64_t x = *(const uint64_t *)a;
+	const uint64_t y = *(const uint64_t *)b;
+
+	if (x < y)
+		return (-1);
+	if (x > y)
+		return (1);
+	return (0);
+}
+
+/*
+ * Create a tree of uint64_t values.
+ */
+static void
+btree_create_u64(zfs_btree_t *bt)
+{
+	zfs_btree_create(bt, u64_compare, NULL, sizeof (uint64_t));
+}
+
+/* ========== */
+
+/* A new tree is empty: no nodes, and nothing to walk. */
+static MunitResult
+test_btree_empty(const MunitParameter params[], void *data)
+{
+	(void) params, (void) data;
+
+	zfs_btree_t bt;
+	zfs_btree_index_t idx;
+
+	btree_create_u64(&bt);
+	unit_zero(zfs_btree_numnodes(&bt));
+	unit_true(zfs_btree_first(&bt, &idx) == NULL);
+	zfs_btree_destroy(&bt);
+
+	return (MUNIT_OK);
+}
+
+/* Added values can be found; the count tracks them; absent values are not. */
+static MunitResult
+test_btree_add_find(const MunitParameter params[], void *data)
+{
+	(void) params, (void) data;
+
+	zfs_btree_t bt;
+	zfs_btree_index_t idx;
+	btree_create_u64(&bt);
+
+	uint64_t vals[] = { 50, 10, 30 };
+	for (size_t i = 0; i < ARRAY_SIZE(vals); i++)
+		zfs_btree_add(&bt, &vals[i]);
+
+	/* The tree now holds exactly the values we added. */
+	unit_eq(zfs_btree_numnodes(&bt), ARRAY_SIZE(vals));
+
+	/* Each value is found; find() returns a pointer to the stored copy. */
+	for (size_t i = 0; i < ARRAY_SIZE(vals); i++) {
+		uint64_t *found = zfs_btree_find(&bt, &vals[i], &idx);
+		unit_true(found != NULL);
+		unit_eq(*found, vals[i]);
+	}
+
+	/* A value that was never added is not in the tree. */
+	uint64_t absent = 99;
+	unit_true(zfs_btree_find(&bt, &absent, &idx) == NULL);
+
+	zfs_btree_destroy(&bt);
+	return (MUNIT_OK);
+}
+
+/* Removing a value drops it from the tree and lowers the count. */
+static MunitResult
+test_btree_remove(const MunitParameter params[], void *data)
+{
+	(void) params, (void) data;
+
+	zfs_btree_t bt;
+	zfs_btree_index_t idx;
+	btree_create_u64(&bt);
+
+	uint64_t vals[] = { 10, 20, 30 };
+	for (size_t i = 0; i < ARRAY_SIZE(vals); i++)
+		zfs_btree_add(&bt, &vals[i]);
+
+	uint64_t gone = 20;
+	zfs_btree_remove(&bt, &gone);
+
+	unit_eq(zfs_btree_numnodes(&bt), 2);
+	unit_true(zfs_btree_find(&bt, &gone, &idx) == NULL);
+
+	/* The values we kept are still present. */
+	uint64_t keep1 = 10, keep2 = 30;
+	unit_true(zfs_btree_find(&bt, &keep1, &idx) != NULL);
+	unit_true(zfs_btree_find(&bt, &keep2, &idx) != NULL);
+
+	zfs_btree_destroy(&bt);
+	return (MUNIT_OK);
+}
+
+/* Values inserted out of order are walked back in ascending order. */
+static MunitResult
+test_btree_walk(const MunitParameter params[], void *data)
+{
+	(void) params, (void) data;
+
+	zfs_btree_t bt;
+	zfs_btree_index_t idx;
+	btree_create_u64(&bt);
+
+	uint64_t vals[] = { 50, 10, 40, 20, 30 };
+	for (size_t i = 0; i < ARRAY_SIZE(vals); i++)
+		zfs_btree_add(&bt, &vals[i]);
+
+	/* first()/next() yield the elements smallest-to-largest. */
+	uint64_t prev = 0;
+	uint64_t count = 0;
+	for (uint64_t *p = zfs_btree_first(&bt, &idx); p != NULL;
+	    p = zfs_btree_next(&bt, &idx, &idx)) {
+		unit_gt(*p, prev);	/* strictly increasing */
+		prev = *p;
+		count++;
+	}
+	unit_eq(count, ARRAY_SIZE(vals));
+
+	zfs_btree_destroy(&bt);
+	return (MUNIT_OK);
+}
+
+/* ========== */
+
+static const MunitTest btree_tests[] = {
+	UNIT_TEST("empty",	test_btree_empty),
+	UNIT_TEST("add_find",	test_btree_add_find),
+	UNIT_TEST("remove",	test_btree_remove),
+	UNIT_TEST("walk",	test_btree_walk),
+	{ 0 },
+};
+
+static const MunitSuite btree_test_suite = {
+	"btree.",
+	btree_tests,
+	NULL,
+	1,
+	MUNIT_SUITE_OPTION_NONE,
+};
+
+int
+main(int argc, char **argv)
+{
+	zfs_btree_init();
+	int ret = munit_suite_main(&btree_test_suite, NULL, argc, argv);
+	zfs_btree_fini();
+	return (ret);
+}

--- a/tests/unit/test_btree.c
+++ b/tests/unit/test_btree.c
@@ -14,11 +14,16 @@
  * Copyright (c) 2026, Christos Longros.
  */
 
+#include <stddef.h>
+#include <stdlib.h>
 #include <sys/types.h>
 #include <sys/sysmacros.h>
+#include <sys/avl.h>
 #include <sys/btree.h>
 
 #include "unit.h"
+
+#define	DRAIN_COUNT	(64 * 1024)
 
 /* ========== */
 
@@ -33,11 +38,7 @@ u64_compare(const void *a, const void *b)
 	const uint64_t x = *(const uint64_t *)a;
 	const uint64_t y = *(const uint64_t *)b;
 
-	if (x < y)
-		return (-1);
-	if (x > y)
-		return (1);
-    return (TREE_CMP(x, y));
+	return (TREE_CMP(x, y));
 }
 
 /*
@@ -47,6 +48,24 @@ static void
 btree_create_u64(zfs_btree_t *bt)
 {
 	zfs_btree_create(bt, u64_compare, NULL, sizeof (uint64_t));
+}
+
+/*
+ * Cross-check the B-Tree against an AVL tree holding the same
+ * values, used as reference.
+ */
+typedef struct int_node {
+	avl_node_t node;
+	uint64_t data;
+} int_node_t;
+
+static int
+avl_u64_compare(const void *v1, const void *v2)
+{
+	const int_node_t *n1 = v1;
+	const int_node_t *n2 = v2;
+
+	return (TREE_CMP(n1->data, n2->data));
 }
 
 /* ========== */
@@ -63,6 +82,7 @@ test_btree_empty(const MunitParameter params[], void *data)
 	btree_create_u64(&bt);
 	unit_zero(zfs_btree_numnodes(&bt));
 	unit_true(zfs_btree_first(&bt, &idx) == NULL);
+	zfs_btree_clear(&bt);
 	zfs_btree_destroy(&bt);
 
 	return (MUNIT_OK);
@@ -96,6 +116,7 @@ test_btree_add_find(const MunitParameter params[], void *data)
 	uint64_t absent = 99;
 	unit_true(zfs_btree_find(&bt, &absent, &idx) == NULL);
 
+	zfs_btree_clear(&bt);
 	zfs_btree_destroy(&bt);
 	return (MUNIT_OK);
 }
@@ -125,6 +146,7 @@ test_btree_remove(const MunitParameter params[], void *data)
 	unit_true(zfs_btree_find(&bt, &keep1, &idx) != NULL);
 	unit_true(zfs_btree_find(&bt, &keep2, &idx) != NULL);
 
+	zfs_btree_clear(&bt);
 	zfs_btree_destroy(&bt);
 	return (MUNIT_OK);
 }
@@ -154,6 +176,102 @@ test_btree_walk(const MunitParameter params[], void *data)
 	}
 	unit_eq(count, ARRAY_SIZE(vals));
 
+	zfs_btree_clear(&bt);
+	zfs_btree_destroy(&bt);
+	return (MUNIT_OK);
+}
+
+/* Verify that zfs_btree_find() works correctly when passed a NULL index. */
+static MunitResult
+test_btree_find_without_index(const MunitParameter params[], void *data)
+{
+	(void) params, (void) data;
+
+	zfs_btree_t bt;
+	btree_create_u64(&bt);
+
+	uint64_t i = 12345;
+	zfs_btree_add(&bt, &i);
+
+	uint64_t *p = zfs_btree_find(&bt, &i, NULL);
+	unit_true(p != NULL);
+	unit_eq(*p, i);
+
+	uint64_t absent = i + 1;
+	unit_true(zfs_btree_find(&bt, &absent, NULL) == NULL);
+
+	zfs_btree_clear(&bt);
+	zfs_btree_destroy(&bt);
+	return (MUNIT_OK);
+}
+
+/*
+ * Fill a B-Tree and an AVL tree with the same random values, then drain
+ * both from alternating ends, checking they stay identical at every step.
+ */
+static MunitResult
+test_btree_drain(const MunitParameter params[], void *data)
+{
+	(void) params, (void) data;
+
+	zfs_btree_t bt;
+	avl_tree_t avl;
+	zfs_btree_index_t bt_idx = {0};
+	avl_index_t avl_idx = {0};
+	int_node_t *node;
+
+	btree_create_u64(&bt);
+	avl_create(&avl, avl_u64_compare, sizeof (int_node_t),
+	    offsetof(int_node_t, node));
+
+	/* Fill both trees with the same data. */
+	for (int i = 0; i < DRAIN_COUNT; i++) {
+		uint64_t randval = unit_rand_uint64();
+		if (zfs_btree_find(&bt, &randval, &bt_idx) != NULL)
+			continue;
+		zfs_btree_add_idx(&bt, &randval, &bt_idx);
+
+		node = malloc(sizeof (int_node_t));
+		unit_true(node != NULL);
+		node->data = randval;
+
+		/* New to the btree, so the avl must not have it either. */
+		unit_true(avl_find(&avl, node, &avl_idx) == NULL);
+		avl_insert(&avl, node, avl_idx);
+	}
+
+	/* Remove from alternating ends, comparing the trees as we go. */
+	while (avl_numnodes(&avl) != 0) {
+		uint64_t *bt_data;
+
+		unit_eq(zfs_btree_numnodes(&bt), avl_numnodes(&avl));
+		if (avl_numnodes(&avl) % 2 == 0) {
+			node = avl_first(&avl);
+			bt_data = zfs_btree_first(&bt, &bt_idx);
+		} else {
+			node = avl_last(&avl);
+			bt_data = zfs_btree_last(&bt, &bt_idx);
+		}
+		unit_eq(*bt_data, node->data);
+		zfs_btree_remove_idx(&bt, &bt_idx);
+		avl_remove(&avl, node);
+		free(node);
+
+		if (avl_numnodes(&avl) == 0)
+			break;
+
+		/* Both ends still agree after the removal. */
+		uint64_t *bt_lo = zfs_btree_first(&bt, NULL);
+		uint64_t *bt_hi = zfs_btree_last(&bt, NULL);
+		int_node_t *avl_lo = avl_first(&avl);
+		int_node_t *avl_hi = avl_last(&avl);
+		unit_eq(*bt_lo, avl_lo->data);
+		unit_eq(*bt_hi, avl_hi->data);
+	}
+	unit_zero(zfs_btree_numnodes(&bt));
+
+	avl_destroy(&avl);
+	zfs_btree_clear(&bt);
 	zfs_btree_destroy(&bt);
 	return (MUNIT_OK);
 }
@@ -161,10 +279,12 @@ test_btree_walk(const MunitParameter params[], void *data)
 /* ========== */
 
 static const MunitTest btree_tests[] = {
-	UNIT_TEST("empty",	test_btree_empty),
-	UNIT_TEST("add_find",	test_btree_add_find),
-	UNIT_TEST("remove",	test_btree_remove),
-	UNIT_TEST("walk",	test_btree_walk),
+	UNIT_TEST("empty",		test_btree_empty),
+	UNIT_TEST("add_find",		test_btree_add_find),
+	UNIT_TEST("remove",		test_btree_remove),
+	UNIT_TEST("walk",		test_btree_walk),
+	UNIT_TEST("find_without_index",	test_btree_find_without_index),
+	UNIT_TEST("drain",		test_btree_drain),
 	{ 0 },
 };
 

--- a/tests/zfs-tests/cmd/btree_test.c
+++ b/tests/zfs-tests/cmd/btree_test.c
@@ -157,30 +157,6 @@ verify_node(avl_tree_t *avl, zfs_btree_t *bt, int_node_t *node)
  * Tests
  */
 
-/* Verify that zfs_btree_find works correctly with a NULL index. */
-static int
-find_without_index(zfs_btree_t *bt, char *why)
-{
-	u_longlong_t *p, i = 12345;
-
-	zfs_btree_add(bt, &i);
-	if ((p = (u_longlong_t *)zfs_btree_find(bt, &i, NULL)) == NULL ||
-	    *p != i) {
-		(void) snprintf(why, BUFSIZE, "Unexpectedly found %llu\n",
-		    p == NULL ? 0 : *p);
-		return (1);
-	}
-
-	i++;
-
-	if ((p = (u_longlong_t *)zfs_btree_find(bt, &i, NULL)) != NULL) {
-		(void) snprintf(why, BUFSIZE, "Found bad value: %llu\n", *p);
-		return (1);
-	}
-
-	return (0);
-}
-
 /* Verify simple insertion and removal from the tree. */
 static int
 insert_find_remove(zfs_btree_t *bt, char *why)
@@ -209,82 +185,6 @@ insert_find_remove(zfs_btree_t *bt, char *why)
 	}
 	ASSERT0(zfs_btree_numnodes(bt));
 	zfs_btree_verify(bt);
-
-	return (0);
-}
-
-/*
- * Add a number of random entries into a btree and avl tree. Then walk them
- * backwards and forwards while emptying the tree, verifying the trees look
- * the same.
- */
-static int
-drain_tree(zfs_btree_t *bt, char *why)
-{
-	avl_tree_t avl;
-	int i = 0;
-	int_node_t *node;
-	avl_index_t avl_idx = {0};
-	zfs_btree_index_t bt_idx = {0};
-
-	avl_create(&avl, avl_compare, sizeof (int_node_t),
-	    offsetof(int_node_t, node));
-
-	/* Fill both trees with the same data */
-	for (i = 0; i < 64 * 1024; i++) {
-		u_longlong_t randval = random();
-		if (zfs_btree_find(bt, &randval, &bt_idx) != NULL) {
-			continue;
-		}
-		zfs_btree_add_idx(bt, &randval, &bt_idx);
-
-		node = malloc(sizeof (int_node_t));
-		if (node == NULL) {
-			perror("malloc");
-			exit(EXIT_FAILURE);
-		}
-
-		node->data = randval;
-		if (avl_find(&avl, node, &avl_idx) != NULL) {
-			(void) snprintf(why, BUFSIZE,
-			    "Found in avl: %llu\n", randval);
-			return (1);
-		}
-		avl_insert(&avl, node, avl_idx);
-	}
-
-	/* Remove data from either side of the trees, comparing the data */
-	while (avl_numnodes(&avl) != 0) {
-		uint64_t *data;
-
-		ASSERT3U(avl_numnodes(&avl), ==, zfs_btree_numnodes(bt));
-		if (avl_numnodes(&avl) % 2 == 0) {
-			node = avl_first(&avl);
-			data = zfs_btree_first(bt, &bt_idx);
-		} else {
-			node = avl_last(&avl);
-			data = zfs_btree_last(bt, &bt_idx);
-		}
-		ASSERT3U(node->data, ==, *data);
-		zfs_btree_remove_idx(bt, &bt_idx);
-		avl_remove(&avl, node);
-
-		if (avl_numnodes(&avl) == 0) {
-			break;
-		}
-
-		node = avl_first(&avl);
-		ASSERT3U(node->data, ==,
-		    *(uint64_t *)zfs_btree_first(bt, NULL));
-		node = avl_last(&avl);
-		ASSERT3U(node->data, ==, *(uint64_t *)zfs_btree_last(bt, NULL));
-	}
-	ASSERT0(zfs_btree_numnodes(bt));
-
-	void *avl_cookie = NULL;
-	while ((node = avl_destroy_nodes(&avl, &avl_cookie)) != NULL)
-		free(node);
-	avl_destroy(&avl);
 
 	return (0);
 }
@@ -453,8 +353,6 @@ typedef struct btree_test {
 
 static btree_test_t test_table[] = {
 	{ "insert_find_remove",		insert_find_remove	},
-	{ "find_without_index",		find_without_index	},
-	{ "drain_tree",			drain_tree		},
 	{ "stress_tree",		stress_tree		},
 	{ NULL,				NULL			}
 };

--- a/tests/zfs-tests/tests/functional/btree/btree_positive.ksh
+++ b/tests/zfs-tests/tests/functional/btree/btree_positive.ksh
@@ -24,11 +24,11 @@
 # without arguments.
 #
 # insert_find_remove - Basic functionality test
-# find_without_index - Using the find function with a NULL argument
-# drain_tree         - Fill the tree then empty it using the first and last
-#                      functions
 # stress_tree        - Allow the tree to have items added and removed for a
 #                      given amount of time
+#
+# The find_without_index and drain_tree tests have been migrated to the
+# tests/unit/test_btree.c unit test.
 #
 
 log_must btree_test


### PR DESCRIPTION
### Motivation and Context

`module/zfs/btree.c` has no dedicated unit test. This adds a small `tests/unit` suite for its basic public operations.

### Description

Adds `tests/unit/test_btree.c` with four tests over a tree of `uint64_t` values:
- **empty** — a new tree has no elements and nothing to walk
- **add_find** — added values are found and the count tracks them; a value never added is not present
- **remove** — removing a value drops it and lowers the count, leaving the rest intact
- **walk** — values inserted out of order are returned smallest-to-largest via `zfs_btree_first`/`zfs_btree_next`
- **find_without_index**:  Verify that zfs_btree_find() works correctly when passed a NULL index
- **drain**: Drain a B-Tree and AVL tree from alternating ends while verifying that their data agree with each other.

Removes the migrated tests from ZTS.

### How Has This Been Tested?

`make unit T=btree` on Linux x86_64:

```
> make unit T=btree
  CC       tests/unit/test_btree-test_btree.o
  CCLD     tests/unit/test_btree
  UNITTEST tests/unit/test_btree
Running test suite with seed 0x3048e885...
btree.empty                          [ OK    ] [ 0.00000255 / 0.00000062 CPU ]
btree.add_find                       [ OK    ] [ 0.00000524 / 0.00000489 CPU ]
btree.remove                         [ OK    ] [ 0.00000393 / 0.00000393 CPU ]
btree.walk                           [ OK    ] [ 0.00000856 / 0.00000749 CPU ]
btree.find_without_index             [ OK    ] [ 0.00000503 / 0.00000467 CPU ]
btree.drain                          [ OK    ] [ 0.01960133 / 0.01951305 CPU ]
6 of 6 (100%) tests successful, 0 (0%) test skipped.
```

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
- [x] My code follows the OpenZFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **contributing** document.
- [x] I have added tests to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.

