### PR TITLE
ZTS: l2arc_multidev_throughput_pos relax throughput window

### DIFF
--- a/tests/zfs-tests/tests/functional/l2arc/l2arc_multidev_throughput_pos.ksh
+++ b/tests/zfs-tests/tests/functional/l2arc/l2arc_multidev_throughput_pos.ksh
@@ -31,7 +31,7 @@
 #	2. Create pool without cache devices, fill ARC to arc_max.
 #	3. Add 2 cache devices after ARC is full and stable.
 #	4. Measure L2ARC throughput over 3 consecutive windows.
-#	5. Verify throughput remains stable (no window drops below 50%
+#	5. Verify throughput remains stable (no window drops below 40%
 #	   of the first).
 #
 
@@ -126,12 +126,12 @@ if [[ ${window_bytes[1]} -le 0 ]]; then
 	log_fail "No L2ARC writes in first window"
 fi
 
-# Each subsequent window must be at least 50% of the first
-typeset min_bytes=$((window_bytes[1] * 50 / 100))
+# Each subsequent window must be at least 40% of the first
+typeset min_bytes=$((window_bytes[1] * 40 / 100))
 for w in $(seq 2 $num_windows); do
 	if [[ ${window_bytes[$w]} -lt $min_bytes ]]; then
 		log_fail "Window $w ($((window_bytes[$w] / 1024 / 1024))MB)" \
-		    "degraded below 50% of window 1" \
+		    "degraded below 40% of window 1" \
 		    "($((window_bytes[1] / 1024 / 1024))MB)"
 	fi
 done


### PR DESCRIPTION
### Motivation and Context

Occasional CI false positives.

https://github.com/openzfs/zfs/actions/runs/28524563173/job/84557434443?pr=18713

```
   [2026-07-01T12:13:28.677847] Test: /usr/share/zfs/zfs-tests/tests/functional/l2arc/l2arc_multidev_throughput_pos (run as root) [01:09] [FAIL]
  12:12:19.41 ASSERTION: L2ARC parallel writes sustain throughput without degradation.
  12:12:19.41 67108864
  12:12:19.42 1
  12:12:19.42 100
  12:12:19.43 25
  12:12:19.43 0
  12:12:19.43 0
  12:12:19.43 SUCCESS: set_tunable32 L2ARC_DWPD_LIMIT 0
  12:12:19.44 SUCCESS: set_tunable64 L2ARC_EXT_HEADROOM_PCT 0
  12:12:19.44 SUCCESS: set_tunable32 L2ARC_WRITE_MAX 4194304
  12:12:19.44 SUCCESS: set_tunable32 L2ARC_NOPREFETCH 0
  12:12:19.44 SUCCESS: set_tunable64 ARC_MAX 996147200
  12:12:19.45 SUCCESS: set_tunable64 ARC_MIN 536870912
  12:12:19.45 SUCCESS: truncate -s 5G /var/tmp/testdir/disk.l2arc/a
  12:12:19.52 SUCCESS: zpool create -f testpool /var/tmp/testdir/disk.l2arc/a
  12:12:27.68 SUCCESS: dd if=/dev/urandom of=/testpool/file1 bs=1M count=950
  12:12:27.90 SUCCESS: zpool sync testpool
  12:12:27.91 SUCCESS: truncate -s 3072M /var/tmp/testdir/disk.l2arc/e
  12:12:27.92 SUCCESS: truncate -s 3072M /var/tmp/testdir/disk.l2arc/f
  12:12:28.01 SUCCESS: zpool add -f testpool cache /var/tmp/testdir/disk.l2arc/e /var/tmp/testdir/disk.l2arc/f
  12:12:39.07 SUCCESS: sleep 10
  12:12:39.08 NOTE: Window 1: 118MB
  12:12:49.58 SUCCESS: sleep 10
  12:12:50.21 NOTE: Window 2: 145MB
  12:13:25.50 SUCCESS: sleep 10
  12:13:26.36 NOTE: Window 3: 52MB
  12:13:26.36 Window 3 (52MB) degraded below 50% of window 1 (118MB)
```

### Description

Occasionally in the CI this test will fail because the throughput for one of the windows drops slightly below 50%.  This is likely due to running in the virtualized CI environment.  Drop the performance cutoff from 50% to 40% to try and reduce the number of false positives.

If this tweak ends up being insufficient we could look at updating the test to something like verify 4/5 windows tested are over 50%.  But for now I wanted to keep it as simple as possible.  @ixhamza can you review this.  I'm open to other approaches, but I'm seeing this a fair bit so I'd like to get it sorted it out.

### How Has This Been Tested?

Will be tested by the CI.  We'll have to see after merging it how much the incidence rate in the CI drops.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)
