### PR TITLE
Fix receive -x according to comment

### DIFF
--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -4337,7 +4337,7 @@ zfs_setup_cmdline_props(libzfs_handle_t *hdl, zfs_type_t type,
 				    newname);
 				if (nvlist_lookup_string(attrs,
 				    ZPROP_SOURCE, &source) == 0 &&
-				    strcmp(source, ZPROP_SOURCE_VAL_RECVD) != 0)
+				    strcmp(source, fsname) == 0)
 					continue;
 			}
 			/*

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -300,6 +300,7 @@ tests = ['zfs_receive_001_pos', 'zfs_receive_002_pos', 'zfs_receive_003_pos',
     'zfs_receive_from_encrypted', 'zfs_receive_to_encrypted',
     'zfs_receive_raw', 'zfs_receive_raw_incremental', 'zfs_receive_-e',
     'zfs_receive_raw_-d', 'zfs_receive_from_zstd', 'zfs_receive_new_props',
+    'zfs_receive-x_props_alternation',
     'zfs_receive_-wR-encrypted-mix', 'zfs_receive_corrective',
     'zfs_receive_compressed_corrective', 'zfs_receive_large_block_corrective']
 tags = ['functional', 'cli_root', 'zfs_receive']

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -896,6 +896,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zfs_receive/zfs_receive_-e.ksh \
 	functional/cli_root/zfs_receive/zfs_receive_from_encrypted.ksh \
 	functional/cli_root/zfs_receive/zfs_receive_from_zstd.ksh \
+	functional/cli_root/zfs_receive/zfs_receive-x_props_alternation.ksh \
 	functional/cli_root/zfs_receive/zfs_receive_new_props.ksh \
 	functional/cli_root/zfs_receive/zfs_receive_raw_-d.ksh \
 	functional/cli_root/zfs_receive/zfs_receive_raw_incremental.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive-x_props_alternation.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive-x_props_alternation.ksh
@@ -1,0 +1,80 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2026 by . All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zfs_set/zfs_set_common.kshlib
+
+#
+# DESCRIPTION:
+# Verify 'zfs receive -x' consistently excludes a property across
+# incremental sends with -p, and does not alternate.
+#
+# STRATEGY:
+# 1. Create source and destination datasets.
+# 2. Set a native property (refquota) on source.
+# 3. Full send with -p, receive with -x refquota.
+# 4. Verify refquota is not set on destination.
+# 5. Loop several incremental sends/receives with -p/-x.
+# 6. Each iteration verify refquota stays consistently excluded.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	destroy_dataset "$orig" "-rf"
+	destroy_dataset "$dest" "-rf"
+}
+
+log_assert "'zfs receive -x' consistently excludes properties" \
+    "across incremental sends."
+log_onexit cleanup
+
+orig=$TESTPOOL/$TESTFS1
+dest=$TESTPOOL/$TESTFS2
+
+# setup source and destination
+log_must zfs create $orig
+log_must zfs create $dest
+
+# set a native property on source
+log_must zfs set refquota=64M $orig
+log_must check_prop_source $orig refquota 67108864 local
+
+# full send with -p, receive with -x
+log_must zfs snapshot $orig@snap1
+log_must eval "zfs send -p $orig@snap1 | zfs receive -e -x refquota $dest"
+
+# destination should NOT have refquota from the stream
+log_must [ "$(get_prop refquota $dest/$TESTFS1)" = "0" ]
+
+# incremental sends: the excluded property must never appear on dest
+typeset -i i=2
+while (( i <= 4 )); do
+	log_must zfs snapshot $orig@snap$i
+	log_must eval "zfs send -p -i $orig@snap$((i-1)) $orig@snap$i \
+	    | zfs receive -e -F -x refquota $dest"
+	log_must [ "$(get_prop refquota $dest/$TESTFS1)" = "0" ]
+	(( i = i + 1 ))
+done
+
+log_pass "'zfs receive -x' consistently excludes properties" \
+    "across incremental sends."


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context

Fixes #18737 

### Description

The old condition skipped the -x for ANY property whose source wasn't explicitly ZPROP_SOURCE_VAL_RECVD - which caught inherited/default properties too, not just locally-set ones. The new condition correctly skips only when the property is locally-set on the destination (source == fsname), which is the documented intent.

### How Has This Been Tested?

Tested with steps described in bug description.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
