### PR TITLE
Trivial backport of #18645 (freebsd: set mnt_time on the rootfs at mountroot time)

### DIFF
--- a/include/zfs_crrd.h
+++ b/include/zfs_crrd.h
@@ -71,5 +71,6 @@ void rrd_add(rrd_t *rrd, hrtime_t time, uint64_t txg);
 
 void dbrrd_add(dbrrd_t *db, hrtime_t time, uint64_t txg);
 uint64_t dbrrd_query(dbrrd_t *r, hrtime_t tv, dbrrd_rounding_t rouding);
+hrtime_t dbrrd_latest_time(dbrrd_t *r);
 
 #endif

--- a/include/zfs_crrd.h
+++ b/include/zfs_crrd.h
@@ -60,12 +60,12 @@ typedef struct {
 	rrd_t		dbr_months;
 } dbrrd_t;
 
-size_t rrd_len(rrd_t *rrd);
+size_t rrd_len(const rrd_t *rrd);
 
-const rrd_data_t *rrd_entry(rrd_t *r, size_t i);
+const rrd_data_t *rrd_entry(const rrd_t *r, size_t i);
 rrd_data_t *rrd_tail_entry(rrd_t *rrd);
 uint64_t rrd_tail(rrd_t *rrd);
-uint64_t rrd_get(rrd_t *rrd, size_t i);
+uint64_t rrd_get(const rrd_t *rrd, size_t i);
 
 void rrd_add(rrd_t *rrd, hrtime_t time, uint64_t txg);
 

--- a/module/os/freebsd/zfs/zfs_vfsops.c
+++ b/module/os/freebsd/zfs/zfs_vfsops.c
@@ -51,7 +51,7 @@
 #include <sys/dsl_prop.h>
 #include <sys/dsl_dataset.h>
 #include <sys/dsl_deleg.h>
-#include <sys/spa.h>
+#include <sys/spa_impl.h>
 #include <sys/zap.h>
 #include <sys/sa.h>
 #include <sys/sa_impl.h>
@@ -69,6 +69,7 @@
 #include <sys/zfs_quota.h>
 
 #include "zfs_comutil.h"
+#include "zfs_crrd.h"
 
 #ifndef	MNTK_VMSETSIZE_BUG
 #define	MNTK_VMSETSIZE_BUG	0
@@ -1315,7 +1316,12 @@ out:
 		dmu_objset_disown(zfsvfs->z_os, B_TRUE, zfsvfs);
 		zfsvfs_free(zfsvfs);
 	} else {
+		spa_t *spa = zfsvfs->z_os->os_spa;
+
 		atomic_inc_32(&zfs_active_fs_count);
+
+		vfsp->mnt_time = dbrrd_latest_time(&spa->spa_txg_log_time);
+		vfsp->mnt_time = MAX(vfsp->mnt_time, spa->spa_load_txg_ts);
 	}
 
 	return (error);

--- a/module/zfs/zfs_crrd.c
+++ b/module/zfs/zfs_crrd.c
@@ -226,3 +226,19 @@ dbrrd_query(dbrrd_t *r, hrtime_t tv, dbrrd_rounding_t rounding)
 
 	return (data == NULL ? 0 : data->rrdd_txg);
 }
+
+hrtime_t
+dbrrd_latest_time(dbrrd_t *r)
+{
+	const rrd_data_t *head;
+	const rrd_t *curdb;
+	size_t dblen;
+
+	curdb = &r->dbr_minutes;
+	dblen = rrd_len(curdb);
+	if (dblen == 0)
+		return (0);
+
+	head = rrd_entry(curdb, dblen - 1);
+	return (head->rrdd_time);
+}

--- a/module/zfs/zfs_crrd.c
+++ b/module/zfs/zfs_crrd.c
@@ -99,14 +99,14 @@ rrd_tail(rrd_t *rrd)
  * rrd_get works from 0..rrd_len()-1.
  */
 size_t
-rrd_len(rrd_t *rrd)
+rrd_len(const rrd_t *rrd)
 {
 
 	return (rrd->rrd_length);
 }
 
 const rrd_data_t *
-rrd_entry(rrd_t *rrd, size_t i)
+rrd_entry(const rrd_t *rrd, size_t i)
 {
 	size_t n;
 
@@ -119,7 +119,7 @@ rrd_entry(rrd_t *rrd, size_t i)
 }
 
 uint64_t
-rrd_get(rrd_t *rrd, size_t i)
+rrd_get(const rrd_t *rrd, size_t i)
 {
 	const rrd_data_t *data = rrd_entry(rrd, i);
 


### PR DESCRIPTION
The appliance that motivated the change is based on FreeBSD 15.x, so it'd be quite useful to get this back into ZFS 2.4.4 / FreeBSD 15.2 (late 2026 / early 2027).  No conflicts in backporting and FreeBSD's `mnt_time` has been in FreeBSD's `struct mount` for ~31 years, so this should build everywhere without a problem.