### PR TITLE
honor file argument in file_wait_event

### DIFF
--- a/tests/zfs-tests/tests/functional/events/events_common.kshlib
+++ b/tests/zfs-tests/tests/functional/events/events_common.kshlib
@@ -40,7 +40,7 @@ function file_wait_event # file event timeout
 
 	SECONDS=0
 
-	until grep -q "^ZEVENT_CLASS=$event" $ZED_DEBUG_LOG ; do
+	until grep -q "^ZEVENT_CLASS=$event" "$file" ; do
 		if [[ $SECONDS -gt $timeout ]]; then
 			echo file_wait_event exceeded $SECONDS seconds
 			return 1


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
When using `file_wait_event` test suite function - we should have it grep the path passed by the caller instead of always using ZED_DEBUG_LOG.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
Every caller currently passes ZED_DEBUG_LOG as the file so this doesn't change behavior but this will let us avoid surprises later on if someone uses this function with another file.
```
tests/zfs-tests/tests/functional/events/events_002_pos.ksh:63:log_must file_wait_event $ZED_DEBUG_LOG 'sysevent\.fs\.zfs\.config_sync' 150
tests/zfs-tests/tests/functional/events/events_002_pos.ksh:88:log_must file_wait_event $ZED_DEBUG_LOG 'sysevent\.fs\.zfs\.resilver_finish' 150
tests/zfs-tests/tests/functional/events/events_002_pos.ksh:91:log_mustnot file_wait_event $ZED_DEBUG_LOG 'sysevent\.fs\.zfs\.pool_create' 30
tests/zfs-tests/tests/functional/events/zed_cksum_reported.ksh:88:      log_must file_wait_event $ZED_DEBUG_LOG "ereport.fs.zfs.checksum" 10
tests/zfs-tests/tests/functional/events/zed_synchronous_zedlet.ksh:121:log_must file_wait_event $ZED_DEBUG_LOG 'sysevent\.fs\.zfs\.scrub_finish' 10
```
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
