### PR TITLE
CI: Increase default watchdog NMI timeout on Linux

### DIFF
--- a/.github/workflows/scripts/qemu-6-tests.sh
+++ b/.github/workflows/scripts/qemu-6-tests.sh
@@ -187,11 +187,15 @@ case "$OS" in
     sudo chmod 1777 /var/tmp
     sudo mv -f /tmp/*.txt /var/tmp
 
-    # Allow for longer RCU timeouts due to the heavily virtualized and
-    # potentially oversubscribed nature of the CI environment.
+    # Allow for longer RCU and watchdog timeouts due to the heavily virtualized
+    # and potentially over-subscribed nature of the CI environment.
     rcu_cpu_stall_timeout="/sys/module/rcupdate/parameters/rcu_cpu_stall_timeout"
     if test -f $rcu_cpu_stall_timeout; then
         echo 120 | sudo sh -c "cat > '$rcu_cpu_stall_timeout'"
+    fi
+
+    if test -c /dev/watchdog; then
+        sudo wdctl --settimeout 120 >/dev/null
     fi
     ;;
 esac


### PR DESCRIPTION
### Motivation and Context

I've noticed on several occasions the pretimeout watchdog has been triggered for CI runs.

https://github.com/openzfs/zfs/actions/runs/28168449226/job/83498569930?pr=18573

### Description

When the watchdog driver is configured and enabled an NMI will be generated when the watchdogd process fails to reguarly reset the watchdog timer.  Given the heavily virtualized and potentially over-subscribed nature of the CI environment increase the default timeout to 120 seconds (normally defaults to 30 seconds).
    
### How Has This Been Tested?

Will be tested by the CI.  This doesn't happen often so we'll have to see if waiting a bit longer is sufficient to prevent it.  We could disable it entirely, but for now I'd prevent to increase the timeout to facilitate getting proper backtraces for legitimate issues.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)