### PR TITLE
ZTS: Update zts-report.py.in exceptions

### DIFF
--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -270,15 +270,6 @@ maybe = {
 
 if sys.platform.startswith('freebsd'):
     maybe.update({
-        'cli_root/zfs_copies/zfs_copies_002_pos': ['FAIL', known_reason],
-        'cli_root/zfs_inherit/zfs_inherit_001_neg': ['FAIL', known_reason],
-        'cli_root/zpool_import/zpool_import_012_pos': ['FAIL', known_reason],
-        'delegate/zfs_allow_003_pos': ['FAIL', known_reason],
-        'inheritance/inherit_001_pos': ['FAIL', 11829],
-        'pool_checkpoint/checkpoint_big_rewind': ['FAIL', 12622],
-        'pool_checkpoint/checkpoint_indirect': ['FAIL', 12623],
-        'resilver/resilver_restart_001': ['FAIL', known_reason],
-        'zvol/zvol_misc/zvol_misc_volmode': ['FAIL', 16668],
         'bclone/bclone_crossfs_corner_cases': ['SKIP', cfr_cross_reason],
         'bclone/bclone_crossfs_corner_cases_limited':
             ['SKIP', cfr_cross_reason],
@@ -295,7 +286,17 @@ if sys.platform.startswith('freebsd'):
             ['SKIP', cfr_cross_reason],
         'block_cloning/block_cloning_copyfilerange_cross_dataset':
             ['SKIP', cfr_cross_reason],
+        'cli_root/zfs_copies/zfs_copies_002_pos': ['FAIL', known_reason],
+        'cli_root/zfs_inherit/zfs_inherit_001_neg': ['FAIL', known_reason],
+        'cli_root/zpool_import/zpool_import_012_pos': ['FAIL', known_reason],
+        'delegate/zfs_allow_003_pos': ['FAIL', known_reason],
+        'inheritance/inherit_001_pos': ['FAIL', 11829],
+        'no_space/enospc_rm': ['FAIL', 18726],
+        'pool_checkpoint/checkpoint_big_rewind': ['FAIL', 12622],
+        'pool_checkpoint/checkpoint_indirect': ['FAIL', 12623],
+        'resilver/resilver_restart_001': ['FAIL', known_reason],
         'stat/statx_dioalign': ['SKIP', 'na_reason'],
+        'zvol/zvol_misc/zvol_misc_volmode': ['FAIL', 16668],
     })
 elif sys.platform.startswith('linux'):
     maybe.update({


### PR DESCRIPTION
### Motivation and Context

The goal is to update `zts-report.py.in` to reflect the reality of what's observed in the CI.  My intention in to iterate on this a bit and open issues as needed to track test failures and update the list accordingly.

### Description

Make another pass at updating the known exceptions list for spurious failures observed in the CI.  Changes include:

- `no_space/enospc_rm` added to FreeBSD 'maybe' list
- Alphabetized FreeBSD 'maybe' list

### How Has This Been Tested?

It has not.  Will be tested by the CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)
