### PR TITLE
Remove zc_objset / zc_zapobj from zap_cursor

### DIFF
--- a/include/sys/zap.h
+++ b/include/sys/zap.h
@@ -451,12 +451,6 @@ typedef struct zap_cursor {
 	uint64_t zc_hash;
 	uint32_t zc_cd;
 	boolean_t zc_prefetch;
-	/*
-	 * Legacy fields to main source compat with Lustre, which accesses
-	 * them directly. Not to be used in new code!
-	 */
-	objset_t *zc_objset;
-	uint64_t zc_zapobj;
 } zap_cursor_t;
 
 /*

--- a/module/zfs/zap.c
+++ b/module/zfs/zap.c
@@ -1053,8 +1053,6 @@ zap_cursor_init_by_dnode_impl(zap_cursor_t *zc, dnode_t *dn,
 		return (err);
 
 	zc->zc_prefetch = prefetch;
-	zc->zc_objset = dn->dn_objset;
-	zc->zc_zapobj = dn->dn_object;
 
 	int hb = zap_hashbits(zc->zc_zap);
 	zc->zc_hash = serialized << (64 - hb);


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

These fields were deprecated in #18603 and were only used by Lustre's osd-zfs. With Lustre patch https://review.whamcloud.com/c/fs/lustre-release/+/66686 the last users of these fields are removed from osd-zfs. Once that patch lands in upstream Lustre, they can be removed in ZFS.

### Description
<!--- Describe your changes in detail -->

Drop unused fields only used by out-of-tree Lustre osd-zfs.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

The Lustre change has been tested: https://testing.whamcloud.com/test_sessions/related?jobs=lustre-reviews&builds=126848#redirect

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
