### PR TITLE
Linux: fix zfs_write() infinite loop on unfaultable buffer

### DIFF
--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -929,7 +929,15 @@ zfs_write(znode_t *zp, zfs_uio_t *uio, int ioflag, cred_t *cr)
 				 * error, and we may break the loop early.
 				 */
 				n -= tx_bytes - zfs_uio_resid(uio);
-				pfbytes -= tx_bytes - zfs_uio_resid(uio);
+				/*
+				 * The prefaulted pages still faulted, so force
+				 * a re-prefault on the next pass.  If they can
+				 * no longer be faulted in (e.g. the calling
+				 * process is exiting), zfs_uio_prefaultpages()
+				 * fails and the loop breaks with EFAULT instead
+				 * of spinning on them forever.
+				 */
+				pfbytes = 0;
 				continue;
 			}
 #endif


### PR DESCRIPTION
### Motivation and Context

Fixes #17129. On Linux, `zfs_write()` can spin forever in an unkillable
`write(2)` at 100% CPU while holding the file range lock, blocking every
other accessor of the file. It is triggered when the source buffer of a
write can no longer be faulted in, for example when the owning process is
torn down while a thread is still in `pwrite(2)` (seen in production via
Samba).

### Description

With page faults disabled during the open transaction, `zfs_write()`
relies on `zfs_uio_prefaultpages()` to keep the source pages resident.
When `dmu_write_uio_dbuf()` returns `EFAULT`, the retry path only
decremented the prefault accounting by the bytes consumed. On a
zero-progress fault `pfbytes` does not change, the `pfbytes < nbytes`
check never re-prefaults, and the loop retries the same failing copy.

This is a regression from b0cbc1aa9a ("Use big transactions for small
recordsize writes."), which dropped the unconditional re-prefault the
EFAULT path had carried since 779a6c0bf6. The fix resets `pfbytes` on
`EFAULT` so the next iteration faults the pages back in; for a
permanently inaccessible buffer `zfs_uio_prefaultpages()` then fails and
the loop breaks with `EFAULT` (already propagated to userspace).
Transient faults (e.g. mmap'ed source pages evicted under pressure) retry
as before.

### How Has This Been Tested?

Built and tested on Linux aarch64 (kernel 7.0). The ZTS `mmap` and
write-path groups pass, and a `munmap`-versus-`write(2)` stress run leaves
no stuck writers. The teardown race is not reproducible on demand, so the
retry paths were also verified by inspection against the reproducers in
the issue. Full-matrix (x86_64 in particular) coverage is left to CI,
hence the draft.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)

### Checklist:
- [x] My code follows the OpenZFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **contributing** document.
- [ ] I have added tests to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
