### PR TITLE
Remove idmap/userns concept from core & FreeBSD platform code

### DIFF
--- a/include/os/freebsd/Makefile.am
+++ b/include/os/freebsd/Makefile.am
@@ -83,6 +83,7 @@ noinst_HEADERS = \
 	%D%/zfs/sys/freebsd_event.h \
 	%D%/zfs/sys/trace_zfs.h \
 	%D%/zfs/sys/vdev_os.h \
+	%D%/zfs/sys/zfs_acl_impl.h \
 	%D%/zfs/sys/zfs_bootenv_os.h \
 	%D%/zfs/sys/zfs_context_os.h \
 	%D%/zfs/sys/zfs_ctldir.h \

--- a/include/os/freebsd/spl/sys/types.h
+++ b/include/os/freebsd/spl/sys/types.h
@@ -106,7 +106,5 @@ typedef	u_longlong_t	len_t;
 
 typedef	longlong_t	diskaddr_t;
 
-typedef void		zidmap_t;
-
 #include <sys/debug.h>
 #endif	/* !_OPENSOLARIS_SYS_TYPES_H_ */

--- a/include/os/freebsd/zfs/sys/zfs_acl_impl.h
+++ b/include/os/freebsd/zfs/sys/zfs_acl_impl.h
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: CDDL-1.0
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or https://opensource.org/licenses/CDDL-1.0.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, TrueNAS.
+ */
+
+#ifndef _ZFS_ACL_IMPL_H
+#define	_ZFS_ACL_IMPL_H
+
+#include <sys/zfs_acl.h>
+
+/*
+ * These functions are only called by FreeBSD platform-specific code. They have
+ * similar names and prototypes to other platforms because of their shared
+ * history, but are otherwise unrelated.
+ */
+
+int zfs_acl_ids_create(struct znode *, int, vattr_t *,
+    cred_t *, vsecattr_t *, zfs_acl_ids_t *, zidmap_t *);
+void zfs_acl_ids_free(zfs_acl_ids_t *);
+boolean_t zfs_acl_ids_overquota(struct zfsvfs *, zfs_acl_ids_t *, uint64_t);
+int zfs_fastaccesschk_execute(struct znode *, cred_t *);
+int zfs_zaccess_unix(void *, int, cred_t *);
+int zfs_acl_chmod_setattr(struct znode *, zfs_acl_t **, uint64_t);
+int zfs_zaccess_delete(struct znode *, struct znode *, cred_t *, zidmap_t *);
+int zfs_zaccess_rename(struct znode *, struct znode *,
+    struct znode *, struct znode *, cred_t *cr, zidmap_t *mnt_ns);
+void zfs_acl_free(zfs_acl_t *);
+int zfs_vsec_2_aclp(struct zfsvfs *, umode_t, vsecattr_t *, cred_t *,
+    struct zfs_fuid_info **, zfs_acl_t **);
+int zfs_aclset_common(struct znode *, zfs_acl_t *, cred_t *, dmu_tx_t *);
+int zfs_znode_acl_version(struct znode *);
+zfs_acl_t *zfs_acl_alloc(int);
+zfs_acl_node_t *zfs_acl_node_alloc(size_t);
+uint64_t zfs_mode_compute(uint64_t, zfs_acl_t *,
+    uint64_t *, uint64_t, uint64_t);
+int zfs_acl_chown_setattr(struct znode *);
+
+#endif

--- a/include/os/freebsd/zfs/sys/zfs_acl_impl.h
+++ b/include/os/freebsd/zfs/sys/zfs_acl_impl.h
@@ -36,15 +36,15 @@
  */
 
 int zfs_acl_ids_create(struct znode *, int, vattr_t *,
-    cred_t *, vsecattr_t *, zfs_acl_ids_t *, zidmap_t *);
+    cred_t *, vsecattr_t *, zfs_acl_ids_t *);
 void zfs_acl_ids_free(zfs_acl_ids_t *);
 boolean_t zfs_acl_ids_overquota(struct zfsvfs *, zfs_acl_ids_t *, uint64_t);
 int zfs_fastaccesschk_execute(struct znode *, cred_t *);
 int zfs_zaccess_unix(void *, int, cred_t *);
 int zfs_acl_chmod_setattr(struct znode *, zfs_acl_t **, uint64_t);
-int zfs_zaccess_delete(struct znode *, struct znode *, cred_t *, zidmap_t *);
+int zfs_zaccess_delete(struct znode *, struct znode *, cred_t *);
 int zfs_zaccess_rename(struct znode *, struct znode *,
-    struct znode *, struct znode *, cred_t *cr, zidmap_t *mnt_ns);
+    struct znode *, struct znode *, cred_t *cr);
 void zfs_acl_free(zfs_acl_t *);
 int zfs_vsec_2_aclp(struct zfsvfs *, umode_t, vsecattr_t *, cred_t *,
     struct zfs_fuid_info **, zfs_acl_t **);

--- a/include/os/freebsd/zfs/sys/zfs_vnops_os.h
+++ b/include/os/freebsd/zfs/sys/zfs_vnops_os.h
@@ -36,23 +36,20 @@ int dmu_read_pages(objset_t *os, uint64_t object, vm_page_t *ma, int count,
     int *rbehind, int *rahead, int last_size);
 extern int zfs_remove(znode_t *dzp, const char *name, cred_t *cr, int flags);
 extern int zfs_mkdir(znode_t *dzp, const char *dirname, vattr_t *vap,
-    znode_t **zpp, cred_t *cr, int flags, vsecattr_t *vsecp, zidmap_t *mnt_ns);
+    znode_t **zpp, cred_t *cr, int flags, vsecattr_t *vsecp);
 extern int zfs_rmdir(znode_t *dzp, const char *name, znode_t *cwd,
     cred_t *cr, int flags);
-extern int zfs_setattr(znode_t *zp, vattr_t *vap, int flag, cred_t *cr,
-    zidmap_t *mnt_ns);
+extern int zfs_setattr(znode_t *zp, vattr_t *vap, int flag, cred_t *cr);
 extern int zfs_rename(znode_t *sdzp, const char *snm, znode_t *tdzp,
-    const char *tnm, cred_t *cr, int flags, uint64_t rflags, vattr_t *wo_vap,
-    zidmap_t *mnt_ns);
+    const char *tnm, cred_t *cr, int flags, uint64_t rflags, vattr_t *wo_vap);
 extern int zfs_symlink(znode_t *dzp, const char *name, vattr_t *vap,
-    const char *link, znode_t **zpp, cred_t *cr, int flags, zidmap_t *mnt_ns);
+    const char *link, znode_t **zpp, cred_t *cr, int flags);
 extern int zfs_link(znode_t *tdzp, znode_t *sp,
     const char *name, cred_t *cr, int flags);
 extern int zfs_space(znode_t *zp, int cmd, struct flock *bfp, int flag,
     offset_t offset, cred_t *cr);
 extern int zfs_create(znode_t *dzp, const char *name, vattr_t *vap, int excl,
-    int mode, znode_t **zpp, cred_t *cr, int flag, vsecattr_t *vsecp,
-    zidmap_t *mnt_ns);
+    int mode, znode_t **zpp, cred_t *cr, int flag, vsecattr_t *vsecp);
 extern int zfs_setsecattr(znode_t *zp, vsecattr_t *vsecp, int flag,
     cred_t *cr);
 extern int zfs_write_simple(znode_t *zp, const void *data, size_t len,

--- a/include/os/freebsd/zfs/sys/zfs_znode_impl.h
+++ b/include/os/freebsd/zfs/sys/zfs_znode_impl.h
@@ -37,7 +37,7 @@
 #include <sys/zfs_sa.h>
 #include <sys/zfs_stat.h>
 #include <sys/zfs_rlock.h>
-#include <sys/zfs_acl.h>
+#include <sys/zfs_acl_impl.h>
 #include <sys/zil.h>
 #include <sys/zfs_project.h>
 #include <vm/vm_object.h>

--- a/include/os/linux/Makefile.am
+++ b/include/os/linux/Makefile.am
@@ -39,6 +39,7 @@ kernel_sys_HEADERS = \
 	%D%/zfs/sys/trace_zil.h \
 	%D%/zfs/sys/trace_zio.h \
 	%D%/zfs/sys/trace_zrlock.h \
+	%D%/zfs/sys/zfs_acl_impl.h \
 	%D%/zfs/sys/zfs_bootenv_os.h \
 	%D%/zfs/sys/zfs_context_os.h \
 	%D%/zfs/sys/zfs_ctldir.h \

--- a/include/os/linux/zfs/sys/zfs_acl_impl.h
+++ b/include/os/linux/zfs/sys/zfs_acl_impl.h
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: CDDL-1.0
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or https://opensource.org/licenses/CDDL-1.0.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, TrueNAS.
+ */
+
+#ifndef _ZFS_ACL_IMPL_H
+#define	_ZFS_ACL_IMPL_H
+
+#include <sys/zfs_acl.h>
+
+/*
+ * These functions are only called by Linux platform-specific code. They have
+ * similar names and prototypes to other platforms because of their shared
+ * history, but are otherwise unrelated.
+ */
+
+int zfs_acl_ids_create(struct znode *, int, vattr_t *,
+    cred_t *, vsecattr_t *, zfs_acl_ids_t *, zidmap_t *);
+void zfs_acl_ids_free(zfs_acl_ids_t *);
+boolean_t zfs_acl_ids_overquota(struct zfsvfs *, zfs_acl_ids_t *, uint64_t);
+int zfs_fastaccesschk_execute(struct znode *, cred_t *);
+int zfs_zaccess_unix(void *, int, cred_t *);
+int zfs_acl_chmod_setattr(struct znode *, zfs_acl_t **, uint64_t);
+int zfs_zaccess_delete(struct znode *, struct znode *, cred_t *, zidmap_t *);
+int zfs_zaccess_rename(struct znode *, struct znode *,
+    struct znode *, struct znode *, cred_t *cr, zidmap_t *mnt_ns);
+void zfs_acl_free(zfs_acl_t *);
+int zfs_vsec_2_aclp(struct zfsvfs *, umode_t, vsecattr_t *, cred_t *,
+    struct zfs_fuid_info **, zfs_acl_t **);
+int zfs_aclset_common(struct znode *, zfs_acl_t *, cred_t *, dmu_tx_t *);
+int zfs_znode_acl_version(struct znode *);
+zfs_acl_t *zfs_acl_alloc(int);
+zfs_acl_node_t *zfs_acl_node_alloc(size_t);
+uint64_t zfs_mode_compute(uint64_t, zfs_acl_t *,
+    uint64_t *, uint64_t, uint64_t);
+int zfs_acl_chown_setattr(struct znode *);
+
+#endif

--- a/include/os/linux/zfs/sys/zfs_acl_impl.h
+++ b/include/os/linux/zfs/sys/zfs_acl_impl.h
@@ -42,6 +42,9 @@ boolean_t zfs_acl_ids_overquota(struct zfsvfs *, zfs_acl_ids_t *, uint64_t);
 int zfs_fastaccesschk_execute(struct znode *, cred_t *);
 int zfs_zaccess_unix(void *, int, cred_t *);
 int zfs_acl_chmod_setattr(struct znode *, zfs_acl_t **, uint64_t);
+int zfs_zaccess_idmap(struct znode *, int, int, boolean_t, cred_t *,
+    zidmap_t *);
+int zfs_zaccess_rwx_idmap(struct znode *, mode_t, int, cred_t *, zidmap_t *);
 int zfs_zaccess_delete(struct znode *, struct znode *, cred_t *, zidmap_t *);
 int zfs_zaccess_rename(struct znode *, struct znode *,
     struct znode *, struct znode *, cred_t *cr, zidmap_t *mnt_ns);

--- a/include/os/linux/zfs/sys/zfs_vnops_os.h
+++ b/include/os/linux/zfs/sys/zfs_vnops_os.h
@@ -21,6 +21,7 @@
  */
 /*
  * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, TrueNAS.
  */
 
 #ifndef	_SYS_FS_ZFS_VNOPS_OS_H
@@ -47,14 +48,12 @@ extern int zfs_lookup(znode_t *dzp, char *nm, znode_t **zpp, int flags,
     cred_t *cr, int *direntflags, pathname_t *realpnp);
 extern int zfs_get_name(znode_t *dzp, char *name, znode_t *zp);
 extern int zfs_create(znode_t *dzp, char *name, vattr_t *vap, int excl,
-    int mode, znode_t **zpp, cred_t *cr, int flag, vsecattr_t *vsecp,
-    zidmap_t *mnt_ns);
+    int mode, znode_t **zpp, cred_t *cr, int flag, vsecattr_t *vsecp);
 extern int zfs_tmpfile(struct inode *dip, vattr_t *vapzfs, int excl,
-    int mode, struct inode **ipp, cred_t *cr, int flag, vsecattr_t *vsecp,
-    zidmap_t *mnt_ns);
+    int mode, struct inode **ipp, cred_t *cr, int flag, vsecattr_t *vsecp);
 extern int zfs_remove(znode_t *dzp, char *name, cred_t *cr, int flags);
 extern int zfs_mkdir(znode_t *dzp, char *dirname, vattr_t *vap,
-    znode_t **zpp, cred_t *cr, int flags, vsecattr_t *vsecp, zidmap_t *mnt_ns);
+    znode_t **zpp, cred_t *cr, int flags, vsecattr_t *vsecp);
 extern int zfs_rmdir(znode_t *dzp, char *name, znode_t *cwd,
     cred_t *cr, int flags);
 extern int zfs_readdir(struct inode *ip, struct dir_context *ctx, cred_t *cr);
@@ -64,13 +63,11 @@ extern int zfs_getattr_fast(zidmap_t *, u32 request_mask, struct inode *ip,
 #else
 extern int zfs_getattr_fast(zidmap_t *, struct inode *ip, struct kstat *sp);
 #endif
-extern int zfs_setattr(znode_t *zp, vattr_t *vap, int flag, cred_t *cr,
-    zidmap_t *mnt_ns);
+extern int zfs_setattr(znode_t *zp, vattr_t *vap, int flag, cred_t *cr);
 extern int zfs_rename(znode_t *sdzp, char *snm, znode_t *tdzp,
-    char *tnm, cred_t *cr, int flags, uint64_t rflags, vattr_t *wo_vap,
-    zidmap_t *mnt_ns);
+    char *tnm, cred_t *cr, int flags, uint64_t rflags, vattr_t *wo_vap);
 extern int zfs_symlink(znode_t *dzp, char *name, vattr_t *vap,
-    char *link, znode_t **zpp, cred_t *cr, int flags, zidmap_t *mnt_ns);
+    char *link, znode_t **zpp, cred_t *cr, int flags);
 extern int zfs_readlink(struct inode *ip, zfs_uio_t *uio, cred_t *cr);
 extern int zfs_link(znode_t *tdzp, znode_t *szp,
     char *name, cred_t *cr, int flags);
@@ -85,6 +82,22 @@ extern int zfs_dirty_inode(struct inode *ip, int flags);
 extern int zfs_map(struct inode *ip, offset_t off, caddr_t *addrp,
     size_t len, unsigned long vm_flags);
 extern void zfs_zrele_async(znode_t *zp);
+
+extern int zfs_create_idmap(znode_t *dzp, char *name, vattr_t *vap, int excl,
+    int mode, znode_t **zpp, cred_t *cr, int flag, vsecattr_t *vsecp,
+    zidmap_t *mnt_ns);
+extern int zfs_tmpfile_idmap(struct inode *dip, vattr_t *vapzfs, int excl,
+    int mode, struct inode **ipp, cred_t *cr, int flag, vsecattr_t *vsecp,
+    zidmap_t *mnt_ns);
+extern int zfs_mkdir_idmap(znode_t *dzp, char *dirname, vattr_t *vap,
+    znode_t **zpp, cred_t *cr, int flags, vsecattr_t *vsecp, zidmap_t *mnt_ns);
+extern int zfs_setattr_idmap(znode_t *zp, vattr_t *vap, int flag, cred_t *cr,
+    zidmap_t *mnt_ns);
+extern int zfs_rename_idmap(znode_t *sdzp, char *snm, znode_t *tdzp,
+    char *tnm, cred_t *cr, int flags, uint64_t rflags, vattr_t *wo_vap,
+    zidmap_t *mnt_ns);
+extern int zfs_symlink_idmap(znode_t *dzp, char *name, vattr_t *vap,
+    char *link, znode_t **zpp, cred_t *cr, int flags, zidmap_t *mnt_ns);
 
 #ifdef	__cplusplus
 }

--- a/include/sys/zfs_acl.h
+++ b/include/sys/zfs_acl.h
@@ -211,14 +211,8 @@ struct zfsvfs;
 /* Platform-specific implementations called by core. */
 int zfs_getacl(struct znode *, vsecattr_t *, boolean_t, cred_t *);
 int zfs_setacl(struct znode *, vsecattr_t *, boolean_t, cred_t *);
-#ifdef __linux__
-int zfs_zaccess(struct znode *, int, int, boolean_t, cred_t *,
-    zidmap_t *);
-int zfs_zaccess_rwx(struct znode *, mode_t, int, cred_t *, zidmap_t *);
-#else
 int zfs_zaccess(struct znode *, int, int, boolean_t, cred_t *);
 int zfs_zaccess_rwx(struct znode *, mode_t, int, cred_t *);
-#endif
 uint64_t zfs_external_acl(struct znode *);
 void zfs_acl_xform(struct znode *, zfs_acl_t *, cred_t *);
 void zfs_acl_data_locator(void **, uint32_t *, uint32_t, boolean_t, void *);

--- a/include/sys/zfs_acl.h
+++ b/include/sys/zfs_acl.h
@@ -211,9 +211,14 @@ struct zfsvfs;
 /* Platform-specific implementations called by core. */
 int zfs_getacl(struct znode *, vsecattr_t *, boolean_t, cred_t *);
 int zfs_setacl(struct znode *, vsecattr_t *, boolean_t, cred_t *);
+#ifdef __linux__
 int zfs_zaccess(struct znode *, int, int, boolean_t, cred_t *,
     zidmap_t *);
 int zfs_zaccess_rwx(struct znode *, mode_t, int, cred_t *, zidmap_t *);
+#else
+int zfs_zaccess(struct znode *, int, int, boolean_t, cred_t *);
+int zfs_zaccess_rwx(struct znode *, mode_t, int, cred_t *);
+#endif
 uint64_t zfs_external_acl(struct znode *);
 void zfs_acl_xform(struct znode *, zfs_acl_t *, cred_t *);
 void zfs_acl_data_locator(void **, uint32_t *, uint32_t, boolean_t, void *);

--- a/include/sys/zfs_acl.h
+++ b/include/sys/zfs_acl.h
@@ -212,7 +212,6 @@ void zfs_acl_ids_free(zfs_acl_ids_t *);
 boolean_t zfs_acl_ids_overquota(struct zfsvfs *, zfs_acl_ids_t *, uint64_t);
 int zfs_getacl(struct znode *, vsecattr_t *, boolean_t, cred_t *);
 int zfs_setacl(struct znode *, vsecattr_t *, boolean_t, cred_t *);
-void zfs_acl_rele(void *);
 void zfs_oldace_byteswap(ace_t *, int);
 void zfs_ace_byteswap(void *, size_t, boolean_t);
 extern boolean_t zfs_has_access(struct znode *zp, cred_t *cr);
@@ -221,7 +220,6 @@ extern int zfs_zaccess(struct znode *, int, int, boolean_t, cred_t *,
 int zfs_fastaccesschk_execute(struct znode *, cred_t *);
 extern int zfs_zaccess_rwx(struct znode *, mode_t, int, cred_t *, zidmap_t *);
 extern int zfs_zaccess_unix(void *, int, cred_t *);
-extern int zfs_acl_access(struct znode *, int, cred_t *);
 int zfs_acl_chmod_setattr(struct znode *, zfs_acl_t **, uint64_t);
 int zfs_zaccess_delete(struct znode *, struct znode *, cred_t *, zidmap_t *);
 int zfs_zaccess_rename(struct znode *, struct znode *,
@@ -232,7 +230,6 @@ int zfs_vsec_2_aclp(struct zfsvfs *, umode_t, vsecattr_t *, cred_t *,
 int zfs_aclset_common(struct znode *, zfs_acl_t *, cred_t *, dmu_tx_t *);
 uint64_t zfs_external_acl(struct znode *);
 int zfs_znode_acl_version(struct znode *);
-int zfs_acl_size(struct znode *, int *);
 zfs_acl_t *zfs_acl_alloc(int);
 zfs_acl_node_t *zfs_acl_node_alloc(size_t);
 void zfs_acl_xform(struct znode *, zfs_acl_t *, cred_t *);

--- a/include/sys/zfs_acl.h
+++ b/include/sys/zfs_acl.h
@@ -21,6 +21,7 @@
  */
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, TrueNAS.
  */
 
 #ifndef	_SYS_FS_ZFS_ACL_H
@@ -206,37 +207,24 @@ struct znode;
 struct zfsvfs;
 
 #ifdef _KERNEL
-int zfs_acl_ids_create(struct znode *, int, vattr_t *,
-    cred_t *, vsecattr_t *, zfs_acl_ids_t *, zidmap_t *);
-void zfs_acl_ids_free(zfs_acl_ids_t *);
-boolean_t zfs_acl_ids_overquota(struct zfsvfs *, zfs_acl_ids_t *, uint64_t);
+
+/* Platform-specific implementations called by core. */
 int zfs_getacl(struct znode *, vsecattr_t *, boolean_t, cred_t *);
 int zfs_setacl(struct znode *, vsecattr_t *, boolean_t, cred_t *);
-void zfs_oldace_byteswap(ace_t *, int);
-void zfs_ace_byteswap(void *, size_t, boolean_t);
-extern int zfs_zaccess(struct znode *, int, int, boolean_t, cred_t *,
+int zfs_zaccess(struct znode *, int, int, boolean_t, cred_t *,
     zidmap_t *);
-int zfs_fastaccesschk_execute(struct znode *, cred_t *);
-extern int zfs_zaccess_rwx(struct znode *, mode_t, int, cred_t *, zidmap_t *);
-extern int zfs_zaccess_unix(void *, int, cred_t *);
-int zfs_acl_chmod_setattr(struct znode *, zfs_acl_t **, uint64_t);
-int zfs_zaccess_delete(struct znode *, struct znode *, cred_t *, zidmap_t *);
-int zfs_zaccess_rename(struct znode *, struct znode *,
-    struct znode *, struct znode *, cred_t *cr, zidmap_t *mnt_ns);
-void zfs_acl_free(zfs_acl_t *);
-int zfs_vsec_2_aclp(struct zfsvfs *, umode_t, vsecattr_t *, cred_t *,
-    struct zfs_fuid_info **, zfs_acl_t **);
-int zfs_aclset_common(struct znode *, zfs_acl_t *, cred_t *, dmu_tx_t *);
+int zfs_zaccess_rwx(struct znode *, mode_t, int, cred_t *, zidmap_t *);
 uint64_t zfs_external_acl(struct znode *);
-int zfs_znode_acl_version(struct znode *);
-zfs_acl_t *zfs_acl_alloc(int);
-zfs_acl_node_t *zfs_acl_node_alloc(size_t);
 void zfs_acl_xform(struct znode *, zfs_acl_t *, cred_t *);
 void zfs_acl_data_locator(void **, uint32_t *, uint32_t, boolean_t, void *);
 uint64_t zfs_mode_compute(uint64_t, zfs_acl_t *,
     uint64_t *, uint64_t, uint64_t);
 int zfs_acl_node_read(struct znode *, boolean_t, zfs_acl_t **, boolean_t);
 int zfs_acl_chown_setattr(struct znode *);
+
+/* Shared core implementations. */
+void zfs_oldace_byteswap(ace_t *, int);
+void zfs_ace_byteswap(void *, size_t, boolean_t);
 
 #endif
 

--- a/include/sys/zfs_acl.h
+++ b/include/sys/zfs_acl.h
@@ -214,7 +214,6 @@ int zfs_getacl(struct znode *, vsecattr_t *, boolean_t, cred_t *);
 int zfs_setacl(struct znode *, vsecattr_t *, boolean_t, cred_t *);
 void zfs_oldace_byteswap(ace_t *, int);
 void zfs_ace_byteswap(void *, size_t, boolean_t);
-extern boolean_t zfs_has_access(struct znode *zp, cred_t *cr);
 extern int zfs_zaccess(struct znode *, int, int, boolean_t, cred_t *,
     zidmap_t *);
 int zfs_fastaccesschk_execute(struct znode *, cred_t *);

--- a/module/os/freebsd/spl/spl_acl.c
+++ b/module/os/freebsd/spl/spl_acl.c
@@ -30,7 +30,7 @@
 #include <sys/types.h>
 #include <sys/malloc.h>
 #include <sys/errno.h>
-#include <sys/zfs_acl.h>
+#include <sys/zfs_acl_impl.h>
 #include <sys/acl.h>
 
 struct zfs2bsd {

--- a/module/os/freebsd/zfs/zfs_acl.c
+++ b/module/os/freebsd/zfs/zfs_acl.c
@@ -2220,24 +2220,6 @@ zfs_zaccess_aces_check(znode_t *zp, uint32_t *working_mode,
 	return (0);
 }
 
-/*
- * Return true if any access whatsoever granted, we don't actually
- * care what access is granted.
- */
-boolean_t
-zfs_has_access(znode_t *zp, cred_t *cr)
-{
-	uint32_t have = ACE_ALL_PERMS;
-
-	if (zfs_zaccess_aces_check(zp, &have, B_TRUE, cr) != 0) {
-		uid_t owner;
-
-		owner = zfs_fuid_map_id(zp->z_zfsvfs, zp->z_uid, cr, ZFS_OWNER);
-		return (secpolicy_vnode_any_access(cr, ZTOV(zp), owner) == 0);
-	}
-	return (B_TRUE);
-}
-
 static int
 zfs_zaccess_common(znode_t *zp, uint32_t v4_mode, uint32_t *working_mode,
     boolean_t *check_privs, boolean_t skipaclchk, cred_t *cr)

--- a/module/os/freebsd/zfs/zfs_acl.c
+++ b/module/os/freebsd/zfs/zfs_acl.c
@@ -44,7 +44,7 @@
 #include <sys/policy.h>
 #include <sys/zfs_znode.h>
 #include <sys/zfs_fuid.h>
-#include <sys/zfs_acl.h>
+#include <sys/zfs_acl_impl.h>
 #include <sys/zfs_dir.h>
 #include <sys/zfs_quota.h>
 #include <sys/zfs_vfsops.h>

--- a/module/os/freebsd/zfs/zfs_acl.c
+++ b/module/os/freebsd/zfs/zfs_acl.c
@@ -23,6 +23,7 @@
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2013 by Delphix. All rights reserved.
  * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright (c) 2026, TrueNAS.
  */
 
 #include <sys/types.h>
@@ -1621,7 +1622,7 @@ zfs_acl_inherit(zfsvfs_t *zfsvfs, vtype_t vtype, zfs_acl_t *paclp,
  */
 int
 zfs_acl_ids_create(znode_t *dzp, int flag, vattr_t *vap, cred_t *cr,
-    vsecattr_t *vsecp, zfs_acl_ids_t *acl_ids, zidmap_t *mnt_ns)
+    vsecattr_t *vsecp, zfs_acl_ids_t *acl_ids)
 {
 	int		error;
 	zfsvfs_t	*zfsvfs = dzp->z_zfsvfs;
@@ -1791,7 +1792,7 @@ zfs_getacl(znode_t *zp, vsecattr_t *vsecp, boolean_t skipaclchk, cred_t *cr)
 	if (mask == 0)
 		return (SET_ERROR(ENOSYS));
 
-	if ((error = zfs_zaccess(zp, ACE_READ_ACL, 0, skipaclchk, cr, NULL)))
+	if ((error = zfs_zaccess(zp, ACE_READ_ACL, 0, skipaclchk, cr)))
 		return (error);
 
 	mutex_enter(&zp->z_acl_lock);
@@ -1954,7 +1955,7 @@ zfs_setacl(znode_t *zp, vsecattr_t *vsecp, boolean_t skipaclchk, cred_t *cr)
 	if (zp->z_pflags & ZFS_IMMUTABLE)
 		return (SET_ERROR(EPERM));
 
-	if ((error = zfs_zaccess(zp, ACE_WRITE_ACL, 0, skipaclchk, cr, NULL)))
+	if ((error = zfs_zaccess(zp, ACE_WRITE_ACL, 0, skipaclchk, cr)))
 		return (error);
 
 	error = zfs_vsec_2_aclp(zfsvfs, ZTOV(zp)->v_type, vsecp, cr, &fuidp,
@@ -2324,8 +2325,7 @@ zfs_fastaccesschk_execute(znode_t *zdp, cred_t *cr)
  * can define any form of access.
  */
 int
-zfs_zaccess(znode_t *zp, int mode, int flags, boolean_t skipaclchk, cred_t *cr,
-    zidmap_t *mnt_ns)
+zfs_zaccess(znode_t *zp, int mode, int flags, boolean_t skipaclchk, cred_t *cr)
 {
 	uint32_t	working_mode;
 	int		error;
@@ -2486,11 +2486,9 @@ zfs_zaccess(znode_t *zp, int mode, int flags, boolean_t skipaclchk, cred_t *cr,
  * NFSv4-style ZFS ACL format and call zfs_zaccess()
  */
 int
-zfs_zaccess_rwx(znode_t *zp, mode_t mode, int flags, cred_t *cr,
-    zidmap_t *mnt_ns)
+zfs_zaccess_rwx(znode_t *zp, mode_t mode, int flags, cred_t *cr)
 {
-	return (zfs_zaccess(zp, zfs_unix_to_v4(mode >> 6), flags, B_FALSE, cr,
-	    mnt_ns));
+	return (zfs_zaccess(zp, zfs_unix_to_v4(mode >> 6), flags, B_FALSE, cr));
 }
 
 /*
@@ -2501,7 +2499,7 @@ zfs_zaccess_unix(void *zp, int mode, cred_t *cr)
 {
 	int v4_mode = zfs_unix_to_v4(mode >> 6);
 
-	return (zfs_zaccess(zp, v4_mode, 0, B_FALSE, cr, NULL));
+	return (zfs_zaccess(zp, v4_mode, 0, B_FALSE, cr));
 }
 
 static int
@@ -2557,7 +2555,7 @@ zfs_delete_final_check(znode_t *zp, znode_t *dzp,
  *
  */
 int
-zfs_zaccess_delete(znode_t *dzp, znode_t *zp, cred_t *cr, zidmap_t *mnt_ns)
+zfs_zaccess_delete(znode_t *dzp, znode_t *zp, cred_t *cr)
 {
 	uint32_t dzp_working_mode = 0;
 	uint32_t zp_working_mode = 0;
@@ -2644,7 +2642,7 @@ zfs_zaccess_delete(znode_t *dzp, znode_t *zp, cred_t *cr, zidmap_t *mnt_ns)
 
 int
 zfs_zaccess_rename(znode_t *sdzp, znode_t *szp, znode_t *tdzp,
-    znode_t *tzp, cred_t *cr, zidmap_t *mnt_ns)
+    znode_t *tzp, cred_t *cr)
 {
 	int add_perm;
 	int error;
@@ -2664,8 +2662,7 @@ zfs_zaccess_rename(znode_t *sdzp, znode_t *szp, znode_t *tdzp,
 	 * to another.
 	 */
 	if (ZTOV(szp)->v_type == VDIR && ZTOV(sdzp) != ZTOV(tdzp)) {
-		if ((error = zfs_zaccess(szp, ACE_WRITE_DATA, 0, B_FALSE, cr,
-		    mnt_ns)))
+		if ((error = zfs_zaccess(szp, ACE_WRITE_DATA, 0, B_FALSE, cr)))
 			return (error);
 	}
 
@@ -2675,19 +2672,19 @@ zfs_zaccess_rename(znode_t *sdzp, znode_t *szp, znode_t *tdzp,
 	 * If that succeeds then check for add_file/add_subdir permissions
 	 */
 
-	if ((error = zfs_zaccess_delete(sdzp, szp, cr, mnt_ns)))
+	if ((error = zfs_zaccess_delete(sdzp, szp, cr)))
 		return (error);
 
 	/*
 	 * If we have a tzp, see if we can delete it?
 	 */
-	if (tzp && (error = zfs_zaccess_delete(tdzp, tzp, cr, mnt_ns)))
+	if (tzp && (error = zfs_zaccess_delete(tdzp, tzp, cr)))
 		return (error);
 
 	/*
 	 * Now check for add permissions
 	 */
-	error = zfs_zaccess(tdzp, add_perm, 0, B_FALSE, cr, mnt_ns);
+	error = zfs_zaccess(tdzp, add_perm, 0, B_FALSE, cr);
 
 	return (error);
 }

--- a/module/os/freebsd/zfs/zfs_dir.c
+++ b/module/os/freebsd/zfs/zfs_dir.c
@@ -48,7 +48,7 @@
 #include <sys/callb.h>
 #include <sys/smp.h>
 #include <sys/zfs_dir.h>
-#include <sys/zfs_acl.h>
+#include <sys/zfs_acl_impl.h>
 #include <sys/fs/zfs.h>
 #include <sys/zap.h>
 #include <sys/dmu.h>

--- a/module/os/freebsd/zfs/zfs_dir.c
+++ b/module/os/freebsd/zfs/zfs_dir.c
@@ -849,7 +849,7 @@ zfs_make_xattrdir(znode_t *zp, vattr_t *vap, znode_t **xvpp, cred_t *cr)
 	*xvpp = NULL;
 
 	if ((error = zfs_acl_ids_create(zp, IS_XATTR, vap, cr, NULL,
-	    &acl_ids, NULL)) != 0)
+	    &acl_ids)) != 0)
 		return (error);
 	if (zfs_acl_ids_overquota(zfsvfs, &acl_ids, zp->z_projid)) {
 		zfs_acl_ids_free(&acl_ids);
@@ -1018,7 +1018,7 @@ zfs_sticky_remove_access(znode_t *zdp, znode_t *zp, cred_t *cr)
 
 	if ((uid = crgetuid(cr)) == downer || uid == fowner ||
 	    (ZTOV(zp)->v_type == VREG &&
-	    zfs_zaccess(zp, ACE_WRITE_DATA, 0, B_FALSE, cr, NULL) == 0))
+	    zfs_zaccess(zp, ACE_WRITE_DATA, 0, B_FALSE, cr) == 0))
 		return (0);
 	else
 		return (secpolicy_vnode_remove(ZTOV(zp), cr));

--- a/module/os/freebsd/zfs/zfs_vnops_os.c
+++ b/module/os/freebsd/zfs/zfs_vnops_os.c
@@ -26,6 +26,7 @@
  * Copyright (c) 2014 Integros [integros.com]
  * Copyright 2017 Nexenta Systems, Inc.
  * Copyright (c) 2025, Klara, Inc.
+ * Copyright (c) 2026, TrueNAS.
  */
 
 /* Portions Copyright 2007 Jeremy Teo */
@@ -324,7 +325,7 @@ zfs_ioctl_setxattr(vnode_t *vp, zfsxattr_t *fsx, cred_t *cr)
 	XVA_SET_REQ(&xva, XAT_PROJID);
 	xoap->xoa_projid = fsx->fsx_projid;
 
-	err = zfs_setattr(zp, (vattr_t *)&xva, 0, cr, NULL);
+	err = zfs_setattr(zp, (vattr_t *)&xva, 0, cr);
 
 	return (err);
 }
@@ -814,10 +815,9 @@ zfs_lookup(vnode_t *dvp, const char *nm, vnode_t **vpp,
 		 */
 		if (flags & LOOKUP_NAMED_ATTR)
 			error = zfs_zaccess(zp, ACE_EXECUTE, V_NAMEDATTR,
-			    B_FALSE, cr, NULL);
+			    B_FALSE, cr);
 		else
-			error = zfs_zaccess(zp, ACE_EXECUTE, 0, B_FALSE, cr,
-			    NULL);
+			error = zfs_zaccess(zp, ACE_EXECUTE, 0, B_FALSE, cr);
 		if (error) {
 			vrele(ZTOV(zp));
 		}
@@ -836,8 +836,7 @@ zfs_lookup(vnode_t *dvp, const char *nm, vnode_t **vpp,
 			cnp->cn_flags &= ~NOEXECCHECK;
 		} else
 #endif
-		if ((error = zfs_zaccess(zdp, ACE_EXECUTE, 0, B_FALSE, cr,
-		    NULL))) {
+		if ((error = zfs_zaccess(zdp, ACE_EXECUTE, 0, B_FALSE, cr))) {
 			zfs_exit(zfsvfs, FTAG);
 			return (error);
 		}
@@ -1025,7 +1024,6 @@ is_nametoolong(zfsvfs_t *zfsvfs, const char *name)
  *		flag	- large file flag [UNUSED].
  *		ct	- caller context
  *		vsecp	- ACL to be set
- *		mnt_ns	- Unused on FreeBSD
  *
  *	OUT:	vpp	- vnode of created or trunc'd entry.
  *
@@ -1037,7 +1035,7 @@ is_nametoolong(zfsvfs_t *zfsvfs, const char *name)
  */
 int
 zfs_create(znode_t *dzp, const char *name, vattr_t *vap, int excl, int mode,
-    znode_t **zpp, cred_t *cr, int flag, vsecattr_t *vsecp, zidmap_t *mnt_ns)
+    znode_t **zpp, cred_t *cr, int flag, vsecattr_t *vsecp)
 {
 	(void) excl, (void) mode, (void) flag;
 	znode_t		*zp;
@@ -1100,7 +1098,7 @@ zfs_create(znode_t *dzp, const char *name, vattr_t *vap, int excl, int mode,
 	 * Create a new file object and update the directory
 	 * to reference it.
 	 */
-	if ((error = zfs_zaccess(dzp, ACE_ADD_FILE, 0, B_FALSE, cr, mnt_ns))) {
+	if ((error = zfs_zaccess(dzp, ACE_ADD_FILE, 0, B_FALSE, cr))) {
 		goto out;
 	}
 
@@ -1116,7 +1114,7 @@ zfs_create(znode_t *dzp, const char *name, vattr_t *vap, int excl, int mode,
 	}
 
 	if ((error = zfs_acl_ids_create(dzp, 0, vap,
-	    cr, vsecp, &acl_ids, NULL)) != 0)
+	    cr, vsecp, &acl_ids)) != 0)
 		goto out;
 
 	if (S_ISREG(vap->va_mode) || S_ISDIR(vap->va_mode))
@@ -1237,7 +1235,7 @@ zfs_remove_(vnode_t *dvp, vnode_t *vp, const char *name, cred_t *cr)
 	xattr_obj = 0;
 	xzp = NULL;
 
-	if ((error = zfs_zaccess_delete(dzp, zp, cr, NULL))) {
+	if ((error = zfs_zaccess_delete(dzp, zp, cr))) {
 		goto out;
 	}
 
@@ -1393,7 +1391,6 @@ zfs_remove(znode_t *dzp, const char *name, cred_t *cr, int flags)
  *		ct	- caller context
  *		flags	- case flags
  *		vsecp	- ACL to be set
- *		mnt_ns	- Unused on FreeBSD
  *
  *	OUT:	vpp	- vnode of created directory.
  *
@@ -1405,7 +1402,7 @@ zfs_remove(znode_t *dzp, const char *name, cred_t *cr, int flags)
  */
 int
 zfs_mkdir(znode_t *dzp, const char *dirname, vattr_t *vap, znode_t **zpp,
-    cred_t *cr, int flags, vsecattr_t *vsecp, zidmap_t *mnt_ns)
+    cred_t *cr, int flags, vsecattr_t *vsecp)
 {
 	(void) flags, (void) vsecp;
 	znode_t		*zp;
@@ -1457,7 +1454,7 @@ zfs_mkdir(znode_t *dzp, const char *dirname, vattr_t *vap, znode_t **zpp,
 	}
 
 	if ((error = zfs_acl_ids_create(dzp, 0, vap, cr,
-	    NULL, &acl_ids, NULL)) != 0) {
+	    NULL, &acl_ids)) != 0) {
 		zfs_exit(zfsvfs, FTAG);
 		return (error);
 	}
@@ -1478,8 +1475,7 @@ zfs_mkdir(znode_t *dzp, const char *dirname, vattr_t *vap, znode_t **zpp,
 	}
 	ASSERT0P(zp);
 
-	if ((error = zfs_zaccess(dzp, ACE_ADD_SUBDIRECTORY, 0, B_FALSE, cr,
-	    mnt_ns))) {
+	if ((error = zfs_zaccess(dzp, ACE_ADD_SUBDIRECTORY, 0, B_FALSE, cr))) {
 		zfs_acl_ids_free(&acl_ids);
 		zfs_exit(zfsvfs, FTAG);
 		return (error);
@@ -1594,7 +1590,7 @@ zfs_rmdir_(vnode_t *dvp, vnode_t *vp, const char *name, cred_t *cr)
 	zilog = zfsvfs->z_log;
 
 
-	if ((error = zfs_zaccess_delete(dzp, zp, cr, NULL))) {
+	if ((error = zfs_zaccess_delete(dzp, zp, cr))) {
 		goto out;
 	}
 
@@ -1989,7 +1985,7 @@ zfs_getattr(vnode_t *vp, vattr_t *vap, int flags, cred_t *cr)
 	if (!(zp->z_pflags & ZFS_ACL_TRIVIAL) &&
 	    (vap->va_uid != crgetuid(cr))) {
 		if ((error = zfs_zaccess(zp, ACE_READ_ATTRIBUTES, 0,
-		    skipaclchk, cr, NULL))) {
+		    skipaclchk, cr))) {
 			zfs_exit(zfsvfs, FTAG);
 			return (error);
 		}
@@ -2285,7 +2281,6 @@ next:
  *		flags	- ATTR_UTIME set if non-default time values provided.
  *			- ATTR_NOACLCHECK (CIFS context only).
  *		cr	- credentials of caller.
- *		mnt_ns	- Unused on FreeBSD
  *
  *	RETURN:	0 on success, error code on failure.
  *
@@ -2293,7 +2288,7 @@ next:
  *	vp - ctime updated, mtime updated if size changed.
  */
 int
-zfs_setattr(znode_t *zp, vattr_t *vap, int flags, cred_t *cr, zidmap_t *mnt_ns)
+zfs_setattr(znode_t *zp, vattr_t *vap, int flags, cred_t *cr)
 {
 	vnode_t		*vp = ZTOV(zp);
 	zfsvfs_t	*zfsvfs = zp->z_zfsvfs;
@@ -2466,7 +2461,7 @@ zfs_setattr(znode_t *zp, vattr_t *vap, int flags, cred_t *cr, zidmap_t *mnt_ns)
 	    XVA_ISSET_REQ(xvap, XAT_CREATETIME) ||
 	    XVA_ISSET_REQ(xvap, XAT_SYSTEM)))) {
 		need_policy = zfs_zaccess(zp, ACE_WRITE_ATTRIBUTES, 0,
-		    skipaclchk, cr, mnt_ns);
+		    skipaclchk, cr);
 	}
 
 	if (mask & (AT_UID|AT_GID)) {
@@ -2503,7 +2498,7 @@ zfs_setattr(znode_t *zp, vattr_t *vap, int flags, cred_t *cr, zidmap_t *mnt_ns)
 		    ((idmask == AT_UID) && take_owner) ||
 		    ((idmask == AT_GID) && take_group)) {
 			if (zfs_zaccess(zp, ACE_WRITE_OWNER, 0,
-			    skipaclchk, cr, mnt_ns) == 0) {
+			    skipaclchk, cr) == 0) {
 				/*
 				 * Remove setuid/setgid for non-privileged users
 				 */
@@ -2612,8 +2607,7 @@ zfs_setattr(znode_t *zp, vattr_t *vap, int flags, cred_t *cr, zidmap_t *mnt_ns)
 	}
 
 	if (mask & AT_MODE) {
-		if (zfs_zaccess(zp, ACE_WRITE_ACL, 0, skipaclchk, cr,
-		    mnt_ns) == 0) {
+		if (zfs_zaccess(zp, ACE_WRITE_ACL, 0, skipaclchk, cr) == 0) {
 			err = secpolicy_setid_setsticky_clear(vp, vap,
 			    &oldva, cr);
 			if (err) {
@@ -3407,7 +3401,7 @@ zfs_do_rename_impl(vnode_t *sdvp, vnode_t **svpp, struct componentname *scnp,
 	 * Note that if target and source are the same, this can be
 	 * done in a single check.
 	 */
-	if ((error = zfs_zaccess_rename(sdzp, szp, tdzp, tzp, cr, NULL)))
+	if ((error = zfs_zaccess_rename(sdzp, szp, tdzp, tzp, cr)))
 		goto out;
 
 	if ((*svpp)->v_type == VDIR) {
@@ -3553,7 +3547,7 @@ out:
 
 int
 zfs_rename(znode_t *sdzp, const char *sname, znode_t *tdzp, const char *tname,
-    cred_t *cr, int flags, uint64_t rflags, vattr_t *wo_vap, zidmap_t *mnt_ns)
+    cred_t *cr, int flags, uint64_t rflags, vattr_t *wo_vap)
 {
 	struct componentname scn, tcn;
 	vnode_t *sdvp, *tdvp;
@@ -3604,7 +3598,6 @@ fail:
  *		cr	- credentials of caller.
  *		ct	- caller context
  *		flags	- case flags
- *		mnt_ns	- Unused on FreeBSD
  *
  *	RETURN:	0 on success, error code on failure.
  *
@@ -3613,7 +3606,7 @@ fail:
  */
 int
 zfs_symlink(znode_t *dzp, const char *name, vattr_t *vap,
-    const char *link, znode_t **zpp, cred_t *cr, int flags, zidmap_t *mnt_ns)
+    const char *link, znode_t **zpp, cred_t *cr, int flags)
 {
 	(void) flags;
 	znode_t		*zp;
@@ -3647,7 +3640,7 @@ zfs_symlink(znode_t *dzp, const char *name, vattr_t *vap,
 	}
 
 	if ((error = zfs_acl_ids_create(dzp, 0,
-	    vap, cr, NULL, &acl_ids, NULL)) != 0) {
+	    vap, cr, NULL, &acl_ids)) != 0) {
 		zfs_exit(zfsvfs, FTAG);
 		return (error);
 	}
@@ -3662,7 +3655,7 @@ zfs_symlink(znode_t *dzp, const char *name, vattr_t *vap,
 		return (error);
 	}
 
-	if ((error = zfs_zaccess(dzp, ACE_ADD_FILE, 0, B_FALSE, cr, mnt_ns))) {
+	if ((error = zfs_zaccess(dzp, ACE_ADD_FILE, 0, B_FALSE, cr))) {
 		zfs_acl_ids_free(&acl_ids);
 		zfs_exit(zfsvfs, FTAG);
 		return (error);
@@ -3888,7 +3881,7 @@ zfs_link(znode_t *tdzp, znode_t *szp, const char *name, cred_t *cr,
 		return (SET_ERROR(EPERM));
 	}
 
-	if ((error = zfs_zaccess(tdzp, ACE_ADD_FILE, 0, B_FALSE, cr, NULL))) {
+	if ((error = zfs_zaccess(tdzp, ACE_ADD_FILE, 0, B_FALSE, cr))) {
 		zfs_exit(zfsvfs, FTAG);
 		return (error);
 	}
@@ -3990,7 +3983,7 @@ zfs_space(znode_t *zp, int cmd, flock64_t *bfp, int flag,
 	 * On Linux we can get here through truncate_range() which
 	 * operates directly on inodes, so we need to check access rights.
 	 */
-	if ((error = zfs_zaccess(zp, ACE_WRITE_DATA, 0, B_FALSE, cr, NULL))) {
+	if ((error = zfs_zaccess(zp, ACE_WRITE_DATA, 0, B_FALSE, cr))) {
 		zfs_exit(zfsvfs, FTAG);
 		return (error);
 	}
@@ -5144,7 +5137,7 @@ zfs_freebsd_create(struct vop_create_args *ap)
 
 	if (rc == 0)
 		rc = zfs_create(VTOZ(dvp), cnp->cn_nameptr, vap, 0, mode,
-		    &zp, cnp->cn_cred, 0 /* flag */, NULL /* vsecattr */, NULL);
+		    &zp, cnp->cn_cred, 0 /* flag */, NULL /* vsecattr */);
 #if __FreeBSD_version >= 1500040
 	if (xvp != NULL)
 		vput(xvp);
@@ -5215,7 +5208,7 @@ zfs_freebsd_mkdir(struct vop_mkdir_args *ap)
 	*ap->a_vpp = NULL;
 
 	rc = zfs_mkdir(VTOZ(ap->a_dvp), ap->a_cnp->cn_nameptr, vap, &zp,
-	    ap->a_cnp->cn_cred, 0, NULL, NULL);
+	    ap->a_cnp->cn_cred, 0, NULL);
 
 	if (rc == 0)
 		*ap->a_vpp = ZTOV(zp);
@@ -5496,7 +5489,7 @@ zfs_freebsd_setattr(struct vop_setattr_args *ap)
 		xvap.xva_vattr.va_mask |= AT_XVATTR;
 		XVA_SET_REQ(&xvap, XAT_CREATETIME);
 	}
-	return (zfs_setattr(VTOZ(vp), (vattr_t *)&xvap, 0, cred, NULL));
+	return (zfs_setattr(VTOZ(vp), (vattr_t *)&xvap, 0, cred));
 }
 
 #ifndef _SYS_SYSPROTO_H_
@@ -5574,7 +5567,7 @@ zfs_freebsd_symlink(struct vop_symlink_args *ap)
 	*ap->a_vpp = NULL;
 
 	rc = zfs_symlink(VTOZ(ap->a_dvp), cnp->cn_nameptr, vap,
-	    ap->a_target, &zp, cnp->cn_cred, 0 /* flags */, NULL);
+	    ap->a_target, &zp, cnp->cn_cred, 0 /* flags */);
 	if (rc == 0) {
 		*ap->a_vpp = ZTOV(zp);
 		ASSERT_VOP_ELOCKED(ZTOV(zp), __func__);

--- a/module/os/freebsd/zfs/zfs_znode_os.c
+++ b/module/os/freebsd/zfs/zfs_znode_os.c
@@ -294,7 +294,7 @@ zfs_create_share_dir(zfsvfs_t *zfsvfs, dmu_tx_t *tx)
 	sharezp->z_pflags = 0;
 
 	VERIFY0(zfs_acl_ids_create(sharezp, IS_ROOT_NODE, &vattr,
-	    kcred, NULL, &acl_ids, NULL));
+	    kcred, NULL, &acl_ids));
 	zfs_mknode(sharezp, &vattr, tx, kcred, IS_ROOT_NODE, &zp, &acl_ids);
 	ASSERT3P(zp, ==, sharezp);
 	POINTER_INVALIDATE(&sharezp->z_zfsvfs);
@@ -1871,7 +1871,7 @@ zfs_create_fs(objset_t *os, cred_t *cr, nvlist_t *zplprops, dmu_tx_t *tx)
 
 	rootzp->z_zfsvfs = zfsvfs;
 	VERIFY0(zfs_acl_ids_create(rootzp, IS_ROOT_NODE, &vattr,
-	    cr, NULL, &acl_ids, NULL));
+	    cr, NULL, &acl_ids));
 	zfs_mknode(rootzp, &vattr, tx, cr, IS_ROOT_NODE, &zp, &acl_ids);
 	ASSERT3P(zp, ==, rootzp);
 	error = zap_add(os, moid, ZFS_ROOT_OBJ, 8, 1, &rootzp->z_id, tx);

--- a/module/os/freebsd/zfs/zfs_znode_os.c
+++ b/module/os/freebsd/zfs/zfs_znode_os.c
@@ -46,7 +46,7 @@
 #include <sys/unistd.h>
 #include <sys/atomic.h>
 #include <sys/zfs_dir.h>
-#include <sys/zfs_acl.h>
+#include <sys/zfs_acl_impl.h>
 #include <sys/zfs_ioctl.h>
 #include <sys/zfs_rlock.h>
 #include <sys/zfs_fuid.h>

--- a/module/os/linux/zfs/zfs_acl.c
+++ b/module/os/linux/zfs/zfs_acl.c
@@ -42,7 +42,7 @@
 #include <sys/policy.h>
 #include <sys/zfs_znode.h>
 #include <sys/zfs_fuid.h>
-#include <sys/zfs_acl.h>
+#include <sys/zfs_acl_impl.h>
 #include <sys/zfs_dir.h>
 #include <sys/zfs_quota.h>
 #include <sys/zfs_vfsops.h>

--- a/module/os/linux/zfs/zfs_acl.c
+++ b/module/os/linux/zfs/zfs_acl.c
@@ -2413,26 +2413,6 @@ zfs_zaccess_aces_check(znode_t *zp, uint32_t *working_mode,
 }
 
 /*
- * Return true if any access whatsoever granted, we don't actually
- * care what access is granted.
- */
-boolean_t
-zfs_has_access(znode_t *zp, cred_t *cr)
-{
-	uint32_t have = ACE_ALL_PERMS;
-
-	if (zfs_zaccess_aces_check(zp, &have, B_TRUE, cr,
-	    zfs_init_idmap) != 0) {
-		uid_t owner;
-
-		owner = zfs_fuid_map_id(ZTOZSB(zp),
-		    KUID_TO_SUID(ZTOI(zp)->i_uid), cr, ZFS_OWNER);
-		return (secpolicy_vnode_any_access(cr, ZTOI(zp), owner) == 0);
-	}
-	return (B_TRUE);
-}
-
-/*
  * Simplified access check for case where ACL is known to not contain
  * information beyond what is defined in the mode. In this case, we
  * can pass along to the kernel / vfs generic_permission() check, which

--- a/module/os/linux/zfs/zfs_acl.c
+++ b/module/os/linux/zfs/zfs_acl.c
@@ -23,6 +23,7 @@
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2013 by Delphix. All rights reserved.
  * Copyright 2014 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright (c) 2026, TrueNAS.
  */
 
 
@@ -1982,8 +1983,7 @@ zfs_getacl(znode_t *zp, vsecattr_t *vsecp, boolean_t skipaclchk, cred_t *cr)
 	if (mask == 0)
 		return (SET_ERROR(ENOSYS));
 
-	if ((error = zfs_zaccess(zp, ACE_READ_ACL, 0, skipaclchk, cr,
-	    zfs_init_idmap)))
+	if ((error = zfs_zaccess(zp, ACE_READ_ACL, 0, skipaclchk, cr)))
 		return (error);
 
 	mutex_enter(&zp->z_acl_lock);
@@ -2142,8 +2142,7 @@ zfs_setacl(znode_t *zp, vsecattr_t *vsecp, boolean_t skipaclchk, cred_t *cr)
 	if (zp->z_pflags & ZFS_IMMUTABLE)
 		return (SET_ERROR(EPERM));
 
-	if ((error = zfs_zaccess(zp, ACE_WRITE_ACL, 0, skipaclchk, cr,
-	    zfs_init_idmap)))
+	if ((error = zfs_zaccess(zp, ACE_WRITE_ACL, 0, skipaclchk, cr)))
 		return (error);
 
 	error = zfs_vsec_2_aclp(zfsvfs, ZTOI(zp)->i_mode, vsecp, cr, &fuidp,
@@ -2591,8 +2590,7 @@ slow:
 	DTRACE_PROBE(zfs__fastpath__execute__access__miss);
 	if ((error = zfs_enter(ZTOZSB(zdp), FTAG)) != 0)
 		return (error);
-	error = zfs_zaccess(zdp, ACE_EXECUTE, 0, B_FALSE, cr,
-	    zfs_init_idmap);
+	error = zfs_zaccess(zdp, ACE_EXECUTE, 0, B_FALSE, cr);
 	zfs_exit(ZTOZSB(zdp), FTAG);
 	return (error);
 }
@@ -2604,8 +2602,8 @@ slow:
  * can define any form of access.
  */
 int
-zfs_zaccess(znode_t *zp, int mode, int flags, boolean_t skipaclchk, cred_t *cr,
-    zidmap_t *mnt_ns)
+zfs_zaccess_idmap(znode_t *zp, int mode, int flags, boolean_t skipaclchk,
+    cred_t *cr, zidmap_t *mnt_ns)
 {
 	uint32_t	working_mode;
 	int		error;
@@ -2748,16 +2746,30 @@ zfs_zaccess(znode_t *zp, int mode, int flags, boolean_t skipaclchk, cred_t *cr,
 	return (error);
 }
 
+int
+zfs_zaccess(znode_t *zp, int mode, int flags, boolean_t skipaclchk,
+    cred_t *cr)
+{
+	return (zfs_zaccess_idmap(zp, mode, flags, skipaclchk, cr,
+	    zfs_init_idmap));
+}
+
 /*
  * Translate traditional unix S_IRUSR/S_IWUSR/S_IXUSR mode into
  * NFSv4-style ZFS ACL format and call zfs_zaccess()
  */
 int
-zfs_zaccess_rwx(znode_t *zp, mode_t mode, int flags, cred_t *cr,
+zfs_zaccess_rwx_idmap(znode_t *zp, mode_t mode, int flags, cred_t *cr,
     zidmap_t *mnt_ns)
 {
-	return (zfs_zaccess(zp, zfs_unix_to_v4(mode >> 6), flags, B_FALSE, cr,
-	    mnt_ns));
+	return (zfs_zaccess_idmap(zp, zfs_unix_to_v4(mode >> 6), flags,
+	    B_FALSE, cr, mnt_ns));
+}
+
+int
+zfs_zaccess_rwx(znode_t *zp, mode_t mode, int flags, cred_t *cr)
+{
+	return (zfs_zaccess_rwx_idmap(zp, mode, flags, cr, zfs_init_idmap));
 }
 
 /*
@@ -2768,7 +2780,7 @@ zfs_zaccess_unix(void *zp, int mode, cred_t *cr)
 {
 	int v4_mode = zfs_unix_to_v4(mode >> 6);
 
-	return (zfs_zaccess(zp, v4_mode, 0, B_FALSE, cr, zfs_init_idmap));
+	return (zfs_zaccess(zp, v4_mode, 0, B_FALSE, cr));
 }
 
 /* See zfs_zaccess_delete() */
@@ -3012,7 +3024,7 @@ zfs_zaccess_rename(znode_t *sdzp, znode_t *szp, znode_t *tdzp,
 	/*
 	 * Now check for add permissions
 	 */
-	error = zfs_zaccess(tdzp, add_perm, 0, B_FALSE, cr, mnt_ns);
+	error = zfs_zaccess_idmap(tdzp, add_perm, 0, B_FALSE, cr, mnt_ns);
 
 	return (error);
 }

--- a/module/os/linux/zfs/zfs_dir.c
+++ b/module/os/linux/zfs/zfs_dir.c
@@ -1314,8 +1314,7 @@ zfs_sticky_remove_access(znode_t *zdp, znode_t *zp, cred_t *cr)
 	    cr, ZFS_OWNER);
 
 	if ((uid = crgetuid(cr)) == downer || uid == fowner ||
-	    zfs_zaccess(zp, ACE_WRITE_DATA, 0, B_FALSE, cr,
-	    zfs_init_idmap) == 0)
+	    zfs_zaccess(zp, ACE_WRITE_DATA, 0, B_FALSE, cr) == 0)
 		return (0);
 	else
 		return (secpolicy_vnode_remove(cr));

--- a/module/os/linux/zfs/zfs_dir.c
+++ b/module/os/linux/zfs/zfs_dir.c
@@ -43,7 +43,7 @@
 #include <sys/random.h>
 #include <sys/policy.h>
 #include <sys/zfs_dir.h>
-#include <sys/zfs_acl.h>
+#include <sys/zfs_acl_impl.h>
 #include <sys/zfs_vnops.h>
 #include <sys/fs/zfs.h>
 #include <sys/zap.h>

--- a/module/os/linux/zfs/zfs_vnops_os.c
+++ b/module/os/linux/zfs/zfs_vnops_os.c
@@ -26,6 +26,7 @@
  * Copyright (c) 2015 by Chunwei Chen. All rights reserved.
  * Copyright 2017 Nexenta Systems, Inc.
  * Copyright (c) 2025, Klara, Inc.
+ * Copyright (c) 2026, TrueNAS.
  */
 
 /* Portions Copyright 2007 Jeremy Teo */
@@ -498,8 +499,7 @@ zfs_lookup(znode_t *zdp, char *nm, znode_t **zpp, int flags, cred_t *cr,
 		 * Do we have permission to get into attribute directory?
 		 */
 
-		if ((error = zfs_zaccess(*zpp, ACE_EXECUTE, 0,
-		    B_TRUE, cr, zfs_init_idmap))) {
+		if ((error = zfs_zaccess(*zpp, ACE_EXECUTE, 0, B_TRUE, cr))) {
 			zrele(*zpp);
 			*zpp = NULL;
 		}
@@ -517,8 +517,7 @@ zfs_lookup(znode_t *zdp, char *nm, znode_t **zpp, int flags, cred_t *cr,
 	 * Check accessibility of directory.
 	 */
 
-	if ((error = zfs_zaccess(zdp, ACE_EXECUTE, 0, B_FALSE, cr,
-	    zfs_init_idmap))) {
+	if ((error = zfs_zaccess(zdp, ACE_EXECUTE, 0, B_FALSE, cr))) {
 		zfs_exit(zfsvfs, FTAG);
 		return (error);
 	}
@@ -691,8 +690,8 @@ top:
 		 * Create a new file object and update the directory
 		 * to reference it.
 		 */
-		if ((error = zfs_zaccess(dzp, ACE_ADD_FILE, 0, skip_acl, cr,
-		    mnt_ns))) {
+		if ((error = zfs_zaccess_idmap(dzp, ACE_ADD_FILE, 0, skip_acl,
+		    cr, mnt_ns))) {
 			if (have_acl)
 				zfs_acl_ids_free(&acl_ids);
 			goto out;
@@ -805,8 +804,8 @@ top:
 		/*
 		 * Verify requested access to file.
 		 */
-		if (mode && (error = zfs_zaccess_rwx(zp, mode, aflags, cr,
-		    mnt_ns))) {
+		if (mode && (error = zfs_zaccess_rwx_idmap(zp, mode, aflags,
+		    cr, mnt_ns))) {
 			goto out;
 		}
 
@@ -896,7 +895,8 @@ top:
 	 * Create a new file object and update the directory
 	 * to reference it.
 	 */
-	if ((error = zfs_zaccess(dzp, ACE_ADD_FILE, 0, B_FALSE, cr, mnt_ns))) {
+	if ((error = zfs_zaccess_idmap(dzp, ACE_ADD_FILE, 0, B_FALSE,
+	    cr, mnt_ns))) {
 		if (have_acl)
 			zfs_acl_ids_free(&acl_ids);
 		goto out;
@@ -1310,8 +1310,8 @@ top:
 		return (error);
 	}
 
-	if ((error = zfs_zaccess(dzp, ACE_ADD_SUBDIRECTORY, 0, B_FALSE, cr,
-	    mnt_ns))) {
+	if ((error = zfs_zaccess_idmap(dzp, ACE_ADD_SUBDIRECTORY, 0, B_FALSE,
+	    cr, mnt_ns))) {
 		zfs_acl_ids_free(&acl_ids);
 		zfs_dirent_unlock(dl);
 		zfs_exit(zfsvfs, FTAG);
@@ -2067,8 +2067,8 @@ top:
 	 */
 
 	if (mask & ATTR_SIZE) {
-		err = zfs_zaccess(zp, ACE_WRITE_DATA, 0, skipaclchk, cr,
-		    mnt_ns);
+		err = zfs_zaccess_idmap(zp, ACE_WRITE_DATA, 0, skipaclchk,
+		    cr, mnt_ns);
 		if (err)
 			goto out3;
 
@@ -2092,7 +2092,7 @@ top:
 	    XVA_ISSET_REQ(xvap, XAT_SPARSE) ||
 	    XVA_ISSET_REQ(xvap, XAT_CREATETIME) ||
 	    XVA_ISSET_REQ(xvap, XAT_SYSTEM)))) {
-		need_policy = zfs_zaccess(zp, ACE_WRITE_ATTRIBUTES, 0,
+		need_policy = zfs_zaccess_idmap(zp, ACE_WRITE_ATTRIBUTES, 0,
 		    skipaclchk, cr, mnt_ns);
 	}
 
@@ -2136,7 +2136,7 @@ top:
 		    take_owner && take_group) ||
 		    ((idmask == ATTR_UID) && take_owner) ||
 		    ((idmask == ATTR_GID) && take_group)) {
-			if (zfs_zaccess(zp, ACE_WRITE_OWNER, 0,
+			if (zfs_zaccess_idmap(zp, ACE_WRITE_OWNER, 0,
 			    skipaclchk, cr, mnt_ns) == 0) {
 				/*
 				 * Remove setuid/setgid for non-privileged users
@@ -2250,7 +2250,7 @@ top:
 	mutex_exit(&zp->z_lock);
 
 	if (mask & ATTR_MODE) {
-		if (zfs_zaccess(zp, ACE_WRITE_ACL, 0, skipaclchk, cr,
+		if (zfs_zaccess_idmap(zp, ACE_WRITE_ACL, 0, skipaclchk, cr,
 		    mnt_ns) == 0) {
 			err = secpolicy_setid_setsticky_clear(ip, vap,
 			    &oldva, cr, mnt_ns, zfs_i_user_ns(ip));
@@ -3043,7 +3043,8 @@ top:
 		 */
 		uint64_t wo_projid = ZFS_DEFAULT_PROJID;
 
-		error = zfs_zaccess(sdzp, ACE_ADD_FILE, 0, B_FALSE, cr, mnt_ns);
+		error = zfs_zaccess_idmap(sdzp, ACE_ADD_FILE, 0, B_FALSE,
+		    cr, mnt_ns);
 		if (error)
 			goto out;
 
@@ -3362,7 +3363,8 @@ top:
 		return (error);
 	}
 
-	if ((error = zfs_zaccess(dzp, ACE_ADD_FILE, 0, B_FALSE, cr, mnt_ns))) {
+	if ((error = zfs_zaccess_idmap(dzp, ACE_ADD_FILE, 0, B_FALSE,
+	    cr, mnt_ns))) {
 		zfs_acl_ids_free(&acl_ids);
 		zfs_dirent_unlock(dl);
 		zfs_exit(zfsvfs, FTAG);
@@ -3616,8 +3618,7 @@ zfs_link(znode_t *tdzp, znode_t *szp, char *name, cred_t *cr,
 		return (SET_ERROR(EPERM));
 	}
 
-	if ((error = zfs_zaccess(tdzp, ACE_ADD_FILE, 0, B_FALSE, cr,
-	    zfs_init_idmap))) {
+	if ((error = zfs_zaccess(tdzp, ACE_ADD_FILE, 0, B_FALSE, cr))) {
 		zfs_exit(zfsvfs, FTAG);
 		return (error);
 	}
@@ -4366,8 +4367,7 @@ zfs_space(znode_t *zp, int cmd, flock64_t *bfp, int flag,
 	 * On Linux we can get here through truncate_range() which
 	 * operates directly on inodes, so we need to check access rights.
 	 */
-	if ((error = zfs_zaccess(zp, ACE_WRITE_DATA, 0, B_FALSE, cr,
-	    zfs_init_idmap))) {
+	if ((error = zfs_zaccess(zp, ACE_WRITE_DATA, 0, B_FALSE, cr))) {
 		zfs_exit(zfsvfs, FTAG);
 		return (error);
 	}

--- a/module/os/linux/zfs/zfs_vnops_os.c
+++ b/module/os/linux/zfs/zfs_vnops_os.c
@@ -47,7 +47,7 @@
 #include <sys/cmn_err.h>
 #include <sys/errno.h>
 #include <sys/zfs_dir.h>
-#include <sys/zfs_acl.h>
+#include <sys/zfs_acl_impl.h>
 #include <sys/zfs_ioctl.h>
 #include <sys/fs/zfs.h>
 #include <sys/dmu.h>

--- a/module/os/linux/zfs/zfs_vnops_os.c
+++ b/module/os/linux/zfs/zfs_vnops_os.c
@@ -600,7 +600,7 @@ zfs_get_name(znode_t *dzp, char *name, znode_t *zp)
  *	 zp - ctime|mtime always, atime if new
  */
 int
-zfs_create(znode_t *dzp, char *name, vattr_t *vap, int excl,
+zfs_create_idmap(znode_t *dzp, char *name, vattr_t *vap, int excl,
     int mode, znode_t **zpp, cred_t *cr, int flag, vsecattr_t *vsecp,
     zidmap_t *mnt_ns)
 {
@@ -844,9 +844,16 @@ out:
 	zfs_exit(zfsvfs, FTAG);
 	return (error);
 }
+int
+zfs_create(znode_t *dzp, char *name, vattr_t *vap, int excl,
+    int mode, znode_t **zpp, cred_t *cr, int flag, vsecattr_t *vsecp)
+{
+	return (zfs_create_idmap(dzp, name, vap, excl, mode, zpp, cr, flag,
+	    vsecp, zfs_init_idmap));
+}
 
 int
-zfs_tmpfile(struct inode *dip, vattr_t *vap, int excl,
+zfs_tmpfile_idmap(struct inode *dip, vattr_t *vap, int excl,
     int mode, struct inode **ipp, cred_t *cr, int flag, vsecattr_t *vsecp,
     zidmap_t *mnt_ns)
 {
@@ -966,6 +973,13 @@ out:
 
 	zfs_exit(zfsvfs, FTAG);
 	return (error);
+}
+int
+zfs_tmpfile(struct inode *dip, vattr_t *vap, int excl,
+    int mode, struct inode **ipp, cred_t *cr, int flag, vsecattr_t *vsecp)
+{
+	return (zfs_tmpfile_idmap(dip, vap, excl, mode, ipp, cr, flag, vsecp,
+	    zfs_init_idmap));
 }
 
 /*
@@ -1231,7 +1245,7 @@ out:
  *	zpp - ctime|mtime|atime updated
  */
 int
-zfs_mkdir(znode_t *dzp, char *dirname, vattr_t *vap, znode_t **zpp,
+zfs_mkdir_idmap(znode_t *dzp, char *dirname, vattr_t *vap, znode_t **zpp,
     cred_t *cr, int flags, vsecattr_t *vsecp, zidmap_t *mnt_ns)
 {
 	znode_t		*zp;
@@ -1404,6 +1418,13 @@ out:
 	}
 	zfs_exit(zfsvfs, FTAG);
 	return (error);
+}
+int
+zfs_mkdir(znode_t *dzp, char *dirname, vattr_t *vap, znode_t **zpp,
+    cred_t *cr, int flags, vsecattr_t *vsecp)
+{
+	return (zfs_mkdir_idmap(dzp, dirname, vap, zpp, cr, flags, vsecp,
+	    zfs_init_idmap));
 }
 
 /*
@@ -1920,7 +1941,8 @@ next:
  *	ip - ctime updated, mtime updated if size changed.
  */
 int
-zfs_setattr(znode_t *zp, vattr_t *vap, int flags, cred_t *cr, zidmap_t *mnt_ns)
+zfs_setattr_idmap(znode_t *zp, vattr_t *vap, int flags, cred_t *cr,
+    zidmap_t *mnt_ns)
 {
 	struct inode	*ip;
 	zfsvfs_t	*zfsvfs = ZTOZSB(zp);
@@ -2654,6 +2676,11 @@ out3:
 	zfs_exit(zfsvfs, FTAG);
 	return (err);
 }
+int
+zfs_setattr(znode_t *zp, vattr_t *vap, int flags, cred_t *cr)
+{
+	return (zfs_setattr_idmap(zp, vap, flags, cr, zfs_init_idmap));
+}
 
 typedef struct zfs_zlock {
 	krwlock_t	*zl_rwlock;	/* lock we acquired */
@@ -2772,7 +2799,7 @@ zfs_rename_lock(znode_t *szp, znode_t *tdzp, znode_t *sdzp, zfs_zlock_t **zlpp)
  *	sdzp,tdzp - ctime|mtime updated
  */
 int
-zfs_rename(znode_t *sdzp, char *snm, znode_t *tdzp, char *tnm,
+zfs_rename_idmap(znode_t *sdzp, char *snm, znode_t *tdzp, char *tnm,
     cred_t *cr, int flags, uint64_t rflags, vattr_t *wo_vap, zidmap_t *mnt_ns)
 {
 	znode_t		*szp, *tzp;
@@ -3287,6 +3314,13 @@ commit_link_szp:
 		VERIFY0(zfs_drop_nlink(szp, tx, NULL));
 	goto commit;
 }
+int
+zfs_rename(znode_t *sdzp, char *snm, znode_t *tdzp, char *tnm,
+    cred_t *cr, int flags, uint64_t rflags, vattr_t *wo_vap)
+{
+	return (zfs_rename_idmap(sdzp, snm, tdzp, tnm, cr, flags, rflags,
+	    wo_vap, zfs_init_idmap));
+}
 
 /*
  * Insert the indicated symbolic reference entry into the directory.
@@ -3307,7 +3341,7 @@ commit_link_szp:
  *	dip - ctime|mtime updated
  */
 int
-zfs_symlink(znode_t *dzp, char *name, vattr_t *vap, char *link,
+zfs_symlink_idmap(znode_t *dzp, char *name, vattr_t *vap, char *link,
     znode_t **zpp, cred_t *cr, int flags, zidmap_t *mnt_ns)
 {
 	znode_t		*zp;
@@ -3459,6 +3493,13 @@ top:
 
 	zfs_exit(zfsvfs, FTAG);
 	return (error);
+}
+int
+zfs_symlink(znode_t *dzp, char *name, vattr_t *vap, char *link,
+    znode_t **zpp, cred_t *cr, int flags)
+{
+	return (zfs_symlink_idmap(dzp, name, vap, link, zpp, cr, flags,
+	    zfs_init_idmap));
 }
 
 /*

--- a/module/os/linux/zfs/zfs_znode_os.c
+++ b/module/os/linux/zfs/zfs_znode_os.c
@@ -40,7 +40,7 @@
 #include <sys/errno.h>
 #include <sys/atomic.h>
 #include <sys/zfs_dir.h>
-#include <sys/zfs_acl.h>
+#include <sys/zfs_acl_impl.h>
 #include <sys/zfs_ioctl.h>
 #include <sys/zfs_rlock.h>
 #include <sys/zfs_fuid.h>

--- a/module/os/linux/zfs/zpl_file.c
+++ b/module/os/linux/zfs/zpl_file.c
@@ -1019,7 +1019,7 @@ zpl_ioctl_setflags(struct file *filp, void __user *arg)
 
 	crhold(cr);
 	cookie = spl_fstrans_mark();
-	err = -zfs_setattr(ITOZ(ip), (vattr_t *)&xva, 0, cr, zfs_init_idmap);
+	err = -zfs_setattr(ITOZ(ip), (vattr_t *)&xva, 0, cr);
 	spl_fstrans_unmark(cookie);
 	crfree(cr);
 
@@ -1067,7 +1067,7 @@ zpl_ioctl_setxattr(struct file *filp, void __user *arg)
 
 	crhold(cr);
 	cookie = spl_fstrans_mark();
-	err = -zfs_setattr(ITOZ(ip), (vattr_t *)&xva, 0, cr, zfs_init_idmap);
+	err = -zfs_setattr(ITOZ(ip), (vattr_t *)&xva, 0, cr);
 	spl_fstrans_unmark(cookie);
 	crfree(cr);
 
@@ -1155,7 +1155,7 @@ zpl_ioctl_setdosflags(struct file *filp, void __user *arg)
 
 	crhold(cr);
 	cookie = spl_fstrans_mark();
-	err = -zfs_setattr(ITOZ(ip), (vattr_t *)&xva, 0, cr, zfs_init_idmap);
+	err = -zfs_setattr(ITOZ(ip), (vattr_t *)&xva, 0, cr);
 	spl_fstrans_unmark(cookie);
 	crfree(cr);
 

--- a/module/os/linux/zfs/zpl_inode.c
+++ b/module/os/linux/zfs/zpl_inode.c
@@ -23,6 +23,7 @@
  * Copyright (c) 2011, Lawrence Livermore National Security, LLC.
  * Copyright (c) 2015 by Chunwei Chen. All rights reserved.
  * Copyright (c) 2025, Rob Norris <robn@despairlabs.com>
+ * Copyright (c) 2026, TrueNAS.
  */
 
 
@@ -193,7 +194,7 @@ zpl_create(struct inode *dir, struct dentry *dentry, umode_t mode, bool flag)
 	zpl_vap_init(vap, dir, mode, cr, user_ns);
 
 	cookie = spl_fstrans_mark();
-	error = -zfs_create(ITOZ(dir), dname(dentry), vap, 0,
+	error = -zfs_create_idmap(ITOZ(dir), dname(dentry), vap, 0,
 	    mode, &zp, cr, 0, NULL, user_ns);
 	if (error == 0) {
 		error = zpl_xattr_security_init(ZTOI(zp), dir, &dentry->d_name);
@@ -255,7 +256,7 @@ zpl_mknod(struct inode *dir, struct dentry *dentry, umode_t mode,
 	vap->va_rdev = rdev;
 
 	cookie = spl_fstrans_mark();
-	error = -zfs_create(ITOZ(dir), dname(dentry), vap, 0,
+	error = -zfs_create_idmap(ITOZ(dir), dname(dentry), vap, 0,
 	    mode, &zp, cr, 0, NULL, user_ns);
 	if (error == 0) {
 		error = zpl_xattr_security_init(ZTOI(zp), dir, &dentry->d_name);
@@ -315,7 +316,7 @@ zpl_tmpfile(struct inode *dir, struct dentry *dentry, umode_t mode)
 	zpl_vap_init(vap, dir, mode, cr, userns);
 
 	cookie = spl_fstrans_mark();
-	error = -zfs_tmpfile(dir, vap, 0, mode, &ip, cr, 0, NULL, userns);
+	error = -zfs_tmpfile_idmap(dir, vap, 0, mode, &ip, cr, 0, NULL, userns);
 	if (error == 0) {
 		/* d_tmpfile will do drop_nlink, so we should set it first */
 		set_nlink(ip, 1);
@@ -411,8 +412,8 @@ zpl_mkdir(struct inode *dir, struct dentry *dentry, umode_t mode)
 	zpl_vap_init(vap, dir, mode | S_IFDIR, cr, user_ns);
 
 	cookie = spl_fstrans_mark();
-	error = -zfs_mkdir(ITOZ(dir), dname(dentry), vap, &zp, cr, 0, NULL,
-	    user_ns);
+	error = -zfs_mkdir_idmap(ITOZ(dir), dname(dentry), vap, &zp, cr, 0,
+	    NULL, user_ns);
 	if (error == 0) {
 		error = zpl_xattr_security_init(ZTOI(zp), dir, &dentry->d_name);
 		if (error == 0)
@@ -626,11 +627,11 @@ zpl_setattr(struct dentry *dentry, struct iattr *ia)
 
 	cookie = spl_fstrans_mark();
 #ifdef HAVE_USERNS_IOPS_SETATTR
-	error = -zfs_setattr(ITOZ(ip), vap, 0, cr, user_ns);
+	error = -zfs_setattr_idmap(ITOZ(ip), vap, 0, cr, user_ns);
 #elif defined(HAVE_IDMAP_IOPS_SETATTR)
-	error = -zfs_setattr(ITOZ(ip), vap, 0, cr, user_ns);
+	error = -zfs_setattr_idmap(ITOZ(ip), vap, 0, cr, user_ns);
 #else
-	error = -zfs_setattr(ITOZ(ip), vap, 0, cr, zfs_init_idmap);
+	error = -zfs_setattr(ITOZ(ip), vap, 0, cr);
 #endif
 	if (!error && (ia->ia_valid & ATTR_MODE))
 		error = zpl_chmod_acl(ip);
@@ -677,7 +678,7 @@ zpl_rename2(struct inode *sdip, struct dentry *sdentry,
 	}
 
 	cookie = spl_fstrans_mark();
-	error = -zfs_rename(ITOZ(sdip), dname(sdentry), ITOZ(tdip),
+	error = -zfs_rename_idmap(ITOZ(sdip), dname(sdentry), ITOZ(tdip),
 	    dname(tdentry), cr, 0, rflags, wo_vap, user_ns);
 	spl_fstrans_unmark(cookie);
 	if (wo_vap)
@@ -728,7 +729,7 @@ zpl_symlink(struct inode *dir, struct dentry *dentry, const char *name)
 	zpl_vap_init(vap, dir, S_IFLNK | S_IRWXUGO, cr, user_ns);
 
 	cookie = spl_fstrans_mark();
-	error = -zfs_symlink(ITOZ(dir), dname(dentry), vap,
+	error = -zfs_symlink_idmap(ITOZ(dir), dname(dentry), vap,
 	    (char *)name, &zp, cr, 0, user_ns);
 	if (error == 0) {
 		error = zpl_xattr_security_init(ZTOI(zp), dir, &dentry->d_name);

--- a/module/os/linux/zfs/zpl_xattr.c
+++ b/module/os/linux/zfs/zpl_xattr.c
@@ -508,7 +508,7 @@ zpl_xattr_set_dir(struct inode *ip, const char *name, const void *value,
 		vap->va_gid = crgetgid(cr);
 
 		error = -zfs_create(dxzp, (char *)name, vap, 0, 0644, &xzp,
-		    cr, ATTR_NOACLCHECK, NULL, zfs_init_idmap);
+		    cr, ATTR_NOACLCHECK, NULL);
 		if (error)
 			goto out;
 	}

--- a/module/zfs/zfs_replay.c
+++ b/module/zfs/zfs_replay.c
@@ -390,14 +390,8 @@ zfs_replay_create_acl(void *arg1, void *arg2, boolean_t byteswap)
 			    (void *)&name, lracl->lr_fuidcnt, lracl->lr_domcnt,
 			    lr->lr_uid, lr->lr_gid);
 		}
-
-#if defined(__linux__)
-		error = zfs_create(dzp, name, &xva.xva_vattr,
-		    0, 0, &zp, kcred, vflg, &vsec, zfs_init_idmap);
-#else
 		error = zfs_create(dzp, name, &xva.xva_vattr,
 		    0, 0, &zp, kcred, vflg, &vsec);
-#endif
 		break;
 	case TX_MKDIR_ACL:
 		aclstart = &lracl->lr_data[0];
@@ -425,13 +419,8 @@ zfs_replay_create_acl(void *arg1, void *arg2, boolean_t byteswap)
 			    (void *)&name, lracl->lr_fuidcnt, lracl->lr_domcnt,
 			    lr->lr_uid, lr->lr_gid);
 		}
-#if defined(__linux__)
-		error = zfs_mkdir(dzp, name, &xva.xva_vattr,
-		    &zp, kcred, vflg, &vsec, zfs_init_idmap);
-#else
 		error = zfs_mkdir(dzp, name, &xva.xva_vattr,
 		    &zp, kcred, vflg, &vsec);
-#endif
 		break;
 	default:
 		error = SET_ERROR(ENOTSUP);
@@ -542,14 +531,8 @@ zfs_replay_create(void *arg1, void *arg2, boolean_t byteswap)
 	case TX_CREATE:
 		if (name == NULL)
 			name = (char *)start;
-
-#if defined(__linux__)
-		error = zfs_create(dzp, name, &xva.xva_vattr,
-		    0, 0, &zp, kcred, vflg, NULL, zfs_init_idmap);
-#else
 		error = zfs_create(dzp, name, &xva.xva_vattr,
 		    0, 0, &zp, kcred, vflg, NULL);
-#endif
 		break;
 	case TX_MKDIR_ATTR:
 		lrattr = (lr_attr_t *)&lrc->lr_data[0];
@@ -565,15 +548,8 @@ zfs_replay_create(void *arg1, void *arg2, boolean_t byteswap)
 	case TX_MKDIR:
 		if (name == NULL)
 			name = (char *)&lrc->lr_data[0];
-
-#if defined(__linux__)
-		error = zfs_mkdir(dzp, name, &xva.xva_vattr,
-		    &zp, kcred, vflg, NULL, zfs_init_idmap);
-#else
 		error = zfs_mkdir(dzp, name, &xva.xva_vattr,
 		    &zp, kcred, vflg, NULL);
-#endif
-
 		break;
 	case TX_MKXATTR:
 		error = zfs_make_xattrdir(dzp, &xva.xva_vattr, &zp, kcred);
@@ -581,13 +557,8 @@ zfs_replay_create(void *arg1, void *arg2, boolean_t byteswap)
 	case TX_SYMLINK:
 		name = &lrc->lr_data[0];
 		link = &lrc->lr_data[strlen(name) + 1];
-#if defined(__linux__)
-		error = zfs_symlink(dzp, name, &xva.xva_vattr,
-		    link, &zp, kcred, vflg, zfs_init_idmap);
-#else
 		error = zfs_symlink(dzp, name, &xva.xva_vattr,
 		    link, &zp, kcred, vflg);
-#endif
 		break;
 	default:
 		error = SET_ERROR(ENOTSUP);
@@ -706,13 +677,8 @@ do_zfs_replay_rename(zfsvfs_t *zfsvfs, _lr_rename_t *lr, char *sname,
 	if (lr->lr_common.lrc_txtype & TX_CI)
 		vflg |= FIGNORECASE;
 
-#if defined(__linux__)
-	error = zfs_rename(sdzp, sname, tdzp, tname, kcred, vflg, rflags,
-	    wo_vap, zfs_init_idmap);
-#else
 	error = zfs_rename(sdzp, sname, tdzp, tname, kcred, vflg, rflags,
 	    wo_vap);
-#endif
 
 	zrele(tdzp);
 	zrele(sdzp);
@@ -1005,11 +971,7 @@ zfs_replay_setattr(void *arg1, void *arg2, boolean_t byteswap)
 	zfsvfs->z_fuid_replay = zfs_replay_fuid_domain(start, &start,
 	    lr->lr_uid, lr->lr_gid);
 
-#if defined(__linux__)
-	error = zfs_setattr(zp, vap, 0, kcred, zfs_init_idmap);
-#else
 	error = zfs_setattr(zp, vap, 0, kcred);
-#endif
 
 	zfs_fuid_info_free(zfsvfs->z_fuid_replay);
 	zfsvfs->z_fuid_replay = NULL;

--- a/module/zfs/zfs_replay.c
+++ b/module/zfs/zfs_replay.c
@@ -24,6 +24,7 @@
  * Copyright (c) 2012 Cyril Plisko. All rights reserved.
  * Copyright (c) 2013, 2017 by Delphix. All rights reserved.
  * Copyright (c) 2021, 2022 by Pawel Jakub Dawidek
+ * Copyright (c) 2026, TrueNAS.
  */
 
 #include <sys/types.h>
@@ -395,7 +396,7 @@ zfs_replay_create_acl(void *arg1, void *arg2, boolean_t byteswap)
 		    0, 0, &zp, kcred, vflg, &vsec, zfs_init_idmap);
 #else
 		error = zfs_create(dzp, name, &xva.xva_vattr,
-		    0, 0, &zp, kcred, vflg, &vsec, NULL);
+		    0, 0, &zp, kcred, vflg, &vsec);
 #endif
 		break;
 	case TX_MKDIR_ACL:
@@ -429,7 +430,7 @@ zfs_replay_create_acl(void *arg1, void *arg2, boolean_t byteswap)
 		    &zp, kcred, vflg, &vsec, zfs_init_idmap);
 #else
 		error = zfs_mkdir(dzp, name, &xva.xva_vattr,
-		    &zp, kcred, vflg, &vsec, NULL);
+		    &zp, kcred, vflg, &vsec);
 #endif
 		break;
 	default:
@@ -547,7 +548,7 @@ zfs_replay_create(void *arg1, void *arg2, boolean_t byteswap)
 		    0, 0, &zp, kcred, vflg, NULL, zfs_init_idmap);
 #else
 		error = zfs_create(dzp, name, &xva.xva_vattr,
-		    0, 0, &zp, kcred, vflg, NULL, NULL);
+		    0, 0, &zp, kcred, vflg, NULL);
 #endif
 		break;
 	case TX_MKDIR_ATTR:
@@ -570,7 +571,7 @@ zfs_replay_create(void *arg1, void *arg2, boolean_t byteswap)
 		    &zp, kcred, vflg, NULL, zfs_init_idmap);
 #else
 		error = zfs_mkdir(dzp, name, &xva.xva_vattr,
-		    &zp, kcred, vflg, NULL, NULL);
+		    &zp, kcred, vflg, NULL);
 #endif
 
 		break;
@@ -585,7 +586,7 @@ zfs_replay_create(void *arg1, void *arg2, boolean_t byteswap)
 		    link, &zp, kcred, vflg, zfs_init_idmap);
 #else
 		error = zfs_symlink(dzp, name, &xva.xva_vattr,
-		    link, &zp, kcred, vflg, NULL);
+		    link, &zp, kcred, vflg);
 #endif
 		break;
 	default:
@@ -710,7 +711,7 @@ do_zfs_replay_rename(zfsvfs_t *zfsvfs, _lr_rename_t *lr, char *sname,
 	    wo_vap, zfs_init_idmap);
 #else
 	error = zfs_rename(sdzp, sname, tdzp, tname, kcred, vflg, rflags,
-	    wo_vap, NULL);
+	    wo_vap);
 #endif
 
 	zrele(tdzp);
@@ -1007,7 +1008,7 @@ zfs_replay_setattr(void *arg1, void *arg2, boolean_t byteswap)
 #if defined(__linux__)
 	error = zfs_setattr(zp, vap, 0, kcred, zfs_init_idmap);
 #else
-	error = zfs_setattr(zp, vap, 0, kcred, NULL);
+	error = zfs_setattr(zp, vap, 0, kcred);
 #endif
 
 	zfs_fuid_info_free(zfsvfs->z_fuid_replay);

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -222,14 +222,13 @@ zfs_access(znode_t *zp, int mode, int flag, cred_t *cr)
 		error = zfs_zaccess(zp, mode, flag, B_FALSE, cr,
 		    zfs_init_idmap);
 #else
-		error = zfs_zaccess(zp, mode, flag, B_FALSE, cr,
-		    NULL);
+		error = zfs_zaccess(zp, mode, flag, B_FALSE, cr);
 #endif
 	else
 #if defined(__linux__)
 		error = zfs_zaccess_rwx(zp, mode, flag, cr, zfs_init_idmap);
 #else
-		error = zfs_zaccess_rwx(zp, mode, flag, cr, NULL);
+		error = zfs_zaccess_rwx(zp, mode, flag, cr);
 #endif
 
 	zfs_exit(zfsvfs, FTAG);

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -218,18 +218,9 @@ zfs_access(znode_t *zp, int mode, int flag, cred_t *cr)
 		return (error);
 
 	if (flag & V_ACE_MASK)
-#if defined(__linux__)
-		error = zfs_zaccess(zp, mode, flag, B_FALSE, cr,
-		    zfs_init_idmap);
-#else
 		error = zfs_zaccess(zp, mode, flag, B_FALSE, cr);
-#endif
 	else
-#if defined(__linux__)
-		error = zfs_zaccess_rwx(zp, mode, flag, cr, zfs_init_idmap);
-#else
 		error = zfs_zaccess_rwx(zp, mode, flag, cr);
-#endif
 
 	zfs_exit(zfsvfs, FTAG);
 	return (error);


### PR DESCRIPTION
### Motivation and Context

While finalising another patch series around disentangling the maze of `ifdef`s around userns/idmap handling in the Linux platform code, I was thinking about how to handle the sort-of-not-really knowledge of this on the FreeBSD side - it sort of apes the Linux API, but not really, just enough to sort of match some of the platform APIs, but not enough to do it sensibly.

I decided actually, it's all a mess because we have "core" code calling into platform code for a couple of things that on the Linux side appear to require an idmap, but actually don't if you look at the specific cases.

So here's a bunch of cleanup that is actually the start of two separate API refactors, but is limited to one thing: removing all mention of idmap/userns/`zidmap_t` from anywhere that is not Linux platform code.

### Description

This is almost entirely removing unneeded interfaces, and then moving and reshaping others to draw a clearer line between "core" and "platform" code.

Best reviewed in commit order. I'll describe the overall shapes here.

We start in `zfs_acl`, which is really a grab-bag of access control _stuff_ vs an actual API. First two commits remove some ancient unused code, just to be slightly tidier. Third creates a platform-specific `zfs_acl_impl.h` and moves there all the header prototypes that are only used in platform code, which turns out to be most of them, despite being identical or very very close on Linux & FreeBSD. The main reason for doing this here is to make it possible to comfortably modify the FreeBSD prototypes, and later, add some new Linux-specific functions, but alone its a good start towards a longer-term refactor of the ACL code.

Next, we remove all the `zidmap_t *mnt_ns` args from the FreeBSD platform code, and the `zidmap_t` typedef itself. In the platform code this was almost entirely just passing a `NULL` around, never using. Almost all of the callers come from `zfs_replay.c`, and for whatever reason, the calls were all `ifdef`'d to have separate Linux and FreeBSD versions, with different `zidmap_t` arg anyway. So almost none of it was necessary. The functions being called this way are in `zfs_vnode_ops.h` (already platform-specific) and `zfs_acl.h`, thus the earlier separation - we can now adjust all the uses in one commit.

The final two commits add the necessary functions to replace the Linux versions of the above calls. Those always pass `zfs_init_idmap` as their `zidmap_t` arg, which is effectively the "identity" idmap. Its easy to return the functions called (eg `zfs_create()` to their "common" versions, and have them be wrappers around extended versions that take an additional `zidmap_t` arg, which we use inside the platform code (for VFS calls). Those commits do this, by renaming the existing functions to have a `_idmap` suffix, and then creating wrappers around them all. Again, this could be the start of a better refactor, some of which will occur in the cleanup PR I mentioned before.

And that gets us to the goal of idmap/userns etc only existing in the Linux code. Lovely!

### How Has This Been Tested?

Compile checked:
- FreeBSD: 15.1-RELEASE
- Linux: 5.4.302 5.10.253 5.15.203 6.1.169 6.2.16 6.4.16 6.6.136 6.12.84 6.18.25 7.0.8

Importantly for Linux, these straddle the kcred->userns transition in 5.12, and the userns->idmap transition in 6.3.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
