### PR TITLE
snapdir: misc cleanups

### DIFF
--- a/include/os/freebsd/zfs/sys/zfs_ctldir.h
+++ b/include/os/freebsd/zfs/sys/zfs_ctldir.h
@@ -49,7 +49,7 @@ int zfsctl_root(zfsvfs_t *, int, vnode_t **);
 void zfsctl_init(void);
 void zfsctl_fini(void);
 boolean_t zfsctl_is_node(vnode_t *);
-int zfsctl_snapshot_unmount(const char *snapname, int flags);
+int zfsctl_snapshot_unmount(const char *snapname);
 int zfsctl_rename_snapshot(const char *from, const char *to);
 int zfsctl_destroy_snapshot(const char *snapname, int force);
 int zfsctl_umount_snapshots(vfs_t *, int, cred_t *);

--- a/include/os/linux/zfs/sys/zfs_ctldir.h
+++ b/include/os/linux/zfs/sys/zfs_ctldir.h
@@ -77,8 +77,7 @@ extern int zfsctl_snapdir_mkdir(struct inode *dip, const char *dirname,
     vattr_t *vap, struct inode **ipp, cred_t *cr, int flags);
 extern int zfsctl_snapshot_mount(struct path *path, int flags);
 extern int zfsctl_snapshot_unmount(const char *snapname, int flags);
-extern int zfsctl_snapshot_unmount_delay(spa_t *spa, uint64_t objsetid,
-    int delay);
+extern int zfsctl_snapshot_unmount_delay(spa_t *spa, uint64_t objsetid);
 extern int zfsctl_snapdir_vget(struct super_block *sb, uint64_t objsetid,
     int gen, struct inode **ipp);
 

--- a/include/os/linux/zfs/sys/zfs_ctldir.h
+++ b/include/os/linux/zfs/sys/zfs_ctldir.h
@@ -75,7 +75,7 @@ extern int zfsctl_snapdir_remove(struct inode *dip, const char *name,
     cred_t *cr, int flags);
 extern int zfsctl_snapdir_mkdir(struct inode *dip, const char *dirname,
     vattr_t *vap, struct inode **ipp, cred_t *cr, int flags);
-extern int zfsctl_snapshot_mount(struct path *path, int flags);
+extern int zfsctl_snapshot_mount(struct path *path);
 extern int zfsctl_snapshot_unmount(const char *snapname);
 extern int zfsctl_snapshot_unmount_delay(spa_t *spa, uint64_t objsetid);
 extern int zfsctl_snapdir_vget(struct super_block *sb, uint64_t objsetid,

--- a/include/os/linux/zfs/sys/zfs_ctldir.h
+++ b/include/os/linux/zfs/sys/zfs_ctldir.h
@@ -76,7 +76,7 @@ extern int zfsctl_snapdir_remove(struct inode *dip, const char *name,
 extern int zfsctl_snapdir_mkdir(struct inode *dip, const char *dirname,
     vattr_t *vap, struct inode **ipp, cred_t *cr, int flags);
 extern int zfsctl_snapshot_mount(struct path *path, int flags);
-extern int zfsctl_snapshot_unmount(const char *snapname, int flags);
+extern int zfsctl_snapshot_unmount(const char *snapname);
 extern int zfsctl_snapshot_unmount_delay(spa_t *spa, uint64_t objsetid);
 extern int zfsctl_snapdir_vget(struct super_block *sb, uint64_t objsetid,
     int gen, struct inode **ipp);

--- a/module/os/freebsd/zfs/zfs_ctldir.c
+++ b/module/os/freebsd/zfs/zfs_ctldir.c
@@ -1370,7 +1370,7 @@ zfsctl_umount_snapshots(vfs_t *vfsp, int fflags, cred_t *cr)
 }
 
 int
-zfsctl_snapshot_unmount(const char *snapname, int flags __unused)
+zfsctl_snapshot_unmount(const char *snapname)
 {
 	vfs_t *vfsp = NULL;
 	zfsvfs_t *zfsvfs = NULL;

--- a/module/os/linux/zfs/zfs_ctldir.c
+++ b/module/os/linux/zfs/zfs_ctldir.c
@@ -136,8 +136,7 @@ static void zfsctl_snapshot_unmount_delay_impl(zfs_snapentry_t *se, int delay);
  * the snapshot name and provided mount point.  No reference is taken.
  */
 static zfs_snapentry_t *
-zfsctl_snapshot_alloc(const char *full_name, const char *full_path, spa_t *spa,
-    uint64_t objsetid)
+zfsctl_snapshot_alloc(const char *full_name, const char *full_path)
 {
 	zfs_snapentry_t *se;
 
@@ -145,8 +144,6 @@ zfsctl_snapshot_alloc(const char *full_name, const char *full_path, spa_t *spa,
 
 	se->se_name = kmem_strdup(full_name);
 	se->se_path = kmem_strdup(full_path);
-	se->se_spa = spa;
-	se->se_objsetid = objsetid;
 	se->se_taskqid = TASKQID_INVALID;
 	mutex_init(&se->se_mtx, NULL, MUTEX_DEFAULT, NULL);
 	cv_init(&se->se_cv, NULL, CV_DEFAULT, NULL);
@@ -1302,7 +1299,7 @@ zfsctl_snapshot_mount(struct path *path, int flags)
 	/*
 	 * Create pending entry and mark mount in progress.
 	 */
-	se = zfsctl_snapshot_alloc(full_name, full_path, NULL, 0);
+	se = zfsctl_snapshot_alloc(full_name, full_path);
 	se->se_mounting = B_TRUE;
 	zfsctl_snapshot_add(se);
 	zfsctl_snapshot_hold(se);

--- a/module/os/linux/zfs/zfs_ctldir.c
+++ b/module/os/linux/zfs/zfs_ctldir.c
@@ -595,7 +595,7 @@ zfsctl_destroy(zfsvfs_t *zfsvfs)
 {
 	if (zfsvfs->z_issnap) {
 		zfs_snapentry_t *se;
-		spa_t *spa = zfsvfs->z_os->os_spa;
+		spa_t *spa = dmu_objset_spa(zfsvfs->z_os);
 		uint64_t objsetid = dmu_objset_id(zfsvfs->z_os);
 
 		rw_enter(&zfs_snapshot_lock, RW_WRITER);
@@ -1367,7 +1367,7 @@ zfsctl_snapshot_mount(struct path *path, int flags)
 		spath.mnt->mnt_flags |= MNT_SHRINKABLE;
 
 		rw_enter(&zfs_snapshot_lock, RW_WRITER);
-		zfsctl_snapshot_fill(se, snap_zfsvfs->z_os->os_spa,
+		zfsctl_snapshot_fill(se, dmu_objset_spa(snap_zfsvfs->z_os),
 		    dmu_objset_id(snap_zfsvfs->z_os));
 		zfsctl_snapshot_unmount_delay_impl(se, zfs_expire_snapshot);
 		rw_exit(&zfs_snapshot_lock);
@@ -1415,7 +1415,8 @@ zfsctl_snapdir_vget(struct super_block *sb, uint64_t objsetid, int gen,
 	 * snapshots, falling back to the on-disk scan if not found.
 	 */
 	rw_enter(&zfs_snapshot_lock, RW_READER);
-	se = zfsctl_snapshot_find_by_objsetid(zfsvfs->z_os->os_spa, objsetid);
+	se = zfsctl_snapshot_find_by_objsetid(
+	    dmu_objset_spa(zfsvfs->z_os), objsetid);
 	rw_exit(&zfs_snapshot_lock);
 	if (se != NULL) {
 		strlcpy(mnt, se->se_path, MAXPATHLEN);

--- a/module/os/linux/zfs/zfs_ctldir.c
+++ b/module/os/linux/zfs/zfs_ctldir.c
@@ -119,7 +119,6 @@ typedef struct {
 	char		*se_path;	/* full mount path */
 	spa_t		*se_spa;	/* pool spa (NULL if pending) */
 	uint64_t	se_objsetid;	/* snapshot objset id */
-	struct dentry   *se_root_dentry; /* snapshot root dentry */
 	taskqid_t	se_taskqid;	/* scheduled unmount taskqid */
 	avl_node_t	se_node_name;	/* zfs_snapshots_by_name link */
 	avl_node_t	se_node_objsetid; /* zfs_snapshots_by_objsetid link */
@@ -138,7 +137,7 @@ static void zfsctl_snapshot_unmount_delay_impl(zfs_snapentry_t *se, int delay);
  */
 static zfs_snapentry_t *
 zfsctl_snapshot_alloc(const char *full_name, const char *full_path, spa_t *spa,
-    uint64_t objsetid, struct dentry *root_dentry)
+    uint64_t objsetid)
 {
 	zfs_snapentry_t *se;
 
@@ -148,7 +147,6 @@ zfsctl_snapshot_alloc(const char *full_name, const char *full_path, spa_t *spa,
 	se->se_path = kmem_strdup(full_path);
 	se->se_spa = spa;
 	se->se_objsetid = objsetid;
-	se->se_root_dentry = root_dentry;
 	se->se_taskqid = TASKQID_INVALID;
 	mutex_init(&se->se_mtx, NULL, MUTEX_DEFAULT, NULL);
 	cv_init(&se->se_cv, NULL, CV_DEFAULT, NULL);
@@ -232,14 +230,12 @@ zfsctl_snapshot_remove(zfs_snapentry_t *se)
  * remaining fields and adds the entry to the zfs_snapshots_by_objsetid tree.
  */
 static void
-zfsctl_snapshot_fill(zfs_snapentry_t *se, spa_t *spa, uint64_t objsetid,
-    struct dentry *root_dentry)
+zfsctl_snapshot_fill(zfs_snapentry_t *se, spa_t *spa, uint64_t objsetid)
 {
 	ASSERT(RW_WRITE_HELD(&zfs_snapshot_lock));
 	ASSERT3P(se->se_spa, ==, NULL);
 	se->se_spa = spa;
 	se->se_objsetid = objsetid;
-	se->se_root_dentry = root_dentry;
 	avl_add(&zfs_snapshots_by_objsetid, se);
 }
 
@@ -1306,7 +1302,7 @@ zfsctl_snapshot_mount(struct path *path, int flags)
 	/*
 	 * Create pending entry and mark mount in progress.
 	 */
-	se = zfsctl_snapshot_alloc(full_name, full_path, NULL, 0, NULL);
+	se = zfsctl_snapshot_alloc(full_name, full_path, NULL, 0);
 	se->se_mounting = B_TRUE;
 	zfsctl_snapshot_add(se);
 	zfsctl_snapshot_hold(se);
@@ -1375,7 +1371,7 @@ zfsctl_snapshot_mount(struct path *path, int flags)
 
 		rw_enter(&zfs_snapshot_lock, RW_WRITER);
 		zfsctl_snapshot_fill(se, snap_zfsvfs->z_os->os_spa,
-		    dmu_objset_id(snap_zfsvfs->z_os), dentry);
+		    dmu_objset_id(snap_zfsvfs->z_os));
 		zfsctl_snapshot_unmount_delay_impl(se, zfs_expire_snapshot);
 		rw_exit(&zfs_snapshot_lock);
 	} else {

--- a/module/os/linux/zfs/zfs_ctldir.c
+++ b/module/os/linux/zfs/zfs_ctldir.c
@@ -1166,7 +1166,7 @@ zfsctl_snapshot_unmount(const char *snapname)
 }
 
 int
-zfsctl_snapshot_mount(struct path *path, int flags)
+zfsctl_snapshot_mount(struct path *path)
 {
 	struct dentry *dentry = path->dentry;
 	struct inode *ip = dentry->d_inode;

--- a/module/os/linux/zfs/zfs_ctldir.c
+++ b/module/os/linux/zfs/zfs_ctldir.c
@@ -1180,8 +1180,7 @@ zfsctl_snapshot_mount(struct path *path)
 	int error;
 	struct path spath;
 
-	if (ip == NULL)
-		return (SET_ERROR(EISDIR));
+	ASSERT3P(ip, !=, NULL);
 
 	zfsvfs = ITOZSB(ip);
 	if ((error = zfs_enter(zfsvfs, FTAG)) != 0)

--- a/module/os/linux/zfs/zfs_ctldir.c
+++ b/module/os/linux/zfs/zfs_ctldir.c
@@ -129,7 +129,7 @@ typedef struct {
 	int		se_mount_error;	/* error from failed mount */
 } zfs_snapentry_t;
 
-static void zfsctl_snapshot_unmount_delay_impl(zfs_snapentry_t *se, int delay);
+static void zfsctl_snapshot_unmount_delay_impl(zfs_snapentry_t *se);
 
 /*
  * Allocate a new zfs_snapentry_t being careful to make a copy of the
@@ -359,7 +359,7 @@ snapentry_expire(void *data)
 	se->se_taskqid = TASKQID_INVALID;
 	zfsctl_snapshot_rele(se);
 	if ((se = zfsctl_snapshot_find_by_objsetid(spa, objsetid)) != NULL) {
-		zfsctl_snapshot_unmount_delay_impl(se, zfs_expire_snapshot);
+		zfsctl_snapshot_unmount_delay_impl(se);
 		zfsctl_snapshot_rele(se);
 	}
 	rw_exit(&zfs_snapshot_lock);
@@ -393,11 +393,11 @@ zfsctl_snapshot_unmount_cancel(zfs_snapentry_t *se)
  * Dispatch the unmount task for delayed handling with a hold protecting it.
  */
 static void
-zfsctl_snapshot_unmount_delay_impl(zfs_snapentry_t *se, int delay)
+zfsctl_snapshot_unmount_delay_impl(zfs_snapentry_t *se)
 {
 	ASSERT(RW_LOCK_HELD(&zfs_snapshot_lock));
 
-	if (delay <= 0)
+	if (zfs_expire_snapshot <= 0)
 		return;
 
 	/*
@@ -415,7 +415,8 @@ zfsctl_snapshot_unmount_delay_impl(zfs_snapentry_t *se, int delay)
 
 	zfsctl_snapshot_hold(se);
 	se->se_taskqid = taskq_dispatch_delay(system_delay_taskq,
-	    snapentry_expire, se, TQ_SLEEP, ddi_get_lbolt() + delay * HZ);
+	    snapentry_expire, se, TQ_SLEEP,
+	    ddi_get_lbolt() + zfs_expire_snapshot * HZ);
 }
 
 /*
@@ -425,7 +426,7 @@ zfsctl_snapshot_unmount_delay_impl(zfs_snapentry_t *se, int delay)
  * and held until the outstanding task is handled or cancelled.
  */
 int
-zfsctl_snapshot_unmount_delay(spa_t *spa, uint64_t objsetid, int delay)
+zfsctl_snapshot_unmount_delay(spa_t *spa, uint64_t objsetid)
 {
 	zfs_snapentry_t *se;
 	int error = ENOENT;
@@ -433,7 +434,7 @@ zfsctl_snapshot_unmount_delay(spa_t *spa, uint64_t objsetid, int delay)
 	rw_enter(&zfs_snapshot_lock, RW_WRITER);
 	if ((se = zfsctl_snapshot_find_by_objsetid(spa, objsetid)) != NULL) {
 		zfsctl_snapshot_unmount_cancel(se);
-		zfsctl_snapshot_unmount_delay_impl(se, delay);
+		zfsctl_snapshot_unmount_delay_impl(se);
 		zfsctl_snapshot_rele(se);
 		error = 0;
 	}
@@ -1369,7 +1370,7 @@ zfsctl_snapshot_mount(struct path *path, int flags)
 		rw_enter(&zfs_snapshot_lock, RW_WRITER);
 		zfsctl_snapshot_fill(se, dmu_objset_spa(snap_zfsvfs->z_os),
 		    dmu_objset_id(snap_zfsvfs->z_os));
-		zfsctl_snapshot_unmount_delay_impl(se, zfs_expire_snapshot);
+		zfsctl_snapshot_unmount_delay_impl(se);
 		rw_exit(&zfs_snapshot_lock);
 	} else {
 		rw_enter(&zfs_snapshot_lock, RW_WRITER);

--- a/module/os/linux/zfs/zfs_ctldir.c
+++ b/module/os/linux/zfs/zfs_ctldir.c
@@ -349,7 +349,7 @@ snapentry_expire(void *data)
 		return;
 	}
 
-	(void) zfsctl_snapshot_unmount(se->se_name, MNT_EXPIRE);
+	(void) zfsctl_snapshot_unmount(se->se_name);
 
 	/*
 	 * Clear taskqid and reschedule if the snapshot wasn't removed.
@@ -973,7 +973,7 @@ zfsctl_snapdir_remove(struct inode *dip, const char *name, cred_t *cr,
 	if (error != 0)
 		goto out;
 
-	error = zfsctl_snapshot_unmount(snapname, MNT_FORCE);
+	error = zfsctl_snapshot_unmount(snapname);
 	if ((error == 0) || (error == ENOENT))
 		error = dsl_destroy_snapshot(snapname, B_FALSE);
 out:
@@ -1110,7 +1110,7 @@ is_current_chrooted(void)
  * it's in use, the unmount will fail harmlessly.
  */
 int
-zfsctl_snapshot_unmount(const char *snapname, int flags)
+zfsctl_snapshot_unmount(const char *snapname)
 {
 	char *argv[] = { "/usr/bin/env", "umount", "-t", "zfs", "-n", NULL,
 	    NULL };
@@ -1133,8 +1133,6 @@ zfsctl_snapshot_unmount(const char *snapname, int flags)
 		cv_wait(&se->se_cv, &se->se_mtx);
 	mutex_exit(&se->se_mtx);
 
-	if (flags & MNT_FORCE)
-		argv[4] = "-fn";
 	argv[5] = se->se_path;
 	dprintf("unmount; path=%s\n", se->se_path);
 	error = call_usermodehelper(argv[0], argv, envp, UMH_WAIT_PROC);

--- a/module/os/linux/zfs/zfs_vfsops.c
+++ b/module/os/linux/zfs/zfs_vfsops.c
@@ -1892,9 +1892,8 @@ zfs_exit_fs(zfsvfs_t *zfsvfs)
 	if (time_after(jiffies, zfsvfs->z_snap_defer_time +
 	    MAX(zfs_expire_snapshot * HZ / 2, HZ))) {
 		zfsvfs->z_snap_defer_time = jiffies;
-		zfsctl_snapshot_unmount_delay(zfsvfs->z_os->os_spa,
-		    dmu_objset_id(zfsvfs->z_os),
-		    zfs_expire_snapshot);
+		zfsctl_snapshot_unmount_delay(dmu_objset_spa(zfsvfs->z_os),
+		    dmu_objset_id(zfsvfs->z_os), zfs_expire_snapshot);
 	}
 }
 

--- a/module/os/linux/zfs/zfs_vfsops.c
+++ b/module/os/linux/zfs/zfs_vfsops.c
@@ -1893,7 +1893,7 @@ zfs_exit_fs(zfsvfs_t *zfsvfs)
 	    MAX(zfs_expire_snapshot * HZ / 2, HZ))) {
 		zfsvfs->z_snap_defer_time = jiffies;
 		zfsctl_snapshot_unmount_delay(dmu_objset_spa(zfsvfs->z_os),
-		    dmu_objset_id(zfsvfs->z_os), zfs_expire_snapshot);
+		    dmu_objset_id(zfsvfs->z_os));
 	}
 }
 

--- a/module/os/linux/zfs/zpl_ctldir.c
+++ b/module/os/linux/zfs/zpl_ctldir.c
@@ -192,10 +192,10 @@ zpl_snapdir_automount(struct path *path)
 }
 
 /*
- * Negative dentries must always be revalidated so newly created snapshots
- * can be detected and automounted.  Normal dentries should be kept because
- * as of the 3.18 kernel revaliding the mountpoint dentry will result in
- * the snapshot being immediately unmounted.
+ * Negative dentries must always be revalidated so newly created snapshots can
+ * be detected and automounted.  Normal dentries should be kept because
+ * revalidating the mountpoint dentry will result in the snapshot being
+ * immediately unmounted.
  */
 #ifdef HAVE_D_REVALIDATE_4ARGS
 static int
@@ -210,14 +210,6 @@ zpl_snapdir_revalidate(struct dentry *dentry, unsigned int flags)
 }
 
 static const struct dentry_operations zpl_dops_snapdirs = {
-/*
- * Auto mounting of snapshots is only supported for 2.6.37 and
- * newer kernels.  Prior to this kernel the ops->follow_link()
- * callback was used as a hack to trigger the mount.  The
- * resulting vfsmount was then explicitly grafted in to the
- * name space.  While it might be possible to add compatibility
- * code to accomplish this it would require considerable care.
- */
 	.d_automount	= zpl_snapdir_automount,
 	.d_revalidate	= zpl_snapdir_revalidate,
 };

--- a/module/os/linux/zfs/zpl_ctldir.c
+++ b/module/os/linux/zfs/zpl_ctldir.c
@@ -168,6 +168,13 @@ const struct inode_operations zpl_ops_root = {
 static struct vfsmount *
 zpl_snapdir_automount(struct path *path)
 {
+	/*
+	 * Negative dentry (eg after zpl_snapdir_rmdir()) that still has
+	 * our dops set. Do nothing.
+	 */
+	if (!path->dentry->d_inode)
+		return (ERR_PTR(-SET_ERROR(EISDIR)));
+
 	int error;
 
 	error = -zfsctl_snapshot_mount(path);

--- a/module/os/linux/zfs/zpl_ctldir.c
+++ b/module/os/linux/zfs/zpl_ctldir.c
@@ -170,7 +170,7 @@ zpl_snapdir_automount(struct path *path)
 {
 	int error;
 
-	error = -zfsctl_snapshot_mount(path, 0);
+	error = -zfsctl_snapshot_mount(path);
 	if (error)
 		return (ERR_PTR(error));
 

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -4282,7 +4282,7 @@ zfs_unmount_snap(const char *snapname)
 	if (strchr(snapname, '@') == NULL)
 		return;
 
-	(void) zfsctl_snapshot_unmount(snapname, MNT_FORCE);
+	(void) zfsctl_snapshot_unmount(snapname);
 }
 
 static int


### PR DESCRIPTION
_[Sponsors: TrueNAS]_

### Motivation and Context

A bunch of cleanups in the Linux snapdir code that will make the rewrite I'm about to submit much easier to follow but also stand on their own.

### Description

See individual commits.

### How Has This Been Tested?

Compile checked on: 5.4.302, 5.10.253, 5.15.203, 6.1.169, 6.6.136, 6.12.84, 6.18.25, 7.0.8.

ZTS run completed: 6.12.86.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
