### PR TITLE
ZTS: uutils compat

### DIFF
--- a/tests/zfs-tests/tests/functional/devices/devices_common.kshlib
+++ b/tests/zfs-tests/tests/functional/devices/devices_common.kshlib
@@ -54,9 +54,9 @@ function create_dev_file
 			# %t - major device type in hex
 			# %T - minor device type in hex
 			#
-			major=$(stat --dereference --format="%t" "$devstr")
-			minor=$(stat --dereference --format="%T" "$devstr")
-			log_must mknod $filename b "0x${major}" "0x${minor}"
+			major=$(printf '%d' 0x$(stat -L -c "%t" "$devstr"))
+			minor=$(printf '%d' 0x$(stat -L -c "%T" "$devstr"))
+			log_must mknod $filename b "${major}" "${minor}"
 			;;
 		*)
 			#
@@ -83,9 +83,9 @@ function create_dev_file
 			# %t - major device type in hex
 			# %T - minor device type in hex
 			#
-			major=$(stat --format="%t" /dev/null)
-			minor=$(stat --format="%T" /dev/null)
-			log_must mknod $filename c "0x${major}" "0x${minor}"
+			major=$(printf '%d' 0x$(stat -c "%t" /dev/null))
+			minor=$(printf '%d' 0x$(stat -c "%T" /dev/null))
+			log_must mknod $filename c "${major}" "${minor}"
 			;;
 		FreeBSD)
 			#

--- a/tests/zfs-tests/tests/functional/stat/statx_dioalign.ksh
+++ b/tests/zfs-tests/tests/functional/stat/statx_dioalign.ksh
@@ -89,7 +89,8 @@ typeset -i PAGE_SIZE=$(getconf PAGE_SIZE)
 # Set recordsize to 128K, and make a 64K file (so only one block) for the
 # sizing tests below.
 log_must zfs set recordsize=128K $TESTDS
-log_must dd if=/dev/urandom of=$TESTFILE bs=64k count=1
+log_must rm -f $TESTFILE
+log_must stride_dd -i /dev/urandom -o $TESTFILE -b 65536 -c 1
 log_must zpool sync
 
 # when DIO is disabled via tunable, statx will not return the dioalign result
@@ -141,7 +142,7 @@ done
 # Now we extend the file into its second block. This effectively locks in its
 # block size, which will always be returned regardless of recordsize changes.
 log_must zfs set recordsize=128K $TESTDS
-log_must dd if=/dev/urandom of=$TESTFILE bs=192K count=1
+log_must stride_dd -i /dev/urandom -o $TESTFILE -b 196608 -c 1
 log_must zpool sync
 
 # Confirm that no matter how we change the recordsize, the alignment remains at
@@ -167,14 +168,14 @@ log_must rm -f $TESTFILE
 log_must touch $TESTFILE
 log_must zpool sync
 assert_dioalign $TESTFILE $PAGE_SIZE 16384
-log_must dd if=/dev/urandom of=$TESTFILE bs=16384 count=16 oflag=direct
+log_must stride_dd -i /dev/urandom -o $TESTFILE -b 16384 -c 16 -D
 
 # same again, but writing with incorrect alignment, which should fail.
 log_must rm -f $TESTFILE
 log_must touch $TESTFILE
 log_must zpool sync
 assert_dioalign $TESTFILE $PAGE_SIZE 16384
-log_mustnot dd if=/dev/urandom of=$TESTFILE bs=1024 count=256 oflag=direct
+log_mustnot stride_dd -i /dev/urandom -o $TESTFILE -b 1024 -c 256 -D
 
 # same again, but without strict, which should succeed.
 log_must set_tunable32 DIO_STRICT 0
@@ -182,6 +183,6 @@ log_must rm -f $TESTFILE
 log_must touch $TESTFILE
 log_must zpool sync
 assert_dioalign $TESTFILE $PAGE_SIZE 16384
-log_must dd if=/dev/urandom of=$TESTFILE bs=1024 count=256 oflag=direct
+log_must stride_dd -i /dev/urandom -o $TESTFILE -b 1024 -c 256 -D
 
 log_pass $CLAIM


### PR DESCRIPTION
### Motivation and Context

Changes required to get the CI passing cleanly for systems using uutils instead of coreutils.

### Description

Backport of two minor changes for uutils compatibility:

912e78697e ZTS: statx_dioalign.ksh update to stride_dd
395305ca3b ZTS: Pass dec instead of hex to mknod

### How Has This Been Tested?

Clean cherry-picks from master.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)
