### PR TITLE
ZTS: ctime_001_pos increase tolerance

### DIFF
--- a/tests/zfs-tests/cmd/ctime.c
+++ b/tests/zfs-tests/cmd/ctime.c
@@ -369,7 +369,7 @@ main(void)
 		 * a little slack in case of scheduling delays or similar.
 		 */
 		long delta = (long)t2 - (long)t1;
-		if (delta < 2 || delta > 4) {
+		if (delta < 2 || delta > 10) {
 			(void) fprintf(stderr,
 			    "%s: BAD time change: t1(%ld), t2(%ld)\n",
 			    timetest_table[i].name, (long)t1, (long)t2);


### PR DESCRIPTION
### Motivation and Context

Tweak the `ctime_001_pos` time to prevent another rare, but possible, false positive.

https://github.com/openzfs/zfs/actions/runs/28561881985/job/84681049480?pr=18718

```
  [2026-07-02T03:59:36.903236] Test: /usr/share/zfs/zfs-tests/tests/functional/ctime/ctime_001_pos (run as root) [00:43] [FAIL]
  03:58:53.43 NOTE: Verify [acm]time is modified appropriately.
  03:58:53.43 NOTE: Testing with xattr set to sa
  03:58:53.45 SUCCESS: zfs set xattr=sa testpool
  03:59:17.46 SUCCESS: ctime
  03:59:17.46 NOTE: Testing with xattr set to on
  03:59:17.48 SUCCESS: zfs set xattr=on testpool
  03:59:36.81 st_atime: good time change: t1(1782964757), t2(1782964759)
  03:59:36.81 st_atime: good time change: t1(1782964759), t2(1782964761)
  03:59:36.81 st_mtime: good time change: t1(1782964761), t2(1782964763)
  03:59:36.81 st_mtime: good time change: t1(1782964763), t2(1782964765)
  03:59:36.81 st_mtime: good time change: t1(1782964765), t2(1782964767)
  03:59:36.81 st_ctime: good time change: t1(1782964767), t2(1782964769)
  03:59:36.81 st_ctime: BAD time change: t1(1782964769), t2(1782964776)
  03:59:36.81 ERROR: ctime exited 1
```

### Description

The ctime_001_pos test checks that timestamp updates occur for a file after performing certain operations (read, write, chown, etc). The test case allowed for a +4 second tolerance in the timestamp value which is generous but up to +7 second discrepencies have been seen in the CI.  Bump the tolerance to +10 seconds to prevent these false positives.  As long as the value increases and is reasonably close to the expected value consider that to be sufficient.

### How Has This Been Tested?

It has not.  Will be tested by the CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)
