### PR TITLE
short path for "zfs/zpool upgrade -v" befor libzfs_init

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -9394,6 +9394,21 @@ main(int argc, char **argv)
 	if (strcmp(cmdname, "help") == 0)
 		return (zfs_do_help(argc, argv));
 
+	/*
+	 * Special case 'upgrade -v' — userspace only, no kernel needed.
+	 */
+	if (strcmp(cmdname, "upgrade") == 0) {
+		for (int i = 2; i < argc; i++) {
+			if (strcmp(argv[i], "-v") == 0) {
+				int idx;
+				if (find_command_idx("upgrade", &idx) == 0)
+					current_command = &command_table[idx];
+				return (zfs_do_upgrade(argc - 1,
+				    argv + 1));
+			}
+		}
+	}
+
 	if ((g_zfs = libzfs_init()) == NULL) {
 		(void) fprintf(stderr, "%s\n", libzfs_error_init(errno));
 		return (1);

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -13890,6 +13890,26 @@ main(int argc, char **argv)
 		}
 	}
 
+	/*
+	 * Special case 'upgrade -v' — userspace only on FreeBSD,
+	 * no kernel needed.  On Linux, zpool_feature_init() needs
+	 * /sys/module/zfs/features.pool, so keep the normal path.
+	 */
+#ifdef __FreeBSD__
+	if (strcmp(cmdname, "upgrade") == 0) {
+		for (int i = 2; i < argc; i++) {
+			if (strcmp(argv[i], "-v") == 0) {
+				int idx;
+				if (find_command_idx("upgrade", &idx) == 0)
+					current_command = &command_table[idx];
+				zpool_feature_init();
+				return (zpool_do_upgrade(argc - 1,
+				    argv + 1));
+			}
+		}
+	}
+#endif
+
 	if ((g_zfs = libzfs_init()) == NULL) {
 		(void) fprintf(stderr, "%s\n", libzfs_error_init(errno));
 		return (1);


### PR DESCRIPTION
### Motivation and Context
In freebsd, there will no kernel auto-load for this two commands. zpool upgrade still need kernel
in linux. Refer to #18593 for more details.

### Description
Just move the two commands before libzfs_init.

### How Has This Been Tested?
Tested locally with strace/truss.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).