### PR TITLE
linux: batch DMU reads of non-resident pages in mappedread()

### DIFF
--- a/module/os/linux/zfs/zfs_vnops_os.c
+++ b/module/os/linux/zfs/zfs_vnops_os.c
@@ -284,6 +284,13 @@ update_pages(znode_t *zp, int64_t start, int len, objset_t *os)
  * When a file is memory mapped, we must keep the I/O data synchronized
  * between the DMU cache and the memory mapped pages.  Preferentially read
  * from memory mapped pages, otherwise fallback to reading through the dmu.
+ *
+ * A run of non-resident pages is read from the DMU in a single call rather
+ * than one call per page.  A page may become resident between the lookup
+ * and the read, but that is safe: zfs_read() holds the rangelock as reader,
+ * so the DMU contents of the range are stable (writes, writeback and
+ * truncation take the writer lock) and a concurrently faulted page is
+ * filled by zfs_getpage() from those same contents.
  */
 int
 mappedread(znode_t *zp, int nbytes, zfs_uio_t *uio)
@@ -329,6 +336,20 @@ mappedread(znode_t *zp, int nbytes, zfs_uio_t *uio)
 			mark_page_accessed(pp);
 			put_page(pp);
 		} else {
+			/*
+			 * Extend the read over any following non-resident
+			 * pages so they are fetched in one DMU call.
+			 */
+			while (bytes < len) {
+				struct page *tp = find_get_page(mp,
+				    (start + PAGE_SIZE) >> PAGE_SHIFT);
+				if (tp != NULL) {
+					put_page(tp);
+					break;
+				}
+				bytes += MIN(PAGE_SIZE, len - bytes);
+				start += PAGE_SIZE;
+			}
 			error = dmu_read_uio_dbuf(sa_get_db(zp->z_sa_hdl),
 			    uio, bytes, DMU_READ_PREFETCH);
 		}


### PR DESCRIPTION
### Motivation and Context

Fixes #16031. Reads of a file that is (or once was) memory mapped can be
4-10x slower than the same reads of an unmapped file. When a chunk being
read holds even one page in the page cache, `zfs_read()` routes it through
`mappedread()`, whose fallback issues a separate `dmu_read_uio_dbuf()`
call for every non-resident `PAGE_SIZE` piece.

### Description

39be46f43 fixed the detection side so fully uncached chunks bypass
`mappedread()`, but a chunk holding one resident page still degrades to
page-sized DMU reads for everything else. This change probes the page
cache with `find_get_page()` and extends the read over the whole run of
following non-resident pages, restoring chunk-sized DMU reads for the
uncached parts of a mapped file.

A page can be faulted in between the lookup and the DMU read, but this is
safe: `zfs_read()` holds the znode rangelock as reader, so the range's DMU
contents are stable (writes, writeback and truncation take the writer
lock) and a concurrently faulted page is filled by `zfs_getpage()` from
those same contents. The reasoning is spelled out in the commit message
and a code comment. FreeBSD's `mappedread()` has the same fallback and
could be batched the same way in a follow-up.

### How Has This Been Tested?

Built and tested on Linux aarch64 (kernel 7.0); the ZTS `mmap` group
passes (12/12). Benchmarked with `dd` on a 1 GiB file held in the ARC:
one resident page per 1 MiB request drops baseline throughput from
~11.4 GB/s to ~5.7 GB/s, and this change restores ~11.4 GB/s; one resident
page per 32 MiB chunk improves from ~5.4 GB/s to ~7.3 GB/s. A fully
resident file is unaffected (~20 GB/s). Broader coverage is left to CI.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code follows the OpenZFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **contributing** document.
- [ ] I have added tests to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
