### PR TITLE
README: update supported FreeBSD release to 15.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,4 +68,4 @@ Generally, if a distribution is following an LTS kernel, it should work well wit
 
 All FreeBSD releases receiving [security support](https://www.freebsd.org/security/#sup) are supported by OpenZFS.
 
-**Supported FreeBSD releases**: **15.0**, **14.4**.
+**Supported FreeBSD releases**: **15.1**, **14.4**.


### PR DESCRIPTION
### Motivation and Context

Our CI runners moved to FreeBSD 15.1 in 0a4b59765 (#18667), but the README still lists 15.0. This updates the
README so it matches the FreeBSD CI version.

### Description

One-line change to `README.md`

### How Has This Been Tested?

Documentation-only change.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [ ] I have read the [contributing document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#testing) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [\`Signed-off-by\`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).