### PR TITLE
Implement FIDEDUPERANGE via block cloning

### DIFF
--- a/include/sys/zfs_vnops.h
+++ b/include/sys/zfs_vnops.h
@@ -40,6 +40,8 @@ extern int zfs_clone_range(znode_t *, uint64_t *, znode_t *, uint64_t *,
     uint64_t *, cred_t *);
 extern int zfs_clone_range_replay(znode_t *, uint64_t, uint64_t, uint64_t,
     const blkptr_t *, size_t);
+extern int zfs_dedupe_range(znode_t *, uint64_t, znode_t *, uint64_t,
+    uint64_t *, cred_t *, boolean_t, boolean_t *);
 extern int zfs_rewrite(znode_t *, uint64_t, uint64_t, uint64_t, uint64_t);
 
 extern int zfs_getsecattr(znode_t *, vsecattr_t *, int, cred_t *);

--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -1567,6 +1567,8 @@ Note that for small files this may be slower than simply copying the file.
 When set to 0 the clone operation will immediately fail if it encounters
 any dirty blocks.
 By default waiting is enabled.
+A FIDEDUPERANGE request always waits, as it has no copy fallback that
+could absorb the failure.
 .
 .It Sy zfs_blake3_impl Ns = Ns Sy fastest Pq string
 Select a BLAKE3 implementation.

--- a/module/os/linux/zfs/zpl_file_range.c
+++ b/module/os/linux/zfs/zpl_file_range.c
@@ -36,6 +36,40 @@
 #include <sys/zfeature.h>
 
 /*
+ * Take the source and destination inode locks for a remap (clone or dedupe).
+ *
+ * Since Linux 4.20 the VFS does not lock the inodes for ->remap_file_range();
+ * the filesystem must, and it must impose an order on the two, or two remaps
+ * running in opposite directions deadlock: each would hold one inode and wait
+ * for the other, and an rwsem writer queues behind the existing readers.  Order
+ * by inode address, as btrfs does.  The destination is taken exclusively and
+ * the source shared, so concurrent remaps out of one hot source still proceed.
+ * Only the acquisition needs the order: releasing never waits, so the unlock
+ * side does not mirror it.
+ */
+static void
+zpl_remap_lock_two(struct inode *src_i, struct inode *dst_i)
+{
+	if (src_i == dst_i) {
+		spl_inode_lock(dst_i);
+	} else if (src_i < dst_i) {
+		spl_inode_lock_shared(src_i);
+		spl_inode_lock(dst_i);
+	} else {
+		spl_inode_lock(dst_i);
+		spl_inode_lock_shared(src_i);
+	}
+}
+
+static void
+zpl_remap_unlock_two(struct inode *src_i, struct inode *dst_i)
+{
+	spl_inode_unlock(dst_i);
+	if (src_i != dst_i)
+		spl_inode_unlock_shared(src_i);
+}
+
+/*
  * Clone part of a file via block cloning.
  *
  * Note that we are not required to update file offsets; the kernel will take
@@ -61,9 +95,7 @@ zpl_clone_file_range_impl(struct file *src_file, loff_t src_off,
 	    dmu_objset_spa(ITOZSB(dst_i)->z_os), SPA_FEATURE_BLOCK_CLONING))
 		return (-EOPNOTSUPP);
 
-	if (src_i != dst_i)
-		spl_inode_lock_shared(src_i);
-	spl_inode_lock(dst_i);
+	zpl_remap_lock_two(src_i, dst_i);
 
 	crhold(cr);
 	cookie = spl_fstrans_mark();
@@ -74,15 +106,66 @@ zpl_clone_file_range_impl(struct file *src_file, loff_t src_off,
 	spl_fstrans_unmark(cookie);
 	crfree(cr);
 
-	spl_inode_unlock(dst_i);
-	if (src_i != dst_i)
-		spl_inode_unlock_shared(src_i);
+	zpl_remap_unlock_two(src_i, dst_i);
 
 	if (err < 0)
 		return (err);
 
 	return ((ssize_t)len_o);
 }
+
+#if defined(HAVE_VFS_REMAP_FILE_RANGE) || \
+	defined(HAVE_VFS_DEDUPE_FILE_RANGE)
+/*
+ * Logic shared by the FIDEDUPERANGE entry points.  Compare len bytes at
+ * src_off in src_file with dst_off in dst_file and, if they are identical,
+ * share the underlying blocks via zfs_dedupe_range().  Returns the number of
+ * bytes deduped, -EBADE if the ranges differ (which the VFS reports as
+ * FILE_DEDUPE_RANGE_DIFFERS), or another negative errno on failure.
+ */
+static ssize_t
+zpl_dedupe_file_range_impl(struct file *src_file, loff_t src_off,
+    struct file *dst_file, loff_t dst_off, size_t len, boolean_t can_shorten)
+{
+	struct inode *src_i = file_inode(src_file);
+	struct inode *dst_i = file_inode(dst_file);
+	uint64_t src_off_o = (uint64_t)src_off;
+	uint64_t dst_off_o = (uint64_t)dst_off;
+	uint64_t len_o = (uint64_t)len;
+	cred_t *cr = CRED();
+	fstrans_cookie_t cookie;
+	boolean_t same = B_FALSE;
+	int err;
+
+	if (!zfs_bclone_enabled)
+		return (-EOPNOTSUPP);
+
+	if (!spa_feature_is_enabled(
+	    dmu_objset_spa(ITOZSB(dst_i)->z_os), SPA_FEATURE_BLOCK_CLONING))
+		return (-EOPNOTSUPP);
+
+	zpl_remap_lock_two(src_i, dst_i);
+
+	crhold(cr);
+	cookie = spl_fstrans_mark();
+
+	err = -zfs_dedupe_range(ITOZ(src_i), src_off_o, ITOZ(dst_i),
+	    dst_off_o, &len_o, cr, can_shorten, &same);
+
+	spl_fstrans_unmark(cookie);
+	crfree(cr);
+
+	zpl_remap_unlock_two(src_i, dst_i);
+
+	if (err < 0)
+		return (err);
+
+	if (!same)
+		return (-EBADE);
+
+	return ((ssize_t)len_o);
+}
+#endif
 
 /*
  * Entry point for copy_file_range(). Copy len bytes from src_off in src_file
@@ -159,9 +242,9 @@ zpl_remap_file_range(struct file *src_file, loff_t src_off,
 	if (flags & ~(REMAP_FILE_DEDUP | REMAP_FILE_CAN_SHORTEN))
 		return (-EINVAL);
 
-	/* No support for dedup yet */
 	if (flags & REMAP_FILE_DEDUP)
-		return (-EOPNOTSUPP);
+		return (zpl_dedupe_file_range_impl(src_file, src_off, dst_file,
+		    dst_off, len, !!(flags & REMAP_FILE_CAN_SHORTEN)));
 
 	/* Zero length means to clone everything to the end of the file */
 	if (len == 0)
@@ -208,7 +291,11 @@ int
 zpl_dedupe_file_range(struct file *src_file, loff_t src_off,
     struct file *dst_file, loff_t dst_off, uint64_t len)
 {
-	/* No support for dedup yet */
-	return (-EOPNOTSUPP);
+	/*
+	 * The pre-4.20 dedupe interface has no way to signal that a short
+	 * dedupe is acceptable, so the whole range must match.
+	 */
+	return (zpl_dedupe_file_range_impl(src_file, src_off, dst_file,
+	    dst_off, len, B_FALSE));
 }
 #endif /* HAVE_VFS_DEDUPE_FILE_RANGE */

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -52,7 +52,9 @@
 #include <sys/dsl_crypt.h>
 #include <sys/dsl_dataset.h>
 #include <sys/spa.h>
+#include <sys/zio_checksum.h>
 #include <sys/txg.h>
+#include <sys/blkptr.h>
 #include <sys/brt.h>
 #include <sys/dbuf.h>
 #include <sys/policy.h>
@@ -1587,77 +1589,32 @@ zfs_exit_two(zfsvfs_t *zfsvfs1, zfsvfs_t *zfsvfs2, const char *tag)
 }
 
 /*
- * We split each clone request in chunks that can fit into a single ZIL
- * log entry. Each ZIL log entry can fit 130816 bytes for a block cloning
- * operation (see zil_max_log_data() and zfs_log_clone_range()). This gives
- * us room for storing 1022 block pointers.
- *
- * On success, the function return the number of bytes copied in *lenp.
- * Note, it doesn't return how much bytes are left to be copied.
- * On errors which are caused by any file system limitations or
- * brt limitations `EINVAL` is returned. In the most cases a user
- * requested bad parameters, it could be possible to clone the file but
- * some parameters don't match the requirements.
+ * Checks shared by zfs_clone_range() and zfs_dedupe_range() that do not
+ * depend on the offsets or length of the request.  Both datasets must
+ * already be entered with zfs_enter_two().
  */
-int
-zfs_clone_range(znode_t *inzp, uint64_t *inoffp, znode_t *outzp,
-    uint64_t *outoffp, uint64_t *lenp, cred_t *cr)
+static int
+zfs_clone_range_precheck(znode_t *inzp, znode_t *outzp)
 {
-	zfsvfs_t	*inzfsvfs, *outzfsvfs;
-	objset_t	*inos, *outos;
-	zfs_locked_range_t *inlr, *outlr;
-	dmu_buf_impl_t	*db;
-	dmu_tx_t	*tx;
-	zilog_t		*zilog;
-	uint64_t	inoff, outoff, len, done;
-	uint64_t	outsize, size;
+	zfsvfs_t	*inzfsvfs = ZTOZSB(inzp);
+	zfsvfs_t	*outzfsvfs = ZTOZSB(outzp);
+	objset_t	*inos = inzfsvfs->z_os;
+	objset_t	*outos = outzfsvfs->z_os;
 	int		error;
-	int		count = 0;
-	sa_bulk_attr_t	bulk[5];
-	uint64_t	mtime[2], ctime[2];
-	uint64_t	uid, gid, projid;
-	blkptr_t	*bps;
-	size_t		maxblocks, nbps;
-	uint_t		inblksz;
-	uint64_t	clear_setid_bits_txg = 0;
-	uint64_t	last_synced_txg = 0;
-
-	inoff = *inoffp;
-	outoff = *outoffp;
-	len = *lenp;
-	done = 0;
-
-	inzfsvfs = ZTOZSB(inzp);
-	outzfsvfs = ZTOZSB(outzp);
-
-	/*
-	 * We need to call zfs_enter() potentially on two different datasets,
-	 * so we need a dedicated function for that.
-	 */
-	error = zfs_enter_two(inzfsvfs, outzfsvfs, FTAG);
-	if (error != 0)
-		return (error);
-
-	inos = inzfsvfs->z_os;
-	outos = outzfsvfs->z_os;
 
 	/*
 	 * Both source and destination have to belong to the same storage pool.
 	 */
-	if (dmu_objset_spa(inos) != dmu_objset_spa(outos)) {
-		zfs_exit_two(inzfsvfs, outzfsvfs, FTAG);
+	if (dmu_objset_spa(inos) != dmu_objset_spa(outos))
 		return (SET_ERROR(EXDEV));
-	}
 
 	/*
 	 * outos and inos belongs to the same storage pool.
 	 * see a few lines above, only one check.
 	 */
 	if (!spa_feature_is_enabled(dmu_objset_spa(outos),
-	    SPA_FEATURE_BLOCK_CLONING)) {
-		zfs_exit_two(inzfsvfs, outzfsvfs, FTAG);
+	    SPA_FEATURE_BLOCK_CLONING))
 		return (SET_ERROR(EOPNOTSUPP));
-	}
 
 	ASSERT(!outzfsvfs->z_replay);
 
@@ -1665,20 +1622,16 @@ zfs_clone_range(znode_t *inzp, uint64_t *inoffp, znode_t *outzp,
 	 * Block cloning from an unencrypted dataset into an encrypted
 	 * dataset and vice versa is not supported.
 	 */
-	if (inos->os_encrypted != outos->os_encrypted) {
-		zfs_exit_two(inzfsvfs, outzfsvfs, FTAG);
+	if (inos->os_encrypted != outos->os_encrypted)
 		return (SET_ERROR(EXDEV));
-	}
 
 	/*
 	 * Cloning across encrypted datasets is possible only if they
 	 * share the same master key.
 	 */
 	if (inos != outos && inos->os_encrypted &&
-	    !dmu_objset_crypto_key_equal(inos, outos)) {
-		zfs_exit_two(inzfsvfs, outzfsvfs, FTAG);
+	    !dmu_objset_crypto_key_equal(inos, outos))
 		return (SET_ERROR(EXDEV));
-	}
 
 	/*
 	 * Cloning between datasets with different properties is possible,
@@ -1690,89 +1643,64 @@ zfs_clone_range(znode_t *inzp, uint64_t *inoffp, znode_t *outzp,
 	    (inos->os_checksum != outos->os_checksum ||
 	    inos->os_compress != outos->os_compress ||
 	    inos->os_copies != outos->os_copies ||
-	    inos->os_dedup_checksum != outos->os_dedup_checksum)) {
-		zfs_exit_two(inzfsvfs, outzfsvfs, FTAG);
+	    inos->os_dedup_checksum != outos->os_dedup_checksum))
 		return (SET_ERROR(EXDEV));
-	}
 
 	error = zfs_verify_zp(inzp);
 	if (error == 0)
 		error = zfs_verify_zp(outzp);
-	if (error != 0) {
-		zfs_exit_two(inzfsvfs, outzfsvfs, FTAG);
+	if (error != 0)
 		return (error);
-	}
 
 	/*
 	 * We don't copy source file's flags that's why we don't allow to clone
 	 * files that are in quarantine.
 	 */
-	if (inzp->z_pflags & ZFS_AV_QUARANTINED) {
-		zfs_exit_two(inzfsvfs, outzfsvfs, FTAG);
+	if (inzp->z_pflags & ZFS_AV_QUARANTINED)
 		return (SET_ERROR(EACCES));
-	}
 
-	if (inoff >= inzp->z_size) {
-		*lenp = 0;
-		zfs_exit_two(inzfsvfs, outzfsvfs, FTAG);
-		return (0);
-	}
-	if (len > inzp->z_size - inoff) {
-		len = inzp->z_size - inoff;
-	}
-	if (len == 0) {
-		*lenp = 0;
-		zfs_exit_two(inzfsvfs, outzfsvfs, FTAG);
-		return (0);
-	}
+	return (0);
+}
 
-	/*
-	 * Callers might not be able to detect properly that we are read-only,
-	 * so check it explicitly here.
-	 */
-	if (zfs_is_readonly(outzfsvfs)) {
-		zfs_exit_two(inzfsvfs, outzfsvfs, FTAG);
-		return (SET_ERROR(EROFS));
-	}
+/*
+ * Clone a range of blocks from inzp into outzp.  The caller must have entered
+ * both datasets, resolved the request against the source EOF, and be holding a
+ * RL_READER range lock on inzp and a RL_WRITER range lock (outlr) on outzp.
+ * The number of bytes cloned is returned via donep; the caller is responsible
+ * for the trailing accounting (access time, zil_commit) and for dropping the
+ * range locks.
+ *
+ * When dedup is set the caller is implementing FIDEDUPERANGE, where the file
+ * content is unchanged: in that case we must not update the destination's
+ * mtime/ctime or strip its setid bits, matching the Linux convention that
+ * REMAP_FILE_DEDUP skips file_modified().
+ */
+static int
+zfs_clone_range_locked(znode_t *inzp, uint64_t inoff, znode_t *outzp,
+    uint64_t outoff, uint64_t len, cred_t *cr, zfs_locked_range_t *outlr,
+    boolean_t dedup, uint64_t *donep)
+{
+	zfsvfs_t	*inzfsvfs = ZTOZSB(inzp);
+	zfsvfs_t	*outzfsvfs = ZTOZSB(outzp);
+	objset_t	*inos = inzfsvfs->z_os;
+	objset_t	*outos = outzfsvfs->z_os;
+	dmu_buf_impl_t	*db;
+	dmu_tx_t	*tx;
+	zilog_t		*zilog = outzfsvfs->z_log;
+	uint64_t	done = 0;
+	uint64_t	outsize, size;
+	int		error = 0;
+	int		count = 0;
+	sa_bulk_attr_t	bulk[5];
+	uint64_t	mtime[2], ctime[2];
+	uint64_t	uid, gid, projid;
+	blkptr_t	*bps;
+	size_t		maxblocks, nbps;
+	uint_t		inblksz;
+	uint64_t	clear_setid_bits_txg = 0;
+	uint64_t	last_synced_txg = 0;
 
-	/*
-	 * If immutable or not appending then return EPERM.
-	 * Intentionally allow ZFS_READONLY through here.
-	 * See zfs_zaccess_common()
-	 */
-	if ((outzp->z_pflags & ZFS_IMMUTABLE) != 0) {
-		zfs_exit_two(inzfsvfs, outzfsvfs, FTAG);
-		return (SET_ERROR(EPERM));
-	}
-
-	/*
-	 * No overlapping if we are cloning within the same file.
-	 */
-	if (inzp == outzp) {
-		if (inoff < outoff + len && outoff < inoff + len) {
-			zfs_exit_two(inzfsvfs, outzfsvfs, FTAG);
-			return (SET_ERROR(EINVAL));
-		}
-	}
-
-	/* Flush any mmap()'d data to disk */
-	if (zn_has_cached_data(inzp, inoff, inoff + len - 1))
-		zn_flush_cached_data(inzp, B_TRUE);
-
-	/*
-	 * Maintain predictable lock order.
-	 */
-	if (inzp < outzp || (inzp == outzp && inoff < outoff)) {
-		inlr = zfs_rangelock_enter(&inzp->z_rangelock, inoff, len,
-		    RL_READER);
-		outlr = zfs_rangelock_enter(&outzp->z_rangelock, outoff, len,
-		    RL_WRITER);
-	} else {
-		outlr = zfs_rangelock_enter(&outzp->z_rangelock, outoff, len,
-		    RL_WRITER);
-		inlr = zfs_rangelock_enter(&inzp->z_rangelock, inoff, len,
-		    RL_READER);
-	}
+	*donep = 0;
 
 	inblksz = inzp->z_blksz;
 
@@ -1790,8 +1718,7 @@ zfs_clone_range(znode_t *inzp, uint64_t *inoffp, znode_t *outzp,
 			if (min_smallblk < inblksz &&
 			    (inos->os_compress != ZIO_COMPRESS_OFF ||
 			    max_smallblk >= inblksz)) {
-				error = SET_ERROR(EXDEV);
-				goto unlock;
+				return (SET_ERROR(EXDEV));
 			}
 		}
 	}
@@ -1803,40 +1730,30 @@ zfs_clone_range(znode_t *inzp, uint64_t *inoffp, znode_t *outzp,
 	 * grow to fail, but we cover what we can before opening transaction
 	 * and the rest detect after we try to do it.
 	 */
-	if (inblksz < outzp->z_blksz) {
-		error = SET_ERROR(EINVAL);
-		goto unlock;
-	}
+	if (inblksz < outzp->z_blksz)
+		return (SET_ERROR(EINVAL));
 	if (inblksz != outzp->z_blksz && (outzp->z_size > outzp->z_blksz ||
-	    outlr->lr_length != UINT64_MAX)) {
-		error = SET_ERROR(EINVAL);
-		goto unlock;
-	}
+	    outlr->lr_length != UINT64_MAX))
+		return (SET_ERROR(EINVAL));
 
 	/*
 	 * Block size must be power-of-2 if destination offset != 0.
 	 * There can be no multiple blocks of non-power-of-2 size.
 	 */
-	if (outoff != 0 && !ISP2(inblksz)) {
-		error = SET_ERROR(EINVAL);
-		goto unlock;
-	}
+	if (outoff != 0 && !ISP2(inblksz))
+		return (SET_ERROR(EINVAL));
 
 	/*
 	 * Offsets and len must be at block boundries.
 	 */
-	if ((inoff % inblksz) != 0 || (outoff % inblksz) != 0) {
-		error = SET_ERROR(EINVAL);
-		goto unlock;
-	}
+	if ((inoff % inblksz) != 0 || (outoff % inblksz) != 0)
+		return (SET_ERROR(EINVAL));
 	/*
 	 * Length must be multipe of blksz, except for the end of the file.
 	 */
 	if ((len % inblksz) != 0 &&
-	    (len < inzp->z_size - inoff || len < outzp->z_size - outoff)) {
-		error = SET_ERROR(EINVAL);
-		goto unlock;
-	}
+	    (len < inzp->z_size - inoff || len < outzp->z_size - outoff))
+		return (SET_ERROR(EINVAL));
 
 	/*
 	 * If we are copying only one block and it is smaller than recordsize
@@ -1846,34 +1763,37 @@ zfs_clone_range(znode_t *inzp, uint64_t *inoffp, znode_t *outzp,
 	 * matter how big the destination grow later.
 	 */
 	if (len <= inblksz && inblksz < outzfsvfs->z_max_blksz &&
-	    outzp->z_size <= inblksz && outoff + len > inblksz) {
-		error = SET_ERROR(EINVAL);
-		goto unlock;
-	}
+	    outzp->z_size <= inblksz && outoff + len > inblksz)
+		return (SET_ERROR(EINVAL));
 
 	error = zn_rlimit_fsize(outoff + len);
-	if (error != 0) {
-		goto unlock;
+	if (error != 0)
+		return (error);
+
+	if (inoff >= MAXOFFSET_T || outoff >= MAXOFFSET_T)
+		return (SET_ERROR(EFBIG));
+
+	/*
+	 * A dedupe leaves the destination's content and metadata alone: it can
+	 * only replace blocks with identical ones.  The times must not move,
+	 * and size, flags and seq cannot change either - a dedupe never extends
+	 * the file, never clears setid bits and never bumps z_seq - so there is
+	 * nothing to write back at all.
+	 */
+	if (!dedup) {
+		SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_MTIME(outzfsvfs), NULL,
+		    &mtime, 16);
+		SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_CTIME(outzfsvfs), NULL,
+		    &ctime, 16);
+		SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_SIZE(outzfsvfs), NULL,
+		    &outzp->z_size, 8);
+		SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_FLAGS(outzfsvfs), NULL,
+		    &outzp->z_pflags, 8);
+		if (outzp->z_is_sa)
+			SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_SEQ(outzfsvfs),
+			    NULL, &outzp->z_seq, 8);
 	}
 
-	if (inoff >= MAXOFFSET_T || outoff >= MAXOFFSET_T) {
-		error = SET_ERROR(EFBIG);
-		goto unlock;
-	}
-
-	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_MTIME(outzfsvfs), NULL,
-	    &mtime, 16);
-	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_CTIME(outzfsvfs), NULL,
-	    &ctime, 16);
-	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_SIZE(outzfsvfs), NULL,
-	    &outzp->z_size, 8);
-	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_FLAGS(outzfsvfs), NULL,
-	    &outzp->z_pflags, 8);
-	if (outzp->z_is_sa)
-		SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_SEQ(outzfsvfs), NULL,
-		    &outzp->z_seq, 8);
-
-	zilog = outzfsvfs->z_log;
 	maxblocks = zil_max_log_data(zilog, sizeof (lr_clone_range_t)) /
 	    sizeof (bps[0]);
 
@@ -1913,8 +1833,12 @@ zfs_clone_range(znode_t *inzp, uint64_t *inoffp, znode_t *outzp,
 			 * EAGAIN here.  Based on zfs_bclone_wait_dirty either
 			 * return a shortened range to the caller so it can
 			 * fallback, or wait for the next TXG and check again.
+			 * A dedupe always waits: it has no fallback, so the
+			 * EAGAIN would surface to the FIDEDUPERANGE caller,
+			 * and the comparison already read this very data.
 			 */
-			if (error == EAGAIN && zfs_bclone_wait_dirty) {
+			if (error == EAGAIN &&
+			    (dedup || zfs_bclone_wait_dirty)) {
 				txg_wait_flag_t wait_flags =
 				    spa_get_failmode(dmu_objset_spa(inos)) ==
 				    ZIO_FAILURE_MODE_CONTINUE ?
@@ -1982,31 +1906,67 @@ zfs_clone_range(znode_t *inzp, uint64_t *inoffp, znode_t *outzp,
 			break;
 		}
 
-		if (zn_has_cached_data(outzp, outoff, outoff + size - 1)) {
+		/*
+		 * A dedupe replaces the destination's blocks with blocks
+		 * holding the same bytes, so a page already cached for this
+		 * range stays correct and there is nothing to refresh.  The
+		 * only page whose contents can differ from the DMU is one
+		 * carrying an mmap store made after the pre-compare flush,
+		 * and refreshing that would discard the store, which is a
+		 * modification a dedupe must never make.
+		 */
+		if (!dedup &&
+		    zn_has_cached_data(outzp, outoff, outoff + size - 1)) {
 			update_pages(outzp, outoff, size, outos);
 		}
 
-		zfs_clear_setid_bits_if_necessary(outzfsvfs, outzp, cr,
-		    &clear_setid_bits_txg, tx);
+		if (!dedup) {
+			zfs_clear_setid_bits_if_necessary(outzfsvfs, outzp, cr,
+			    &clear_setid_bits_txg, tx);
 
-		zfs_tstamp_update_setup(outzp, CONTENT_MODIFIED, mtime, ctime);
-		if (outzp->z_is_sa)
-			outzp->z_has_seq = B_TRUE;
+			zfs_tstamp_update_setup(outzp, CONTENT_MODIFIED, mtime,
+			    ctime);
 
-		/*
-		 * Update the file size (zp_size) if it has changed;
-		 * account for possible concurrent updates.
-		 */
-		while ((outsize = outzp->z_size) < outoff + size) {
-			(void) atomic_cas_64(&outzp->z_size, outsize,
-			    outoff + size);
+			if (outzp->z_is_sa)
+				outzp->z_has_seq = B_TRUE;
+
+			/*
+			 * Update the file size (zp_size) if it has changed;
+			 * account for possible concurrent updates.
+			 */
+			while ((outsize = outzp->z_size) < outoff + size) {
+				(void) atomic_cas_64(&outzp->z_size, outsize,
+				    outoff + size);
+			}
+		} else {
+			/* A dedupe can only ever rewrite blocks in place. */
+			ASSERT3U(outoff + size, <=, outzp->z_size);
 		}
 
-		ASSERT3S(count, <=, ARRAY_SIZE(bulk));
-		error = sa_bulk_update(outzp->z_sa_hdl, bulk, count, tx);
+		if (count > 0) {
+			ASSERT3S(count, <=, ARRAY_SIZE(bulk));
+			error = sa_bulk_update(outzp->z_sa_hdl, bulk, count,
+			    tx);
+		}
 
-		zfs_log_clone_range(zilog, tx, TX_CLONE_RANGE, outzp, outoff,
-		    size, inblksz, bps, nbps);
+		/*
+		 * A dedupe is not logged.  It replaces the destination's blocks
+		 * with blocks holding the very same bytes, so if the txg is
+		 * lost to a crash and never replayed, the destination simply
+		 * keeps its own copy of that identical content: nothing a
+		 * reader can observe is lost, only the sharing.  Sharing is all
+		 * FIDEDUPERANGE promises anyway, and it is the cheaper of the
+		 * alternatives.  Logging a plain TX_CLONE_RANGE would restamp
+		 * the destination's mtime/ctime on replay, and telling a dedupe
+		 * apart with a record of its own would be an on-disk ZIL format
+		 * change: an old kernel meeting an unknown txtype fails
+		 * zil_parse(), and zil_replay() then destroys the whole log,
+		 * discarding every later record - including synced writes.
+		 */
+		if (!dedup) {
+			zfs_log_clone_range(zilog, tx, TX_CLONE_RANGE, outzp,
+			    outoff, size, inblksz, bps, nbps);
+		}
 
 		dmu_tx_commit(tx);
 
@@ -2027,7 +1987,127 @@ zfs_clone_range(znode_t *inzp, uint64_t *inoffp, znode_t *outzp,
 	vmem_free(bps, sizeof (bps[0]) * maxblocks);
 	zfs_znode_update_vfs(outzp);
 
-unlock:
+	*donep = done;
+
+	return (error);
+}
+
+/*
+ * Clone part of inzp file into outzp file. This must be done under range locks
+ * held on both files so as to prevent it from being modified while the clone
+ * takes place.
+ *
+ * Copies bytes from inzp->inoffp to outzp->outoffp, up to *lenp bytes.  On
+ * entry *lenp holds the requested length; on successful return it holds the
+ * number of bytes actually cloned, and inoffp/outoffp are advanced by that
+ * amount.
+ *
+ * If we make no progress at all, then the caller made a mistake or asked for
+ * something impossible, and EINVAL (or another appropriate error) is returned.
+ *
+ * Note, it doesn't return how many bytes are left to be copied.
+ * On errors which are caused by any file system limitations or
+ * BRT limitations EINVAL is returned. In the most cases a user
+ * requested bad parameters, it could be possible to clone the file but
+ * some parameters don't match the requirements.
+ */
+int
+zfs_clone_range(znode_t *inzp, uint64_t *inoffp, znode_t *outzp,
+    uint64_t *outoffp, uint64_t *lenp, cred_t *cr)
+{
+	zfsvfs_t	*inzfsvfs = ZTOZSB(inzp);
+	zfsvfs_t	*outzfsvfs = ZTOZSB(outzp);
+	zfs_locked_range_t *inlr, *outlr;
+	zilog_t		*zilog;
+	uint64_t	inoff = *inoffp;
+	uint64_t	outoff = *outoffp;
+	uint64_t	len = *lenp;
+	uint64_t	done = 0;
+	int		error;
+
+	/*
+	 * We need to call zfs_enter() potentially on two different datasets,
+	 * so we need a dedicated function for that.
+	 */
+	error = zfs_enter_two(inzfsvfs, outzfsvfs, FTAG);
+	if (error != 0)
+		return (error);
+
+	/*
+	 * Read z_log only after entering, so a suspend/resume (rollback,
+	 * zfs receive -F) cannot leave us with a stale or freed zilog.
+	 */
+	zilog = outzfsvfs->z_log;
+
+	error = zfs_clone_range_precheck(inzp, outzp);
+	if (error != 0)
+		goto out;
+
+	/*
+	 * The range to clone must lie within the source file.  Clamp it to the
+	 * source EOF and treat an empty range as a no-op.
+	 */
+	if (inoff >= inzp->z_size) {
+		*lenp = 0;
+		goto out;
+	}
+	if (len > inzp->z_size - inoff)
+		len = inzp->z_size - inoff;
+	if (len == 0) {
+		*lenp = 0;
+		goto out;
+	}
+
+	/*
+	 * Callers might not be able to detect properly that we are read-only,
+	 * so check it explicitly here.
+	 */
+	if (zfs_is_readonly(outzfsvfs)) {
+		error = SET_ERROR(EROFS);
+		goto out;
+	}
+
+	/*
+	 * If immutable then return EPERM.  Intentionally allow ZFS_READONLY
+	 * through here.  See zfs_zaccess_common().
+	 */
+	if ((outzp->z_pflags & ZFS_IMMUTABLE) != 0) {
+		error = SET_ERROR(EPERM);
+		goto out;
+	}
+
+	/*
+	 * No overlapping if we are cloning within the same file.
+	 */
+	if (inzp == outzp) {
+		if (inoff < outoff + len && outoff < inoff + len) {
+			error = SET_ERROR(EINVAL);
+			goto out;
+		}
+	}
+
+	/* Flush any mmap()'d data to disk */
+	if (zn_has_cached_data(inzp, inoff, inoff + len - 1))
+		zn_flush_cached_data(inzp, B_TRUE);
+
+	/*
+	 * Maintain predictable lock order.
+	 */
+	if (inzp < outzp || (inzp == outzp && inoff < outoff)) {
+		inlr = zfs_rangelock_enter(&inzp->z_rangelock, inoff, len,
+		    RL_READER);
+		outlr = zfs_rangelock_enter(&outzp->z_rangelock, outoff, len,
+		    RL_WRITER);
+	} else {
+		outlr = zfs_rangelock_enter(&outzp->z_rangelock, outoff, len,
+		    RL_WRITER);
+		inlr = zfs_rangelock_enter(&inzp->z_rangelock, inoff, len,
+		    RL_READER);
+	}
+
+	error = zfs_clone_range_locked(inzp, inoff, outzp, outoff, len, cr,
+	    outlr, B_FALSE, &done);
+
 	zfs_rangelock_exit(outlr);
 	zfs_rangelock_exit(inlr);
 
@@ -2039,9 +2119,8 @@ unlock:
 
 		ZFS_ACCESSTIME_STAMP(inzfsvfs, inzp);
 
-		if (outos->os_sync == ZFS_SYNC_ALWAYS) {
+		if (outzfsvfs->z_os->os_sync == ZFS_SYNC_ALWAYS)
 			error = zil_commit(zilog, outzp->z_id);
-		}
 
 		*inoffp += done;
 		*outoffp += done;
@@ -2054,6 +2133,710 @@ unlock:
 		ASSERT3S(error, !=, 0);
 	}
 
+out:
+	zfs_exit_two(inzfsvfs, outzfsvfs, FTAG);
+
+	return (error);
+}
+
+/*
+ * Compare two ranges by copying them out of the DMU into buffers and comparing
+ * those.  Only used where the dbuf comparison below cannot go; see there.
+ */
+static int
+zfs_dedupe_range_copy_memcmp(znode_t *inzp, uint64_t inoff, znode_t *outzp,
+    uint64_t outoff, uint64_t len, boolean_t *eqp)
+{
+	objset_t	*inos = ZTOZSB(inzp)->z_os;
+	objset_t	*outos = ZTOZSB(outzp)->z_os;
+	uint64_t	chunk = MIN(len, (uint64_t)zfs_vnops_read_chunk_size);
+	char		*inbuf, *outbuf;
+	int		error = 0;
+
+	*eqp = B_FALSE;
+
+	inbuf = vmem_alloc(chunk, KM_SLEEP);
+	outbuf = vmem_alloc(chunk, KM_SLEEP);
+
+	while (len > 0) {
+		uint64_t n = MIN(len, chunk);
+
+		if (issig()) {
+			error = SET_ERROR(EINTR);
+			break;
+		}
+
+		error = dmu_read(inos, inzp->z_id, inoff, n, inbuf,
+		    DMU_READ_PREFETCH);
+		if (error != 0)
+			break;
+		error = dmu_read(outos, outzp->z_id, outoff, n, outbuf,
+		    DMU_READ_PREFETCH);
+		if (error != 0)
+			break;
+
+		if (memcmp(inbuf, outbuf, n) != 0)
+			break;
+
+		inoff += n;
+		outoff += n;
+		len -= n;
+	}
+
+	if (error == 0 && len == 0)
+		*eqp = B_TRUE;
+
+	vmem_free(inbuf, chunk);
+	vmem_free(outbuf, chunk);
+
+	return (error);
+}
+
+/*
+ * Compare [inoff, inoff + len) in inzp with [outoff, outoff + len) in outzp by
+ * reading the committed on-disk data through the DMU (the same data
+ * zfs_clone_range_locked() will clone) and byte-comparing it.  Both files must
+ * be range locked by the caller.  On return *eqp is set if the ranges are
+ * byte-for-byte equal.  This is the authoritative (and always-correct) path;
+ * the DMU serves holes as zeros and decrypts transparently, so it needs no
+ * special-casing for encryption, holes or embedded blocks.
+ *
+ * The comparison is done on the dbufs themselves.  dmu_read() would only hold
+ * the very same buffers and memcpy() out of them, so going through it would
+ * cost two allocations and a copy of every byte, for nothing: we are not
+ * keeping the data, only looking at it.  Our range locks keep it still while
+ * we do.
+ */
+static int
+zfs_dedupe_range_memcmp(znode_t *inzp, uint64_t inoff, znode_t *outzp,
+    uint64_t outoff, uint64_t len, boolean_t *eqp)
+{
+	objset_t	*inos = ZTOZSB(inzp)->z_os;
+	objset_t	*outos = ZTOZSB(outzp)->z_os;
+	dnode_t		*indn, *outdn;
+	boolean_t	diff = B_FALSE;
+	int		error;
+
+	*eqp = B_FALSE;
+
+	error = dnode_hold(inos, inzp->z_id, FTAG, &indn);
+	if (error != 0)
+		return (error);
+	error = dnode_hold(outos, outzp->z_id, FTAG, &outdn);
+	if (error != 0) {
+		dnode_rele(indn, FTAG);
+		return (error);
+	}
+
+	/*
+	 * dmu_buf_hold_array_by_dnode() refuses to look past a single block
+	 * whose size is not a power of two, calling zfs_panic_recover() rather
+	 * than serving the tail as zeros the way dmu_read() does.  A ZPL file
+	 * should never present that shape - zfs_grow_blocksize() only leaves a
+	 * block size alone once the file has outgrown it, so an odd-sized block
+	 * means the file still fits inside it and the range cannot reach past
+	 * it.  Should one turn up regardless, fall back to copying rather than
+	 * add another way to take the pool down.  Our caller reaches
+	 * dmu_read_l0_bps() first, which holds the same buffers and would trip
+	 * over such a file before we ever got here, so in practice this only
+	 * catches what gets past that on a pool running with zfs_recover set.
+	 */
+	if ((indn->dn_datablkshift == 0 && inoff + len > indn->dn_datablksz) ||
+	    (outdn->dn_datablkshift == 0 &&
+	    outoff + len > outdn->dn_datablksz)) {
+		dnode_rele(outdn, FTAG);
+		dnode_rele(indn, FTAG);
+		return (zfs_dedupe_range_copy_memcmp(inzp, inoff, outzp,
+		    outoff, len, eqp));
+	}
+
+	while (len > 0 && !diff) {
+		/*
+		 * Hold no more at once than the copying path used to allocate,
+		 * so that a large request does not pin an unbounded stretch of
+		 * the ARC while we walk it.
+		 */
+		uint64_t n = MIN(len, (uint64_t)zfs_vnops_read_chunk_size);
+		uint64_t left = n;
+		dmu_buf_t **indbp, **outdbp;
+		int innum, outnum;
+
+		if (issig()) {
+			error = SET_ERROR(EINTR);
+			break;
+		}
+
+		error = dmu_buf_hold_array_by_dnode(indn, inoff, n, TRUE,
+		    FTAG, &innum, &indbp, DMU_READ_PREFETCH);
+		if (error != 0)
+			break;
+		error = dmu_buf_hold_array_by_dnode(outdn, outoff, n, TRUE,
+		    FTAG, &outnum, &outdbp, DMU_READ_PREFETCH);
+		if (error != 0) {
+			dmu_buf_rele_array(indbp, innum, FTAG);
+			break;
+		}
+
+		/*
+		 * The two files share a block size and both offsets are block
+		 * aligned, so the two arrays cover the span the same way.
+		 * Should that assumption ever break, refuse rather than walk
+		 * the shorter array out of bounds.
+		 */
+		ASSERT3S(innum, ==, outnum);
+		if (innum != outnum) {
+			dmu_buf_rele_array(outdbp, outnum, FTAG);
+			dmu_buf_rele_array(indbp, innum, FTAG);
+			error = SET_ERROR(EINVAL);
+			break;
+		}
+
+		for (int i = 0; i < innum; i++) {
+			uint64_t inbufoff = inoff - indbp[i]->db_offset;
+			uint64_t outbufoff = outoff - outdbp[i]->db_offset;
+			uint64_t tocmp = MIN(indbp[i]->db_size - inbufoff,
+			    left);
+
+			ASSERT3P(indbp[i]->db_data, !=, NULL);
+			ASSERT3P(outdbp[i]->db_data, !=, NULL);
+
+			if (memcmp((char *)indbp[i]->db_data + inbufoff,
+			    (char *)outdbp[i]->db_data + outbufoff,
+			    tocmp) != 0) {
+				diff = B_TRUE;
+				break;
+			}
+
+			inoff += tocmp;
+			outoff += tocmp;
+			left -= tocmp;
+		}
+
+		dmu_buf_rele_array(outdbp, outnum, FTAG);
+		dmu_buf_rele_array(indbp, innum, FTAG);
+
+		len -= (n - left);
+	}
+
+	if (error == 0 && len == 0 && !diff)
+		*eqp = B_TRUE;
+
+	dnode_rele(outdn, FTAG);
+	dnode_rele(indn, FTAG);
+
+	return (error);
+}
+
+/*
+ * Decide, from the two L0 block pointers alone, whether they already name the
+ * same data: the same physical block, or two holes.  This is what a
+ * previously cloned or deduped pair of ranges looks like, and it is the one
+ * case where the clone step itself would have nothing left to do.
+ */
+static boolean_t
+zfs_dedupe_bp_same_block(const blkptr_t *bi, const blkptr_t *bo)
+{
+	/*
+	 * Two holes are both a run of zeros over the same block, so they are
+	 * equal without either one naming any storage.  Their sizes are not
+	 * worth comparing and must not be: our caller pairs the two files
+	 * block for block over a block size they share, but a block that was
+	 * never written at all reaches us as an all-zero block pointer (see
+	 * dmu_read_l0_bps()), whose BP_GET_LSIZE() decodes to the minimum
+	 * block size rather than to the file's.  Reading a hole to compare
+	 * its zeros against another hole's zeros is exactly what this avoids.
+	 */
+	if (BP_IS_HOLE(bi) && BP_IS_HOLE(bo))
+		return (B_TRUE);
+
+	if (BP_IS_HOLE(bi) || BP_IS_HOLE(bo) ||
+	    BP_IS_EMBEDDED(bi) || BP_IS_EMBEDDED(bo) ||
+	    BP_IS_REDACTED(bi) || BP_IS_REDACTED(bo))
+		return (B_FALSE);
+
+	/*
+	 * One allocation is one DVA born in one txg, so a matching first DVA
+	 * at a matching physical birth means both pointers name the same
+	 * physical block - typically because the ranges were already cloned
+	 * or deduped.  This needs no checksum and holds even where the
+	 * checksum test below cannot (encryption, weak checksums): the same
+	 * block under the same key decrypts to the same data.  BP_EQUAL() is
+	 * too strict for this: it also compares the logical births, and
+	 * cloning restamps those on every clone.
+	 */
+	return (BP_GET_PHYSICAL_BIRTH(bi) == BP_GET_PHYSICAL_BIRTH(bo) &&
+	    DVA_EQUAL(&bi->blk_dva[0], &bo->blk_dva[0]));
+}
+
+/*
+ * Decide, from the two L0 block pointers alone, whether the blocks provably
+ * hold identical logical data.  Modeled on the nopwrite guard set in
+ * zio_nop_write(): a match of a cryptographically strong (dedup-grade)
+ * checksum is trusted to imply data equality, exactly as ZFS dedup relies on
+ * it.  This can only ever prove equality; a mismatch (or any non-provable
+ * case) is inconclusive and the caller must fall back to reading the data.
+ * Embedded blocks are the exception to needing a checksum: their payload
+ * lives in the pointer itself, so two of them are compared directly.
+ *
+ * All of the following must hold for a checksum match to be trusted:
+ *   - neither BP is embedded, a hole, or redacted (no usable blk_cksum);
+ *   - neither BP is encrypted (per-block IV/salt make the checksum data-
+ *     independent, so equal plaintext yields different checksums);
+ *   - both BPs use the same checksum function and it carries the DEDUP flag
+ *     (sha256/sha512/skein/blake3; fletcher and edonr are excluded);
+ *   - compression, PSIZE, LSIZE and byteorder match, since blk_cksum is
+ *     computed over the physical (post-compression) bytes.
+ * Salted checksums (skein/blake3) are safe here because block cloning is
+ * always intra-pool (zfs_clone_range_precheck() returns EXDEV otherwise) and
+ * the salt is per-pool, so identical data yields identical checksums.
+ */
+static boolean_t
+zfs_dedupe_bp_provably_equal(const blkptr_t *bi, const blkptr_t *bo)
+{
+	enum zio_checksum ck;
+
+	if (zfs_dedupe_bp_same_block(bi, bo))
+		return (B_TRUE);
+
+	/*
+	 * Two embedded blocks carry their (possibly compressed) payload in
+	 * the pointers themselves.  The same payload bytes under the same
+	 * compression function decompress to the same data, so equality is
+	 * provable without decompressing anything.  A payload mismatch
+	 * proves nothing - equal data can compress to different bytes - and
+	 * falls through to the read path like any other unprovable case.
+	 */
+	if (BP_IS_EMBEDDED(bi) && BP_IS_EMBEDDED(bo)) {
+		uint8_t pi[BPE_PAYLOAD_SIZE], po[BPE_PAYLOAD_SIZE];
+
+		if (BPE_GET_ETYPE(bi) != BP_EMBEDDED_TYPE_DATA ||
+		    BPE_GET_ETYPE(bo) != BP_EMBEDDED_TYPE_DATA ||
+		    BP_GET_COMPRESS(bi) != BP_GET_COMPRESS(bo) ||
+		    BPE_GET_LSIZE(bi) != BPE_GET_LSIZE(bo) ||
+		    BPE_GET_PSIZE(bi) != BPE_GET_PSIZE(bo) ||
+		    BP_GET_BYTEORDER(bi) != BP_GET_BYTEORDER(bo))
+			return (B_FALSE);
+
+		/*
+		 * The psize bit field can encode more than the payload area
+		 * holds.  No valid pointer does, but this is cheaper than
+		 * trusting that.
+		 */
+		if (BPE_GET_PSIZE(bi) > BPE_PAYLOAD_SIZE)
+			return (B_FALSE);
+
+		decode_embedded_bp_compressed(bi, pi);
+		decode_embedded_bp_compressed(bo, po);
+
+		return (memcmp(pi, po, BPE_GET_PSIZE(bi)) == 0);
+	}
+
+	if (BP_IS_EMBEDDED(bi) || BP_IS_EMBEDDED(bo) ||
+	    BP_IS_HOLE(bi) || BP_IS_HOLE(bo) ||
+	    BP_IS_REDACTED(bi) || BP_IS_REDACTED(bo) ||
+	    BP_IS_ENCRYPTED(bi) || BP_IS_ENCRYPTED(bo))
+		return (B_FALSE);
+
+	ck = BP_GET_CHECKSUM(bi);
+	if (ck != BP_GET_CHECKSUM(bo))
+		return (B_FALSE);
+	if ((zio_checksum_table[ck].ci_flags & ZCHECKSUM_FLAG_DEDUP) == 0)
+		return (B_FALSE);
+
+	if (BP_GET_COMPRESS(bi) != BP_GET_COMPRESS(bo) ||
+	    BP_GET_PSIZE(bi) != BP_GET_PSIZE(bo) ||
+	    BP_GET_LSIZE(bi) != BP_GET_LSIZE(bo) ||
+	    BP_GET_BYTEORDER(bi) != BP_GET_BYTEORDER(bo))
+		return (B_FALSE);
+
+	return (ZIO_CHECKSUM_EQUAL(bi->blk_cksum, bo->blk_cksum));
+}
+
+/*
+ * The mirror of zfs_dedupe_bp_provably_equal(): decide, from the two L0 block
+ * pointers alone, whether the blocks provably hold *different* logical data,
+ * so the caller can report the ranges as differing without reading them.  This
+ * can only ever prove inequality; anything not provable is inconclusive and
+ * the caller must fall back to reading the data.
+ *
+ * A checksum covers the physical bytes, so unequal checksums prove only that
+ * the physical bytes differ.  Carrying that back to the logical data needs the
+ * block stored verbatim, hence the insistence on compression being off: two
+ * blocks holding identical data can perfectly well compress to different
+ * bytes, say after the compression property was changed, and zstd records only
+ * its algorithm in the BP, not its level.  Encrypted blocks are excluded for
+ * the same reason as in the equality test, to the opposite effect: per-block
+ * IVs give identical plaintext different ciphertext, so unequal checksums
+ * there would say nothing.  Holes and embedded blocks carry no comparable
+ * checksum at all.
+ *
+ * Unlike the equality test this does not need a dedup-grade checksum.  Even a
+ * weak one is deterministic, so equal data always gives equal checksums, and
+ * unequal checksums therefore always mean unequal data.
+ */
+static boolean_t
+zfs_dedupe_bp_provably_unequal(const blkptr_t *bi, const blkptr_t *bo)
+{
+	if (BP_IS_EMBEDDED(bi) || BP_IS_EMBEDDED(bo) ||
+	    BP_IS_HOLE(bi) || BP_IS_HOLE(bo) ||
+	    BP_IS_REDACTED(bi) || BP_IS_REDACTED(bo) ||
+	    BP_IS_ENCRYPTED(bi) || BP_IS_ENCRYPTED(bo))
+		return (B_FALSE);
+
+	if (BP_GET_COMPRESS(bi) != ZIO_COMPRESS_OFF ||
+	    BP_GET_COMPRESS(bo) != ZIO_COMPRESS_OFF)
+		return (B_FALSE);
+
+	if (BP_GET_CHECKSUM(bi) != BP_GET_CHECKSUM(bo) ||
+	    BP_GET_LSIZE(bi) != BP_GET_LSIZE(bo) ||
+	    BP_GET_BYTEORDER(bi) != BP_GET_BYTEORDER(bo))
+		return (B_FALSE);
+
+	return (!ZIO_CHECKSUM_EQUAL(bi->blk_cksum, bo->blk_cksum));
+}
+
+/*
+ * Compare [inoff, inoff + len) in inzp with [outoff, outoff + len) in outzp,
+ * setting *samep if the ranges are byte-for-byte equal.  Both files must be
+ * range locked by the caller.
+ *
+ * As a fast path, blocks are compared by their block-pointer checksums, which
+ * can settle a block either way without reading it: equal, when a strong
+ * checksum matches (zfs_dedupe_bp_provably_equal(), mirroring how ZFS dedup
+ * trusts checksums), or unequal, when checksums over verbatim-stored blocks
+ * differ (zfs_dedupe_bp_provably_unequal()).  Whatever neither can settle - a
+ * weak or mismatched checksum, encryption, a hole, compression, a dirty (not
+ * yet synced) block, etc. - falls back to reading and byte-comparing the data.
+ * Both tests only ever assert what the block pointers prove, so the result is
+ * identical to a full byte compare.
+ *
+ * A trailing block the range only partly covers is no different: the two files
+ * share a block size and both offsets are block aligned, so the tail occupies
+ * the same intra-block span in each, and equal whole-block checksums prove the
+ * whole blocks equal, hence any common prefix of them equal.  Only the bytes
+ * inside the range are ever compared.
+ *
+ * When the ranges match, *sharedp additionally reports whether every block
+ * pair already names the same storage (or is a pair of holes), in which case
+ * the clone step would only reinstall pointers that are already in place and
+ * the caller can skip it.
+ */
+static int
+zfs_dedupe_range_compare(znode_t *inzp, uint64_t inoff, znode_t *outzp,
+    uint64_t outoff, uint64_t len, boolean_t *samep, boolean_t *sharedp)
+{
+	objset_t	*inos = ZTOZSB(inzp)->z_os;
+	objset_t	*outos = ZTOZSB(outzp)->z_os;
+	uint_t		blksz = inzp->z_blksz;
+	blkptr_t	*bps_in = NULL, *bps_out = NULL;
+	size_t		maxblocks;
+	uint64_t	off = 0;
+	boolean_t	eq;
+	boolean_t	shared = B_TRUE;
+	int		error = 0;
+
+	*samep = B_FALSE;
+	*sharedp = B_FALSE;
+
+	/*
+	 * zfs_dedupe_range() has already rejected differing block sizes and
+	 * unaligned offsets, so the two files' blocks line up one to one.
+	 */
+	ASSERT3U(outzp->z_blksz, ==, blksz);
+	ASSERT0(inoff % blksz);
+	ASSERT0(outoff % blksz);
+
+	/*
+	 * Bound the block-pointer batch so the temporary arrays stay small and
+	 * each dmu_read_l0_bps() stays within DMU_MAX_ACCESS.
+	 */
+	maxblocks = MAX(1, MIN((uint64_t)16, (DMU_MAX_ACCESS >> 1) / blksz));
+	bps_in = kmem_alloc(sizeof (blkptr_t) * maxblocks, KM_SLEEP);
+	bps_out = kmem_alloc(sizeof (blkptr_t) * maxblocks, KM_SLEEP);
+
+	while (off < len) {
+		uint64_t span = MIN(len - off, (uint64_t)maxblocks * blksz);
+		size_t nin = maxblocks, nout = maxblocks;
+		int e1, e2;
+
+		if (issig()) {
+			error = SET_ERROR(EINTR);
+			goto out;
+		}
+
+		e1 = dmu_read_l0_bps(inos, inzp->z_id, inoff + off, span,
+		    bps_in, &nin);
+		e2 = dmu_read_l0_bps(outos, outzp->z_id, outoff + off, span,
+		    bps_out, &nout);
+
+		if (e1 != 0 || e2 != 0 || nin != nout) {
+			/*
+			 * A block created in the current txg (EAGAIN), or any
+			 * other reason we could not get stable BPs, just means
+			 * we compare this span by reading it; the data path is
+			 * always correct, including for dirty blocks.
+			 */
+			shared = B_FALSE;
+			error = zfs_dedupe_range_memcmp(inzp, inoff + off,
+			    outzp, outoff + off, span, &eq);
+			if (error != 0 || !eq)
+				goto out;
+			off += span;
+			continue;
+		}
+
+		for (size_t i = 0; i < nin; i++) {
+			uint64_t cmpoff = off + (uint64_t)i * blksz;
+			uint64_t cmplen = MIN((uint64_t)blksz, len - cmpoff);
+
+			if (zfs_dedupe_bp_same_block(&bps_in[i], &bps_out[i]))
+				continue;
+			shared = B_FALSE;
+
+			if (zfs_dedupe_bp_provably_equal(&bps_in[i],
+			    &bps_out[i]))
+				continue;
+
+			/*
+			 * Blocks that provably differ make the whole range
+			 * differ - but only when the range covers all of this
+			 * one.  Two differing blocks can still agree over the
+			 * part a trailing sub-block request covers.
+			 */
+			if (cmplen == blksz &&
+			    zfs_dedupe_bp_provably_unequal(&bps_in[i],
+			    &bps_out[i]))
+				goto out;
+
+			/*
+			 * Not provable from BPs: compare just this block, or
+			 * only the part of it the range covers.
+			 */
+			error = zfs_dedupe_range_memcmp(inzp, inoff + cmpoff,
+			    outzp, outoff + cmpoff, cmplen, &eq);
+			if (error != 0 || !eq)
+				goto out;
+		}
+
+		off += span;
+	}
+
+	*samep = B_TRUE;
+	*sharedp = shared;
+
+out:
+	kmem_free(bps_in, sizeof (blkptr_t) * maxblocks);
+	kmem_free(bps_out, sizeof (blkptr_t) * maxblocks);
+
+	return (error);
+}
+
+/*
+ * Deduplicate a range of outzp against inzp: if [inoff, inoff + *lenp) and
+ * [outoff, outoff + *lenp) hold identical data, clone the source blocks over
+ * the destination so the two ranges share storage.  Implements the Linux
+ * FIDEDUPERANGE ioctl on top of block cloning.
+ *
+ * The comparison and the clone are performed while holding a RL_READER range
+ * lock on inzp and a RL_WRITER range lock on outzp, so the blocks that get
+ * cloned are exactly the bytes that were compared.
+ *
+ * On return:
+ *   error != 0            - the request failed;
+ *   *samep == B_FALSE     - the ranges differ, nothing was deduped;
+ *   *samep == B_TRUE      - the ranges matched and *lenp holds the number of
+ *                           bytes deduped (0 if a shortened range aligned away
+ *                           to nothing).
+ *
+ * Both ranges must lie within their files.  A trailing partial block is
+ * aligned away when can_shorten is set, and rejected with EINVAL when it is
+ * not, so a dedupe can still cover less than the caller asked for.
+ */
+int
+zfs_dedupe_range(znode_t *inzp, uint64_t inoff, znode_t *outzp, uint64_t outoff,
+    uint64_t *lenp, cred_t *cr, boolean_t can_shorten, boolean_t *samep)
+{
+	zfsvfs_t	*inzfsvfs = ZTOZSB(inzp);
+	zfsvfs_t	*outzfsvfs = ZTOZSB(outzp);
+	zfs_locked_range_t *inlr = NULL, *outlr = NULL;
+	uint64_t	len = *lenp;
+	uint64_t	done = 0;
+	uint_t		inblksz;
+	boolean_t	shared = B_FALSE;
+	int		error;
+
+	*samep = B_FALSE;
+
+	error = zfs_enter_two(inzfsvfs, outzfsvfs, FTAG);
+	if (error != 0)
+		return (error);
+
+	error = zfs_clone_range_precheck(inzp, outzp);
+	if (error != 0)
+		goto out;
+
+	/*
+	 * Deduplicating nothing trivially succeeds.
+	 */
+	if (len == 0) {
+		*lenp = 0;
+		*samep = B_TRUE;
+		goto out;
+	}
+
+	/*
+	 * Unlike a clone, a dedupe request is not silently clamped to the
+	 * source EOF: the whole compared range must lie within the source.
+	 */
+	if (inoff >= inzp->z_size || len > inzp->z_size - inoff) {
+		error = SET_ERROR(EINVAL);
+		goto out;
+	}
+
+	/*
+	 * The destination range must lie within the destination too.  Trimming
+	 * it to the destination EOF would be invisible to the caller, because
+	 * the ioctl reports the length it was asked for rather than the one a
+	 * filesystem returns, so a shortened dedupe would be indistinguishable
+	 * from a complete one.  generic_remap_checks() rejects this for the
+	 * filesystems that use it; do the same here.
+	 */
+	if (outoff >= outzp->z_size || len > outzp->z_size - outoff) {
+		error = SET_ERROR(EINVAL);
+		goto out;
+	}
+
+	/*
+	 * Callers might not be able to detect properly that we are read-only,
+	 * so check it explicitly here.
+	 */
+	if (zfs_is_readonly(outzfsvfs)) {
+		error = SET_ERROR(EROFS);
+		goto out;
+	}
+
+	/*
+	 * A dedupe leaves the content as it was, but it still frees the
+	 * destination's blocks and replaces them with shared ones, so honor
+	 * immutable here the way every other data-writing path does.
+	 */
+	if ((outzp->z_pflags & ZFS_IMMUTABLE) != 0) {
+		error = SET_ERROR(EPERM);
+		goto out;
+	}
+
+	/*
+	 * No overlapping if we are deduping within the same file.
+	 */
+	if (inzp == outzp) {
+		if (inoff < outoff + len && outoff < inoff + len) {
+			error = SET_ERROR(EINVAL);
+			goto out;
+		}
+	}
+
+	/* Flush any mmap()'d data on both files before we compare it. */
+	if (zn_has_cached_data(inzp, inoff, inoff + len - 1))
+		zn_flush_cached_data(inzp, B_TRUE);
+	if (zn_has_cached_data(outzp, outoff, outoff + len - 1))
+		zn_flush_cached_data(outzp, B_TRUE);
+
+	/*
+	 * Maintain predictable lock order.
+	 */
+	if (inzp < outzp || (inzp == outzp && inoff < outoff)) {
+		inlr = zfs_rangelock_enter(&inzp->z_rangelock, inoff, len,
+		    RL_READER);
+		outlr = zfs_rangelock_enter(&outzp->z_rangelock, outoff, len,
+		    RL_WRITER);
+	} else {
+		outlr = zfs_rangelock_enter(&outzp->z_rangelock, outoff, len,
+		    RL_WRITER);
+		inlr = zfs_rangelock_enter(&inzp->z_rangelock, inoff, len,
+		    RL_READER);
+	}
+
+	/*
+	 * The clone step can only replace whole blocks of the destination with
+	 * whole blocks of the source, so the two files must agree on the block
+	 * size and both offsets must be block-aligned; those can never be
+	 * shortened away.  A trailing partial block is handled after the
+	 * comparison below.  Block sizes cannot change under us here: growing
+	 * one takes the whole-file rangelock, which our holds exclude.
+	 */
+	inblksz = inzp->z_blksz;
+	if (inblksz != outzp->z_blksz) {
+		error = SET_ERROR(EINVAL);
+		goto unlock;
+	}
+	if ((inoff % inblksz) != 0 || (outoff % inblksz) != 0) {
+		error = SET_ERROR(EINVAL);
+		goto unlock;
+	}
+	if ((len % inblksz) != 0 &&
+	    (len < inzp->z_size - inoff || len < outzp->z_size - outoff) &&
+	    !can_shorten) {
+		error = SET_ERROR(EINVAL);
+		goto unlock;
+	}
+
+	/*
+	 * Compare the whole requested range under the locks, before aligning
+	 * it down for the clone.  Comparing the full range is what makes a
+	 * differing trailing sub-block report DIFFERS rather than being
+	 * silently dropped by the alignment below (which, with a large
+	 * recordsize, can round the whole request away to nothing).
+	 */
+	error = zfs_dedupe_range_compare(inzp, inoff, outzp, outoff, len,
+	    samep, &shared);
+	if (error != 0 || !*samep)
+		goto unlock;
+
+	/*
+	 * The ranges are identical.  Align a trailing partial block away for
+	 * the clone step; the ranges still compared equal, so *samep stays
+	 * set even if this leaves nothing to share.
+	 */
+	if ((len % inblksz) != 0 &&
+	    (len < inzp->z_size - inoff || len < outzp->z_size - outoff))
+		len = P2ALIGN_TYPED(len, inblksz, uint64_t);
+	if (len == 0)
+		goto unlock;
+
+	/*
+	 * When every destination block already shares its source block (or
+	 * both are holes), the ranges were cloned or deduped before and the
+	 * clone would only reinstall the pointers the destination already
+	 * has - dirtying every block, restamping its logical birth (which
+	 * makes the next incremental send carry it again) and churning the
+	 * BRT for an end state that is already on disk.  Dedupe tools cannot
+	 * see ZFS-level sharing, so they will keep finding the same identical
+	 * files; make rededuping them free.
+	 */
+	if (shared) {
+		done = len;
+		goto unlock;
+	}
+
+	error = zfs_clone_range_locked(inzp, inoff, outzp, outoff, len, cr,
+	    outlr, B_TRUE, &done);
+
+unlock:
+	zfs_rangelock_exit(outlr);
+	zfs_rangelock_exit(inlr);
+
+	if (error == 0) {
+		if (done > 0) {
+			/*
+			 * No zil_commit() here: a dedupe logs nothing, so
+			 * there is no itx to wait for even with sync=always.
+			 */
+			ZFS_ACCESSTIME_STAMP(inzfsvfs, inzp);
+		}
+		*lenp = done;
+	}
+
+out:
 	zfs_exit_two(inzfsvfs, outzfsvfs, FTAG);
 
 	return (error);
@@ -2170,6 +2953,7 @@ EXPORT_SYMBOL(zfs_getsecattr);
 EXPORT_SYMBOL(zfs_setsecattr);
 EXPORT_SYMBOL(zfs_clone_range);
 EXPORT_SYMBOL(zfs_clone_range_replay);
+EXPORT_SYMBOL(zfs_dedupe_range);
 
 ZFS_MODULE_PARAM(zfs_vnops, zfs_vnops_, read_chunk_size, U64, ZMOD_RW,
 	"Bytes to read per chunk");

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -52,7 +52,9 @@
 #include <sys/dsl_crypt.h>
 #include <sys/dsl_dataset.h>
 #include <sys/spa.h>
+#include <sys/zio_checksum.h>
 #include <sys/txg.h>
+#include <sys/blkptr.h>
 #include <sys/brt.h>
 #include <sys/dbuf.h>
 #include <sys/policy.h>
@@ -1587,77 +1589,32 @@ zfs_exit_two(zfsvfs_t *zfsvfs1, zfsvfs_t *zfsvfs2, const char *tag)
 }
 
 /*
- * We split each clone request in chunks that can fit into a single ZIL
- * log entry. Each ZIL log entry can fit 130816 bytes for a block cloning
- * operation (see zil_max_log_data() and zfs_log_clone_range()). This gives
- * us room for storing 1022 block pointers.
- *
- * On success, the function return the number of bytes copied in *lenp.
- * Note, it doesn't return how much bytes are left to be copied.
- * On errors which are caused by any file system limitations or
- * brt limitations `EINVAL` is returned. In the most cases a user
- * requested bad parameters, it could be possible to clone the file but
- * some parameters don't match the requirements.
+ * Checks shared by zfs_clone_range() and zfs_dedupe_range() that do not
+ * depend on the offsets or length of the request.  Both datasets must
+ * already be entered with zfs_enter_two().
  */
-int
-zfs_clone_range(znode_t *inzp, uint64_t *inoffp, znode_t *outzp,
-    uint64_t *outoffp, uint64_t *lenp, cred_t *cr)
+static int
+zfs_clone_range_precheck(znode_t *inzp, znode_t *outzp)
 {
-	zfsvfs_t	*inzfsvfs, *outzfsvfs;
-	objset_t	*inos, *outos;
-	zfs_locked_range_t *inlr, *outlr;
-	dmu_buf_impl_t	*db;
-	dmu_tx_t	*tx;
-	zilog_t		*zilog;
-	uint64_t	inoff, outoff, len, done;
-	uint64_t	outsize, size;
+	zfsvfs_t	*inzfsvfs = ZTOZSB(inzp);
+	zfsvfs_t	*outzfsvfs = ZTOZSB(outzp);
+	objset_t	*inos = inzfsvfs->z_os;
+	objset_t	*outos = outzfsvfs->z_os;
 	int		error;
-	int		count = 0;
-	sa_bulk_attr_t	bulk[5];
-	uint64_t	mtime[2], ctime[2];
-	uint64_t	uid, gid, projid;
-	blkptr_t	*bps;
-	size_t		maxblocks, nbps;
-	uint_t		inblksz;
-	uint64_t	clear_setid_bits_txg = 0;
-	uint64_t	last_synced_txg = 0;
-
-	inoff = *inoffp;
-	outoff = *outoffp;
-	len = *lenp;
-	done = 0;
-
-	inzfsvfs = ZTOZSB(inzp);
-	outzfsvfs = ZTOZSB(outzp);
-
-	/*
-	 * We need to call zfs_enter() potentially on two different datasets,
-	 * so we need a dedicated function for that.
-	 */
-	error = zfs_enter_two(inzfsvfs, outzfsvfs, FTAG);
-	if (error != 0)
-		return (error);
-
-	inos = inzfsvfs->z_os;
-	outos = outzfsvfs->z_os;
 
 	/*
 	 * Both source and destination have to belong to the same storage pool.
 	 */
-	if (dmu_objset_spa(inos) != dmu_objset_spa(outos)) {
-		zfs_exit_two(inzfsvfs, outzfsvfs, FTAG);
+	if (dmu_objset_spa(inos) != dmu_objset_spa(outos))
 		return (SET_ERROR(EXDEV));
-	}
 
 	/*
 	 * outos and inos belongs to the same storage pool.
 	 * see a few lines above, only one check.
 	 */
 	if (!spa_feature_is_enabled(dmu_objset_spa(outos),
-	    SPA_FEATURE_BLOCK_CLONING)) {
-		zfs_exit_two(inzfsvfs, outzfsvfs, FTAG);
+	    SPA_FEATURE_BLOCK_CLONING))
 		return (SET_ERROR(EOPNOTSUPP));
-	}
 
 	ASSERT(!outzfsvfs->z_replay);
 
@@ -1665,20 +1622,16 @@ zfs_clone_range(znode_t *inzp, uint64_t *inoffp, znode_t *outzp,
 	 * Block cloning from an unencrypted dataset into an encrypted
 	 * dataset and vice versa is not supported.
 	 */
-	if (inos->os_encrypted != outos->os_encrypted) {
-		zfs_exit_two(inzfsvfs, outzfsvfs, FTAG);
+	if (inos->os_encrypted != outos->os_encrypted)
 		return (SET_ERROR(EXDEV));
-	}
 
 	/*
 	 * Cloning across encrypted datasets is possible only if they
 	 * share the same master key.
 	 */
 	if (inos != outos && inos->os_encrypted &&
-	    !dmu_objset_crypto_key_equal(inos, outos)) {
-		zfs_exit_two(inzfsvfs, outzfsvfs, FTAG);
+	    !dmu_objset_crypto_key_equal(inos, outos))
 		return (SET_ERROR(EXDEV));
-	}
 
 	/*
 	 * Cloning between datasets with different properties is possible,
@@ -1690,89 +1643,64 @@ zfs_clone_range(znode_t *inzp, uint64_t *inoffp, znode_t *outzp,
 	    (inos->os_checksum != outos->os_checksum ||
 	    inos->os_compress != outos->os_compress ||
 	    inos->os_copies != outos->os_copies ||
-	    inos->os_dedup_checksum != outos->os_dedup_checksum)) {
-		zfs_exit_two(inzfsvfs, outzfsvfs, FTAG);
+	    inos->os_dedup_checksum != outos->os_dedup_checksum))
 		return (SET_ERROR(EXDEV));
-	}
 
 	error = zfs_verify_zp(inzp);
 	if (error == 0)
 		error = zfs_verify_zp(outzp);
-	if (error != 0) {
-		zfs_exit_two(inzfsvfs, outzfsvfs, FTAG);
+	if (error != 0)
 		return (error);
-	}
 
 	/*
 	 * We don't copy source file's flags that's why we don't allow to clone
 	 * files that are in quarantine.
 	 */
-	if (inzp->z_pflags & ZFS_AV_QUARANTINED) {
-		zfs_exit_two(inzfsvfs, outzfsvfs, FTAG);
+	if (inzp->z_pflags & ZFS_AV_QUARANTINED)
 		return (SET_ERROR(EACCES));
-	}
 
-	if (inoff >= inzp->z_size) {
-		*lenp = 0;
-		zfs_exit_two(inzfsvfs, outzfsvfs, FTAG);
-		return (0);
-	}
-	if (len > inzp->z_size - inoff) {
-		len = inzp->z_size - inoff;
-	}
-	if (len == 0) {
-		*lenp = 0;
-		zfs_exit_two(inzfsvfs, outzfsvfs, FTAG);
-		return (0);
-	}
+	return (0);
+}
 
-	/*
-	 * Callers might not be able to detect properly that we are read-only,
-	 * so check it explicitly here.
-	 */
-	if (zfs_is_readonly(outzfsvfs)) {
-		zfs_exit_two(inzfsvfs, outzfsvfs, FTAG);
-		return (SET_ERROR(EROFS));
-	}
+/*
+ * Clone a range of blocks from inzp into outzp.  The caller must have entered
+ * both datasets, resolved the request against the source EOF, and be holding a
+ * RL_READER range lock on inzp and a RL_WRITER range lock (outlr) on outzp.
+ * The number of bytes cloned is returned via donep; the caller is responsible
+ * for the trailing accounting (access time, zil_commit) and for dropping the
+ * range locks.
+ *
+ * When dedup is set the caller is implementing FIDEDUPERANGE, where the file
+ * content is unchanged: in that case we must not update the destination's
+ * mtime/ctime or strip its setid bits, matching the Linux convention that
+ * REMAP_FILE_DEDUP skips file_modified().
+ */
+static int
+zfs_clone_range_locked(znode_t *inzp, uint64_t inoff, znode_t *outzp,
+    uint64_t outoff, uint64_t len, cred_t *cr, zfs_locked_range_t *outlr,
+    boolean_t dedup, uint64_t *donep)
+{
+	zfsvfs_t	*inzfsvfs = ZTOZSB(inzp);
+	zfsvfs_t	*outzfsvfs = ZTOZSB(outzp);
+	objset_t	*inos = inzfsvfs->z_os;
+	objset_t	*outos = outzfsvfs->z_os;
+	dmu_buf_impl_t	*db;
+	dmu_tx_t	*tx;
+	zilog_t		*zilog = outzfsvfs->z_log;
+	uint64_t	done = 0;
+	uint64_t	outsize, size;
+	int		error = 0;
+	int		count = 0;
+	sa_bulk_attr_t	bulk[5];
+	uint64_t	mtime[2], ctime[2];
+	uint64_t	uid, gid, projid;
+	blkptr_t	*bps;
+	size_t		maxblocks, nbps;
+	uint_t		inblksz;
+	uint64_t	clear_setid_bits_txg = 0;
+	uint64_t	last_synced_txg = 0;
 
-	/*
-	 * If immutable or not appending then return EPERM.
-	 * Intentionally allow ZFS_READONLY through here.
-	 * See zfs_zaccess_common()
-	 */
-	if ((outzp->z_pflags & ZFS_IMMUTABLE) != 0) {
-		zfs_exit_two(inzfsvfs, outzfsvfs, FTAG);
-		return (SET_ERROR(EPERM));
-	}
-
-	/*
-	 * No overlapping if we are cloning within the same file.
-	 */
-	if (inzp == outzp) {
-		if (inoff < outoff + len && outoff < inoff + len) {
-			zfs_exit_two(inzfsvfs, outzfsvfs, FTAG);
-			return (SET_ERROR(EINVAL));
-		}
-	}
-
-	/* Flush any mmap()'d data to disk */
-	if (zn_has_cached_data(inzp, inoff, inoff + len - 1))
-		zn_flush_cached_data(inzp, B_TRUE);
-
-	/*
-	 * Maintain predictable lock order.
-	 */
-	if (inzp < outzp || (inzp == outzp && inoff < outoff)) {
-		inlr = zfs_rangelock_enter(&inzp->z_rangelock, inoff, len,
-		    RL_READER);
-		outlr = zfs_rangelock_enter(&outzp->z_rangelock, outoff, len,
-		    RL_WRITER);
-	} else {
-		outlr = zfs_rangelock_enter(&outzp->z_rangelock, outoff, len,
-		    RL_WRITER);
-		inlr = zfs_rangelock_enter(&inzp->z_rangelock, inoff, len,
-		    RL_READER);
-	}
+	*donep = 0;
 
 	inblksz = inzp->z_blksz;
 
@@ -1790,8 +1718,7 @@ zfs_clone_range(znode_t *inzp, uint64_t *inoffp, znode_t *outzp,
 			if (min_smallblk < inblksz &&
 			    (inos->os_compress != ZIO_COMPRESS_OFF ||
 			    max_smallblk >= inblksz)) {
-				error = SET_ERROR(EXDEV);
-				goto unlock;
+				return (SET_ERROR(EXDEV));
 			}
 		}
 	}
@@ -1803,40 +1730,30 @@ zfs_clone_range(znode_t *inzp, uint64_t *inoffp, znode_t *outzp,
 	 * grow to fail, but we cover what we can before opening transaction
 	 * and the rest detect after we try to do it.
 	 */
-	if (inblksz < outzp->z_blksz) {
-		error = SET_ERROR(EINVAL);
-		goto unlock;
-	}
+	if (inblksz < outzp->z_blksz)
+		return (SET_ERROR(EINVAL));
 	if (inblksz != outzp->z_blksz && (outzp->z_size > outzp->z_blksz ||
-	    outlr->lr_length != UINT64_MAX)) {
-		error = SET_ERROR(EINVAL);
-		goto unlock;
-	}
+	    outlr->lr_length != UINT64_MAX))
+		return (SET_ERROR(EINVAL));
 
 	/*
 	 * Block size must be power-of-2 if destination offset != 0.
 	 * There can be no multiple blocks of non-power-of-2 size.
 	 */
-	if (outoff != 0 && !ISP2(inblksz)) {
-		error = SET_ERROR(EINVAL);
-		goto unlock;
-	}
+	if (outoff != 0 && !ISP2(inblksz))
+		return (SET_ERROR(EINVAL));
 
 	/*
 	 * Offsets and len must be at block boundries.
 	 */
-	if ((inoff % inblksz) != 0 || (outoff % inblksz) != 0) {
-		error = SET_ERROR(EINVAL);
-		goto unlock;
-	}
+	if ((inoff % inblksz) != 0 || (outoff % inblksz) != 0)
+		return (SET_ERROR(EINVAL));
 	/*
 	 * Length must be multipe of blksz, except for the end of the file.
 	 */
 	if ((len % inblksz) != 0 &&
-	    (len < inzp->z_size - inoff || len < outzp->z_size - outoff)) {
-		error = SET_ERROR(EINVAL);
-		goto unlock;
-	}
+	    (len < inzp->z_size - inoff || len < outzp->z_size - outoff))
+		return (SET_ERROR(EINVAL));
 
 	/*
 	 * If we are copying only one block and it is smaller than recordsize
@@ -1846,34 +1763,37 @@ zfs_clone_range(znode_t *inzp, uint64_t *inoffp, znode_t *outzp,
 	 * matter how big the destination grow later.
 	 */
 	if (len <= inblksz && inblksz < outzfsvfs->z_max_blksz &&
-	    outzp->z_size <= inblksz && outoff + len > inblksz) {
-		error = SET_ERROR(EINVAL);
-		goto unlock;
-	}
+	    outzp->z_size <= inblksz && outoff + len > inblksz)
+		return (SET_ERROR(EINVAL));
 
 	error = zn_rlimit_fsize(outoff + len);
-	if (error != 0) {
-		goto unlock;
+	if (error != 0)
+		return (error);
+
+	if (inoff >= MAXOFFSET_T || outoff >= MAXOFFSET_T)
+		return (SET_ERROR(EFBIG));
+
+	/*
+	 * A dedupe leaves the destination's content and metadata alone: it can
+	 * only replace blocks with identical ones.  The times must not move,
+	 * and size, flags and seq cannot change either - a dedupe never extends
+	 * the file, never clears setid bits and never bumps z_seq - so there is
+	 * nothing to write back at all.
+	 */
+	if (!dedup) {
+		SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_MTIME(outzfsvfs), NULL,
+		    &mtime, 16);
+		SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_CTIME(outzfsvfs), NULL,
+		    &ctime, 16);
+		SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_SIZE(outzfsvfs), NULL,
+		    &outzp->z_size, 8);
+		SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_FLAGS(outzfsvfs), NULL,
+		    &outzp->z_pflags, 8);
+		if (outzp->z_is_sa)
+			SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_SEQ(outzfsvfs),
+			    NULL, &outzp->z_seq, 8);
 	}
 
-	if (inoff >= MAXOFFSET_T || outoff >= MAXOFFSET_T) {
-		error = SET_ERROR(EFBIG);
-		goto unlock;
-	}
-
-	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_MTIME(outzfsvfs), NULL,
-	    &mtime, 16);
-	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_CTIME(outzfsvfs), NULL,
-	    &ctime, 16);
-	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_SIZE(outzfsvfs), NULL,
-	    &outzp->z_size, 8);
-	SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_FLAGS(outzfsvfs), NULL,
-	    &outzp->z_pflags, 8);
-	if (outzp->z_is_sa)
-		SA_ADD_BULK_ATTR(bulk, count, SA_ZPL_SEQ(outzfsvfs), NULL,
-		    &outzp->z_seq, 8);
-
-	zilog = outzfsvfs->z_log;
 	maxblocks = zil_max_log_data(zilog, sizeof (lr_clone_range_t)) /
 	    sizeof (bps[0]);
 
@@ -1913,8 +1833,12 @@ zfs_clone_range(znode_t *inzp, uint64_t *inoffp, znode_t *outzp,
 			 * EAGAIN here.  Based on zfs_bclone_wait_dirty either
 			 * return a shortened range to the caller so it can
 			 * fallback, or wait for the next TXG and check again.
+			 * A dedupe always waits: it has no fallback, so the
+			 * EAGAIN would surface to the FIDEDUPERANGE caller,
+			 * and the comparison already read this very data.
 			 */
-			if (error == EAGAIN && zfs_bclone_wait_dirty) {
+			if (error == EAGAIN &&
+			    (dedup || zfs_bclone_wait_dirty)) {
 				txg_wait_flag_t wait_flags =
 				    spa_get_failmode(dmu_objset_spa(inos)) ==
 				    ZIO_FAILURE_MODE_CONTINUE ?
@@ -1982,31 +1906,67 @@ zfs_clone_range(znode_t *inzp, uint64_t *inoffp, znode_t *outzp,
 			break;
 		}
 
-		if (zn_has_cached_data(outzp, outoff, outoff + size - 1)) {
+		/*
+		 * A dedupe replaces the destination's blocks with blocks
+		 * holding the same bytes, so a page already cached for this
+		 * range stays correct and there is nothing to refresh.  The
+		 * only page whose contents can differ from the DMU is one
+		 * carrying an mmap store made after the pre-compare flush,
+		 * and refreshing that would discard the store, which is a
+		 * modification a dedupe must never make.
+		 */
+		if (!dedup &&
+		    zn_has_cached_data(outzp, outoff, outoff + size - 1)) {
 			update_pages(outzp, outoff, size, outos);
 		}
 
-		zfs_clear_setid_bits_if_necessary(outzfsvfs, outzp, cr,
-		    &clear_setid_bits_txg, tx);
+		if (!dedup) {
+			zfs_clear_setid_bits_if_necessary(outzfsvfs, outzp, cr,
+			    &clear_setid_bits_txg, tx);
 
-		zfs_tstamp_update_setup(outzp, CONTENT_MODIFIED, mtime, ctime);
-		if (outzp->z_is_sa)
-			outzp->z_has_seq = B_TRUE;
+			zfs_tstamp_update_setup(outzp, CONTENT_MODIFIED, mtime,
+			    ctime);
 
-		/*
-		 * Update the file size (zp_size) if it has changed;
-		 * account for possible concurrent updates.
-		 */
-		while ((outsize = outzp->z_size) < outoff + size) {
-			(void) atomic_cas_64(&outzp->z_size, outsize,
-			    outoff + size);
+			if (outzp->z_is_sa)
+				outzp->z_has_seq = B_TRUE;
+
+			/*
+			 * Update the file size (zp_size) if it has changed;
+			 * account for possible concurrent updates.
+			 */
+			while ((outsize = outzp->z_size) < outoff + size) {
+				(void) atomic_cas_64(&outzp->z_size, outsize,
+				    outoff + size);
+			}
+		} else {
+			/* A dedupe can only ever rewrite blocks in place. */
+			ASSERT3U(outoff + size, <=, outzp->z_size);
 		}
 
-		ASSERT3S(count, <=, ARRAY_SIZE(bulk));
-		error = sa_bulk_update(outzp->z_sa_hdl, bulk, count, tx);
+		if (count > 0) {
+			ASSERT3S(count, <=, ARRAY_SIZE(bulk));
+			error = sa_bulk_update(outzp->z_sa_hdl, bulk, count,
+			    tx);
+		}
 
-		zfs_log_clone_range(zilog, tx, TX_CLONE_RANGE, outzp, outoff,
-		    size, inblksz, bps, nbps);
+		/*
+		 * A dedupe is not logged.  It replaces the destination's blocks
+		 * with blocks holding the very same bytes, so if the txg is
+		 * lost to a crash and never replayed, the destination simply
+		 * keeps its own copy of that identical content: nothing a
+		 * reader can observe is lost, only the sharing.  Sharing is all
+		 * FIDEDUPERANGE promises anyway, and it is the cheaper of the
+		 * alternatives.  Logging a plain TX_CLONE_RANGE would restamp
+		 * the destination's mtime/ctime on replay, and telling a dedupe
+		 * apart with a record of its own would be an on-disk ZIL format
+		 * change: an old kernel meeting an unknown txtype fails
+		 * zil_parse(), and zil_replay() then destroys the whole log,
+		 * discarding every later record - including synced writes.
+		 */
+		if (!dedup) {
+			zfs_log_clone_range(zilog, tx, TX_CLONE_RANGE, outzp,
+			    outoff, size, inblksz, bps, nbps);
+		}
 
 		dmu_tx_commit(tx);
 
@@ -2027,7 +1987,127 @@ zfs_clone_range(znode_t *inzp, uint64_t *inoffp, znode_t *outzp,
 	vmem_free(bps, sizeof (bps[0]) * maxblocks);
 	zfs_znode_update_vfs(outzp);
 
-unlock:
+	*donep = done;
+
+	return (error);
+}
+
+/*
+ * Clone part of inzp file into outzp file. This must be done under range locks
+ * held on both files so as to prevent it from being modified while the clone
+ * takes place.
+ *
+ * Copies bytes from inzp->inoffp to outzp->outoffp, up to *lenp bytes.  On
+ * entry *lenp holds the requested length; on successful return it holds the
+ * number of bytes actually cloned, and inoffp/outoffp are advanced by that
+ * amount.
+ *
+ * If we make no progress at all, then the caller made a mistake or asked for
+ * something impossible, and EINVAL (or another appropriate error) is returned.
+ *
+ * Note, it doesn't return how many bytes are left to be copied.
+ * On errors which are caused by any file system limitations or
+ * BRT limitations EINVAL is returned. In the most cases a user
+ * requested bad parameters, it could be possible to clone the file but
+ * some parameters don't match the requirements.
+ */
+int
+zfs_clone_range(znode_t *inzp, uint64_t *inoffp, znode_t *outzp,
+    uint64_t *outoffp, uint64_t *lenp, cred_t *cr)
+{
+	zfsvfs_t	*inzfsvfs = ZTOZSB(inzp);
+	zfsvfs_t	*outzfsvfs = ZTOZSB(outzp);
+	zfs_locked_range_t *inlr, *outlr;
+	zilog_t		*zilog;
+	uint64_t	inoff = *inoffp;
+	uint64_t	outoff = *outoffp;
+	uint64_t	len = *lenp;
+	uint64_t	done = 0;
+	int		error;
+
+	/*
+	 * We need to call zfs_enter() potentially on two different datasets,
+	 * so we need a dedicated function for that.
+	 */
+	error = zfs_enter_two(inzfsvfs, outzfsvfs, FTAG);
+	if (error != 0)
+		return (error);
+
+	/*
+	 * Read z_log only after entering, so a suspend/resume (rollback,
+	 * zfs receive -F) cannot leave us with a stale or freed zilog.
+	 */
+	zilog = outzfsvfs->z_log;
+
+	error = zfs_clone_range_precheck(inzp, outzp);
+	if (error != 0)
+		goto out;
+
+	/*
+	 * The range to clone must lie within the source file.  Clamp it to the
+	 * source EOF and treat an empty range as a no-op.
+	 */
+	if (inoff >= inzp->z_size) {
+		*lenp = 0;
+		goto out;
+	}
+	if (len > inzp->z_size - inoff)
+		len = inzp->z_size - inoff;
+	if (len == 0) {
+		*lenp = 0;
+		goto out;
+	}
+
+	/*
+	 * Callers might not be able to detect properly that we are read-only,
+	 * so check it explicitly here.
+	 */
+	if (zfs_is_readonly(outzfsvfs)) {
+		error = SET_ERROR(EROFS);
+		goto out;
+	}
+
+	/*
+	 * If immutable then return EPERM.  Intentionally allow ZFS_READONLY
+	 * through here.  See zfs_zaccess_common().
+	 */
+	if ((outzp->z_pflags & ZFS_IMMUTABLE) != 0) {
+		error = SET_ERROR(EPERM);
+		goto out;
+	}
+
+	/*
+	 * No overlapping if we are cloning within the same file.
+	 */
+	if (inzp == outzp) {
+		if (inoff < outoff + len && outoff < inoff + len) {
+			error = SET_ERROR(EINVAL);
+			goto out;
+		}
+	}
+
+	/* Flush any mmap()'d data to disk */
+	if (zn_has_cached_data(inzp, inoff, inoff + len - 1))
+		zn_flush_cached_data(inzp, B_TRUE);
+
+	/*
+	 * Maintain predictable lock order.
+	 */
+	if (inzp < outzp || (inzp == outzp && inoff < outoff)) {
+		inlr = zfs_rangelock_enter(&inzp->z_rangelock, inoff, len,
+		    RL_READER);
+		outlr = zfs_rangelock_enter(&outzp->z_rangelock, outoff, len,
+		    RL_WRITER);
+	} else {
+		outlr = zfs_rangelock_enter(&outzp->z_rangelock, outoff, len,
+		    RL_WRITER);
+		inlr = zfs_rangelock_enter(&inzp->z_rangelock, inoff, len,
+		    RL_READER);
+	}
+
+	error = zfs_clone_range_locked(inzp, inoff, outzp, outoff, len, cr,
+	    outlr, B_FALSE, &done);
+
 	zfs_rangelock_exit(outlr);
 	zfs_rangelock_exit(inlr);
 
@@ -2039,9 +2119,8 @@ unlock:
 
 		ZFS_ACCESSTIME_STAMP(inzfsvfs, inzp);
 
-		if (outos->os_sync == ZFS_SYNC_ALWAYS) {
+		if (outzfsvfs->z_os->os_sync == ZFS_SYNC_ALWAYS)
 			error = zil_commit(zilog, outzp->z_id);
-		}
 
 		*inoffp += done;
 		*outoffp += done;
@@ -2054,6 +2133,721 @@ unlock:
 		ASSERT3S(error, !=, 0);
 	}
 
+out:
+	zfs_exit_two(inzfsvfs, outzfsvfs, FTAG);
+
+	return (error);
+}
+
+/*
+ * Compare two ranges by copying them out of the DMU into buffers and comparing
+ * those.  Only used where the dbuf comparison below cannot go; see there.
+ */
+static int
+zfs_dedupe_range_copy_memcmp(znode_t *inzp, uint64_t inoff, znode_t *outzp,
+    uint64_t outoff, uint64_t len, boolean_t *eqp)
+{
+	objset_t	*inos = ZTOZSB(inzp)->z_os;
+	objset_t	*outos = ZTOZSB(outzp)->z_os;
+	uint64_t	chunk = MIN(len, (uint64_t)zfs_vnops_read_chunk_size);
+	char		*inbuf, *outbuf;
+	int		error = 0;
+
+	*eqp = B_FALSE;
+
+	inbuf = vmem_alloc(chunk, KM_SLEEP);
+	outbuf = vmem_alloc(chunk, KM_SLEEP);
+
+	while (len > 0) {
+		uint64_t n = MIN(len, chunk);
+
+		if (issig()) {
+			error = SET_ERROR(EINTR);
+			break;
+		}
+
+		error = dmu_read(inos, inzp->z_id, inoff, n, inbuf,
+		    DMU_READ_PREFETCH);
+		if (error != 0)
+			break;
+		error = dmu_read(outos, outzp->z_id, outoff, n, outbuf,
+		    DMU_READ_PREFETCH);
+		if (error != 0)
+			break;
+
+		if (memcmp(inbuf, outbuf, n) != 0)
+			break;
+
+		inoff += n;
+		outoff += n;
+		len -= n;
+	}
+
+	if (error == 0 && len == 0)
+		*eqp = B_TRUE;
+
+	vmem_free(inbuf, chunk);
+	vmem_free(outbuf, chunk);
+
+	return (error);
+}
+
+/*
+ * Compare [inoff, inoff + len) in inzp with [outoff, outoff + len) in outzp by
+ * reading the committed on-disk data through the DMU (the same data
+ * zfs_clone_range_locked() will clone) and byte-comparing it.  Both files must
+ * be range locked by the caller.  On return *eqp is set if the ranges are
+ * byte-for-byte equal.  This is the authoritative (and always-correct) path;
+ * the DMU serves holes as zeros and decrypts transparently, so it needs no
+ * special-casing for encryption, holes or embedded blocks.
+ *
+ * The comparison is done on the dbufs themselves.  dmu_read() would only hold
+ * the very same buffers and memcpy() out of them, so going through it would
+ * cost two allocations and a copy of every byte, for nothing: we are not
+ * keeping the data, only looking at it.  Our range locks keep it still while
+ * we do.
+ */
+static int
+zfs_dedupe_range_memcmp(znode_t *inzp, uint64_t inoff, znode_t *outzp,
+    uint64_t outoff, uint64_t len, boolean_t *eqp)
+{
+	objset_t	*inos = ZTOZSB(inzp)->z_os;
+	objset_t	*outos = ZTOZSB(outzp)->z_os;
+	dnode_t		*indn, *outdn;
+	uint64_t	blksz, chunk;
+	boolean_t	diff = B_FALSE;
+	int		error;
+
+	*eqp = B_FALSE;
+
+	error = dnode_hold(inos, inzp->z_id, FTAG, &indn);
+	if (error != 0)
+		return (error);
+	error = dnode_hold(outos, outzp->z_id, FTAG, &outdn);
+	if (error != 0) {
+		dnode_rele(indn, FTAG);
+		return (error);
+	}
+
+	/*
+	 * dmu_buf_hold_array_by_dnode() refuses to look past a single block
+	 * whose size is not a power of two, calling zfs_panic_recover() rather
+	 * than serving the tail as zeros the way dmu_read() does.  A ZPL file
+	 * should never present that shape - zfs_grow_blocksize() only leaves a
+	 * block size alone once the file has outgrown it, so an odd-sized block
+	 * means the file still fits inside it and the range cannot reach past
+	 * it.  Should one turn up regardless, fall back to copying rather than
+	 * add another way to take the pool down.  Our caller reaches
+	 * dmu_read_l0_bps() first, which holds the same buffers and would trip
+	 * over such a file before we ever got here, so in practice this only
+	 * catches what gets past that on a pool running with zfs_recover set.
+	 */
+	if ((indn->dn_datablkshift == 0 && inoff + len > indn->dn_datablksz) ||
+	    (outdn->dn_datablkshift == 0 &&
+	    outoff + len > outdn->dn_datablksz)) {
+		dnode_rele(outdn, FTAG);
+		dnode_rele(indn, FTAG);
+		return (zfs_dedupe_range_copy_memcmp(inzp, inoff, outzp,
+		    outoff, len, eqp));
+	}
+
+	/*
+	 * A block is read and decompressed in full whatever part of it we ask
+	 * for, so a chunk below the block size would buy nothing and only hold
+	 * the same buffer once per piece of it.  Take whole blocks, at least
+	 * one, capped the way zfs_read() caps its own chunk so that a large
+	 * request does not pin an unbounded stretch of the ARC.
+	 *
+	 * zfs_dedupe_range() has already refused an unaligned range, so each
+	 * buffer we are handed begins at the offset we are comparing.
+	 */
+	blksz = indn->dn_datablksz;
+	ASSERT3U(outdn->dn_datablksz, ==, blksz);
+	chunk = MAX(1, MIN(zfs_vnops_read_chunk_size, DMU_MAX_ACCESS / 2) /
+	    blksz) * blksz;
+
+	while (len > 0 && !diff) {
+		uint64_t n = MIN(len, chunk);
+		uint64_t left = n;
+		dmu_buf_t **indbp, **outdbp;
+		int innum, outnum;
+
+		if (issig()) {
+			error = SET_ERROR(EINTR);
+			break;
+		}
+
+		error = dmu_buf_hold_array_by_dnode(indn, inoff, n, TRUE,
+		    FTAG, &innum, &indbp, DMU_READ_PREFETCH);
+		if (error != 0)
+			break;
+		error = dmu_buf_hold_array_by_dnode(outdn, outoff, n, TRUE,
+		    FTAG, &outnum, &outdbp, DMU_READ_PREFETCH);
+		if (error != 0) {
+			dmu_buf_rele_array(indbp, innum, FTAG);
+			break;
+		}
+
+		/*
+		 * The two files share a block size and both offsets are block
+		 * aligned, so the two arrays cover the span the same way.
+		 * Should that assumption ever break, refuse rather than walk
+		 * the shorter array out of bounds.
+		 */
+		ASSERT3S(innum, ==, outnum);
+		if (innum != outnum) {
+			dmu_buf_rele_array(outdbp, outnum, FTAG);
+			dmu_buf_rele_array(indbp, innum, FTAG);
+			error = SET_ERROR(EINVAL);
+			break;
+		}
+
+		for (int i = 0; i < innum; i++) {
+			uint64_t tocmp;
+
+			ASSERT3U(indbp[i]->db_offset, ==, inoff);
+			ASSERT3U(outdbp[i]->db_offset, ==, outoff);
+			ASSERT3P(indbp[i]->db_data, !=, NULL);
+			ASSERT3P(outdbp[i]->db_data, !=, NULL);
+
+			tocmp = MIN(indbp[i]->db_size, left);
+
+			if (memcmp(indbp[i]->db_data, outdbp[i]->db_data,
+			    tocmp) != 0) {
+				diff = B_TRUE;
+				break;
+			}
+
+			inoff += tocmp;
+			outoff += tocmp;
+			left -= tocmp;
+		}
+
+		dmu_buf_rele_array(outdbp, outnum, FTAG);
+		dmu_buf_rele_array(indbp, innum, FTAG);
+
+		len -= (n - left);
+	}
+
+	if (error == 0 && len == 0 && !diff)
+		*eqp = B_TRUE;
+
+	dnode_rele(outdn, FTAG);
+	dnode_rele(indn, FTAG);
+
+	return (error);
+}
+
+/*
+ * Decide, from the two L0 block pointers alone, whether they already name the
+ * same data: the same physical block, or two holes.  This is what a
+ * previously cloned or deduped pair of ranges looks like, and it is the one
+ * case where the clone step itself would have nothing left to do.
+ */
+static boolean_t
+zfs_dedupe_bp_same_block(const blkptr_t *bi, const blkptr_t *bo)
+{
+	/*
+	 * Two holes are both a run of zeros over the same block, so they are
+	 * equal without either one naming any storage.  Their sizes are not
+	 * worth comparing and must not be: our caller pairs the two files
+	 * block for block over a block size they share, but a block that was
+	 * never written at all reaches us as an all-zero block pointer (see
+	 * dmu_read_l0_bps()), whose BP_GET_LSIZE() decodes to the minimum
+	 * block size rather than to the file's.  Reading a hole to compare
+	 * its zeros against another hole's zeros is exactly what this avoids.
+	 */
+	if (BP_IS_HOLE(bi) && BP_IS_HOLE(bo))
+		return (B_TRUE);
+
+	if (BP_IS_HOLE(bi) || BP_IS_HOLE(bo) ||
+	    BP_IS_EMBEDDED(bi) || BP_IS_EMBEDDED(bo) ||
+	    BP_IS_REDACTED(bi) || BP_IS_REDACTED(bo))
+		return (B_FALSE);
+
+	/*
+	 * One allocation is one DVA born in one txg, so a matching first DVA
+	 * at a matching physical birth means both pointers name the same
+	 * physical block - typically because the ranges were already cloned
+	 * or deduped.  This needs no checksum and holds even where the
+	 * checksum test below cannot (encryption, weak checksums): the same
+	 * block under the same key decrypts to the same data.  BP_EQUAL() is
+	 * too strict for this: it also compares the logical births, and
+	 * cloning restamps those on every clone.
+	 */
+	return (BP_GET_PHYSICAL_BIRTH(bi) == BP_GET_PHYSICAL_BIRTH(bo) &&
+	    DVA_EQUAL(&bi->blk_dva[0], &bo->blk_dva[0]));
+}
+
+/*
+ * Decide, from the two L0 block pointers alone, whether the blocks provably
+ * hold identical logical data.  Modeled on the nopwrite guard set in
+ * zio_nop_write(): a match of a cryptographically strong (dedup-grade)
+ * checksum is trusted to imply data equality, exactly as ZFS dedup relies on
+ * it.  This can only ever prove equality; a mismatch (or any non-provable
+ * case) is inconclusive and the caller must fall back to reading the data.
+ * Embedded blocks are the exception to needing a checksum: their payload
+ * lives in the pointer itself, so two of them are compared directly.
+ *
+ * All of the following must hold for a checksum match to be trusted:
+ *   - neither BP is embedded, a hole, or redacted (no usable blk_cksum);
+ *   - neither BP is encrypted (per-block IV/salt make the checksum data-
+ *     independent, so equal plaintext yields different checksums);
+ *   - both BPs use the same checksum function and it carries the DEDUP flag
+ *     (sha256/sha512/skein/blake3; fletcher and edonr are excluded);
+ *   - compression, PSIZE, LSIZE and byteorder match, since blk_cksum is
+ *     computed over the physical (post-compression) bytes.
+ * Salted checksums (skein/blake3) are safe here because block cloning is
+ * always intra-pool (zfs_clone_range_precheck() returns EXDEV otherwise) and
+ * the salt is per-pool, so identical data yields identical checksums.
+ */
+static boolean_t
+zfs_dedupe_bp_provably_equal(const blkptr_t *bi, const blkptr_t *bo)
+{
+	enum zio_checksum ck;
+
+	if (zfs_dedupe_bp_same_block(bi, bo))
+		return (B_TRUE);
+
+	/*
+	 * Two embedded blocks carry their (possibly compressed) payload in
+	 * the pointers themselves.  The same payload bytes under the same
+	 * compression function decompress to the same data, so equality is
+	 * provable without decompressing anything.  A payload mismatch
+	 * proves nothing - equal data can compress to different bytes - and
+	 * falls through to the read path like any other unprovable case.
+	 */
+	if (BP_IS_EMBEDDED(bi) && BP_IS_EMBEDDED(bo)) {
+		uint8_t pi[BPE_PAYLOAD_SIZE], po[BPE_PAYLOAD_SIZE];
+
+		if (BPE_GET_ETYPE(bi) != BP_EMBEDDED_TYPE_DATA ||
+		    BPE_GET_ETYPE(bo) != BP_EMBEDDED_TYPE_DATA ||
+		    BP_GET_COMPRESS(bi) != BP_GET_COMPRESS(bo) ||
+		    BPE_GET_LSIZE(bi) != BPE_GET_LSIZE(bo) ||
+		    BPE_GET_PSIZE(bi) != BPE_GET_PSIZE(bo) ||
+		    BP_GET_BYTEORDER(bi) != BP_GET_BYTEORDER(bo))
+			return (B_FALSE);
+
+		/*
+		 * The psize bit field can encode more than the payload area
+		 * holds.  No valid pointer does, but this is cheaper than
+		 * trusting that.
+		 */
+		if (BPE_GET_PSIZE(bi) > BPE_PAYLOAD_SIZE)
+			return (B_FALSE);
+
+		decode_embedded_bp_compressed(bi, pi);
+		decode_embedded_bp_compressed(bo, po);
+
+		return (memcmp(pi, po, BPE_GET_PSIZE(bi)) == 0);
+	}
+
+	if (BP_IS_EMBEDDED(bi) || BP_IS_EMBEDDED(bo) ||
+	    BP_IS_HOLE(bi) || BP_IS_HOLE(bo) ||
+	    BP_IS_REDACTED(bi) || BP_IS_REDACTED(bo) ||
+	    BP_IS_ENCRYPTED(bi) || BP_IS_ENCRYPTED(bo))
+		return (B_FALSE);
+
+	ck = BP_GET_CHECKSUM(bi);
+	if (ck != BP_GET_CHECKSUM(bo))
+		return (B_FALSE);
+	if ((zio_checksum_table[ck].ci_flags & ZCHECKSUM_FLAG_DEDUP) == 0)
+		return (B_FALSE);
+
+	if (BP_GET_COMPRESS(bi) != BP_GET_COMPRESS(bo) ||
+	    BP_GET_PSIZE(bi) != BP_GET_PSIZE(bo) ||
+	    BP_GET_LSIZE(bi) != BP_GET_LSIZE(bo) ||
+	    BP_GET_BYTEORDER(bi) != BP_GET_BYTEORDER(bo))
+		return (B_FALSE);
+
+	return (ZIO_CHECKSUM_EQUAL(bi->blk_cksum, bo->blk_cksum));
+}
+
+/*
+ * The mirror of zfs_dedupe_bp_provably_equal(): decide, from the two L0 block
+ * pointers alone, whether the blocks provably hold *different* logical data,
+ * so the caller can report the ranges as differing without reading them.  This
+ * can only ever prove inequality; anything not provable is inconclusive and
+ * the caller must fall back to reading the data.
+ *
+ * A checksum covers the physical bytes, so unequal checksums prove only that
+ * the physical bytes differ.  Carrying that back to the logical data needs the
+ * block stored verbatim, hence the insistence on compression being off: two
+ * blocks holding identical data can perfectly well compress to different
+ * bytes, say after the compression property was changed, and zstd records only
+ * its algorithm in the BP, not its level.  Encrypted blocks are excluded for
+ * the same reason as in the equality test, to the opposite effect: per-block
+ * IVs give identical plaintext different ciphertext, so unequal checksums
+ * there would say nothing.  Holes and embedded blocks carry no comparable
+ * checksum at all.
+ *
+ * Unlike the equality test this does not need a dedup-grade checksum.  Even a
+ * weak one is deterministic, so equal data always gives equal checksums, and
+ * unequal checksums therefore always mean unequal data.
+ */
+static boolean_t
+zfs_dedupe_bp_provably_unequal(const blkptr_t *bi, const blkptr_t *bo)
+{
+	if (BP_IS_EMBEDDED(bi) || BP_IS_EMBEDDED(bo) ||
+	    BP_IS_HOLE(bi) || BP_IS_HOLE(bo) ||
+	    BP_IS_REDACTED(bi) || BP_IS_REDACTED(bo) ||
+	    BP_IS_ENCRYPTED(bi) || BP_IS_ENCRYPTED(bo))
+		return (B_FALSE);
+
+	if (BP_GET_COMPRESS(bi) != ZIO_COMPRESS_OFF ||
+	    BP_GET_COMPRESS(bo) != ZIO_COMPRESS_OFF)
+		return (B_FALSE);
+
+	if (BP_GET_CHECKSUM(bi) != BP_GET_CHECKSUM(bo) ||
+	    BP_GET_LSIZE(bi) != BP_GET_LSIZE(bo) ||
+	    BP_GET_BYTEORDER(bi) != BP_GET_BYTEORDER(bo))
+		return (B_FALSE);
+
+	return (!ZIO_CHECKSUM_EQUAL(bi->blk_cksum, bo->blk_cksum));
+}
+
+/*
+ * Compare [inoff, inoff + len) in inzp with [outoff, outoff + len) in outzp,
+ * setting *samep if the ranges are byte-for-byte equal.  Both files must be
+ * range locked by the caller.
+ *
+ * As a fast path, blocks are compared by their block-pointer checksums, which
+ * can settle a block either way without reading it: equal, when a strong
+ * checksum matches (zfs_dedupe_bp_provably_equal(), mirroring how ZFS dedup
+ * trusts checksums), or unequal, when checksums over verbatim-stored blocks
+ * differ (zfs_dedupe_bp_provably_unequal()).  Whatever neither can settle - a
+ * weak or mismatched checksum, encryption, a hole, compression, a dirty (not
+ * yet synced) block, etc. - falls back to reading and byte-comparing the data.
+ * Both tests only ever assert what the block pointers prove, so the result is
+ * identical to a full byte compare.
+ *
+ * A trailing block the range only partly covers is no different: the two files
+ * share a block size and both offsets are block aligned, so the tail occupies
+ * the same intra-block span in each, and equal whole-block checksums prove the
+ * whole blocks equal, hence any common prefix of them equal.  Only the bytes
+ * inside the range are ever compared.
+ *
+ * When the ranges match, *sharedp additionally reports whether every block
+ * pair already names the same storage (or is a pair of holes), in which case
+ * the clone step would only reinstall pointers that are already in place and
+ * the caller can skip it.
+ */
+static int
+zfs_dedupe_range_compare(znode_t *inzp, uint64_t inoff, znode_t *outzp,
+    uint64_t outoff, uint64_t len, boolean_t *samep, boolean_t *sharedp)
+{
+	objset_t	*inos = ZTOZSB(inzp)->z_os;
+	objset_t	*outos = ZTOZSB(outzp)->z_os;
+	uint_t		blksz = inzp->z_blksz;
+	blkptr_t	*bps_in = NULL, *bps_out = NULL;
+	size_t		maxblocks;
+	uint64_t	off = 0;
+	boolean_t	eq;
+	boolean_t	shared = B_TRUE;
+	int		error = 0;
+
+	*samep = B_FALSE;
+	*sharedp = B_FALSE;
+
+	/*
+	 * zfs_dedupe_range() has already rejected differing block sizes and
+	 * unaligned offsets, so the two files' blocks line up one to one.
+	 */
+	ASSERT3U(outzp->z_blksz, ==, blksz);
+	ASSERT0(inoff % blksz);
+	ASSERT0(outoff % blksz);
+
+	/*
+	 * Bound the block-pointer batch so the temporary arrays stay small and
+	 * each dmu_read_l0_bps() stays within DMU_MAX_ACCESS.
+	 */
+	maxblocks = MAX(1, MIN((uint64_t)16, (DMU_MAX_ACCESS >> 1) / blksz));
+	bps_in = kmem_alloc(sizeof (blkptr_t) * maxblocks, KM_SLEEP);
+	bps_out = kmem_alloc(sizeof (blkptr_t) * maxblocks, KM_SLEEP);
+
+	while (off < len) {
+		uint64_t span = MIN(len - off, (uint64_t)maxblocks * blksz);
+		size_t nin = maxblocks, nout = maxblocks;
+		int e1, e2;
+
+		if (issig()) {
+			error = SET_ERROR(EINTR);
+			goto out;
+		}
+
+		e1 = dmu_read_l0_bps(inos, inzp->z_id, inoff + off, span,
+		    bps_in, &nin);
+		e2 = dmu_read_l0_bps(outos, outzp->z_id, outoff + off, span,
+		    bps_out, &nout);
+
+		if (e1 != 0 || e2 != 0 || nin != nout) {
+			/*
+			 * A block created in the current txg (EAGAIN), or any
+			 * other reason we could not get stable BPs, just means
+			 * we compare this span by reading it; the data path is
+			 * always correct, including for dirty blocks.
+			 */
+			shared = B_FALSE;
+			error = zfs_dedupe_range_memcmp(inzp, inoff + off,
+			    outzp, outoff + off, span, &eq);
+			if (error != 0 || !eq)
+				goto out;
+			off += span;
+			continue;
+		}
+
+		for (size_t i = 0; i < nin; i++) {
+			uint64_t cmpoff = off + (uint64_t)i * blksz;
+			uint64_t cmplen = MIN((uint64_t)blksz, len - cmpoff);
+
+			if (zfs_dedupe_bp_same_block(&bps_in[i], &bps_out[i]))
+				continue;
+			shared = B_FALSE;
+
+			if (zfs_dedupe_bp_provably_equal(&bps_in[i],
+			    &bps_out[i]))
+				continue;
+
+			/*
+			 * Blocks that provably differ make the whole range
+			 * differ - but only when the range covers all of this
+			 * one.  Two differing blocks can still agree over the
+			 * part a trailing sub-block request covers.
+			 */
+			if (cmplen == blksz &&
+			    zfs_dedupe_bp_provably_unequal(&bps_in[i],
+			    &bps_out[i]))
+				goto out;
+
+			/*
+			 * Not provable from BPs: compare just this block, or
+			 * only the part of it the range covers.
+			 */
+			error = zfs_dedupe_range_memcmp(inzp, inoff + cmpoff,
+			    outzp, outoff + cmpoff, cmplen, &eq);
+			if (error != 0 || !eq)
+				goto out;
+		}
+
+		off += span;
+	}
+
+	*samep = B_TRUE;
+	*sharedp = shared;
+
+out:
+	kmem_free(bps_in, sizeof (blkptr_t) * maxblocks);
+	kmem_free(bps_out, sizeof (blkptr_t) * maxblocks);
+
+	return (error);
+}
+
+/*
+ * Deduplicate a range of outzp against inzp: if [inoff, inoff + *lenp) and
+ * [outoff, outoff + *lenp) hold identical data, clone the source blocks over
+ * the destination so the two ranges share storage.  Implements the Linux
+ * FIDEDUPERANGE ioctl on top of block cloning.
+ *
+ * The comparison and the clone are performed while holding a RL_READER range
+ * lock on inzp and a RL_WRITER range lock on outzp, so the blocks that get
+ * cloned are exactly the bytes that were compared.
+ *
+ * On return:
+ *   error != 0            - the request failed;
+ *   *samep == B_FALSE     - the ranges differ, nothing was deduped;
+ *   *samep == B_TRUE      - the ranges matched and *lenp holds the number of
+ *                           bytes deduped (0 if a shortened range aligned away
+ *                           to nothing).
+ *
+ * Both ranges must lie within their files.  A trailing partial block is
+ * aligned away when can_shorten is set, and rejected with EINVAL when it is
+ * not, so a dedupe can still cover less than the caller asked for.
+ */
+int
+zfs_dedupe_range(znode_t *inzp, uint64_t inoff, znode_t *outzp, uint64_t outoff,
+    uint64_t *lenp, cred_t *cr, boolean_t can_shorten, boolean_t *samep)
+{
+	zfsvfs_t	*inzfsvfs = ZTOZSB(inzp);
+	zfsvfs_t	*outzfsvfs = ZTOZSB(outzp);
+	zfs_locked_range_t *inlr = NULL, *outlr = NULL;
+	uint64_t	len = *lenp;
+	uint64_t	done = 0;
+	uint_t		inblksz;
+	boolean_t	shared = B_FALSE;
+	int		error;
+
+	*samep = B_FALSE;
+
+	error = zfs_enter_two(inzfsvfs, outzfsvfs, FTAG);
+	if (error != 0)
+		return (error);
+
+	error = zfs_clone_range_precheck(inzp, outzp);
+	if (error != 0)
+		goto out;
+
+	/*
+	 * Deduplicating nothing trivially succeeds.
+	 */
+	if (len == 0) {
+		*lenp = 0;
+		*samep = B_TRUE;
+		goto out;
+	}
+
+	/*
+	 * Unlike a clone, a dedupe request is not silently clamped to the
+	 * source EOF: the whole compared range must lie within the source.
+	 */
+	if (inoff >= inzp->z_size || len > inzp->z_size - inoff) {
+		error = SET_ERROR(EINVAL);
+		goto out;
+	}
+
+	/*
+	 * The destination range must lie within the destination too.  Trimming
+	 * it to the destination EOF would be invisible to the caller, because
+	 * the ioctl reports the length it was asked for rather than the one a
+	 * filesystem returns, so a shortened dedupe would be indistinguishable
+	 * from a complete one.  generic_remap_checks() rejects this for the
+	 * filesystems that use it; do the same here.
+	 */
+	if (outoff >= outzp->z_size || len > outzp->z_size - outoff) {
+		error = SET_ERROR(EINVAL);
+		goto out;
+	}
+
+	/*
+	 * Callers might not be able to detect properly that we are read-only,
+	 * so check it explicitly here.
+	 */
+	if (zfs_is_readonly(outzfsvfs)) {
+		error = SET_ERROR(EROFS);
+		goto out;
+	}
+
+	/*
+	 * A dedupe leaves the content as it was, but it still frees the
+	 * destination's blocks and replaces them with shared ones, so honor
+	 * immutable here the way every other data-writing path does.
+	 */
+	if ((outzp->z_pflags & ZFS_IMMUTABLE) != 0) {
+		error = SET_ERROR(EPERM);
+		goto out;
+	}
+
+	/*
+	 * No overlapping if we are deduping within the same file.
+	 */
+	if (inzp == outzp) {
+		if (inoff < outoff + len && outoff < inoff + len) {
+			error = SET_ERROR(EINVAL);
+			goto out;
+		}
+	}
+
+	/* Flush any mmap()'d data on both files before we compare it. */
+	if (zn_has_cached_data(inzp, inoff, inoff + len - 1))
+		zn_flush_cached_data(inzp, B_TRUE);
+	if (zn_has_cached_data(outzp, outoff, outoff + len - 1))
+		zn_flush_cached_data(outzp, B_TRUE);
+
+	/*
+	 * Maintain predictable lock order.
+	 */
+	if (inzp < outzp || (inzp == outzp && inoff < outoff)) {
+		inlr = zfs_rangelock_enter(&inzp->z_rangelock, inoff, len,
+		    RL_READER);
+		outlr = zfs_rangelock_enter(&outzp->z_rangelock, outoff, len,
+		    RL_WRITER);
+	} else {
+		outlr = zfs_rangelock_enter(&outzp->z_rangelock, outoff, len,
+		    RL_WRITER);
+		inlr = zfs_rangelock_enter(&inzp->z_rangelock, inoff, len,
+		    RL_READER);
+	}
+
+	/*
+	 * The clone step can only replace whole blocks of the destination with
+	 * whole blocks of the source, so the two files must agree on the block
+	 * size and both offsets must be block-aligned; those can never be
+	 * shortened away.  A trailing partial block is handled after the
+	 * comparison below.  Block sizes cannot change under us here: growing
+	 * one takes the whole-file rangelock, which our holds exclude.
+	 */
+	inblksz = inzp->z_blksz;
+	if (inblksz != outzp->z_blksz) {
+		error = SET_ERROR(EINVAL);
+		goto unlock;
+	}
+	if ((inoff % inblksz) != 0 || (outoff % inblksz) != 0) {
+		error = SET_ERROR(EINVAL);
+		goto unlock;
+	}
+	if ((len % inblksz) != 0 &&
+	    (len < inzp->z_size - inoff || len < outzp->z_size - outoff) &&
+	    !can_shorten) {
+		error = SET_ERROR(EINVAL);
+		goto unlock;
+	}
+
+	/*
+	 * Compare the whole requested range under the locks, before aligning
+	 * it down for the clone.  Comparing the full range is what makes a
+	 * differing trailing sub-block report DIFFERS rather than being
+	 * silently dropped by the alignment below (which, with a large
+	 * recordsize, can round the whole request away to nothing).
+	 */
+	error = zfs_dedupe_range_compare(inzp, inoff, outzp, outoff, len,
+	    samep, &shared);
+	if (error != 0 || !*samep)
+		goto unlock;
+
+	/*
+	 * The ranges are identical.  Align a trailing partial block away for
+	 * the clone step; the ranges still compared equal, so *samep stays
+	 * set even if this leaves nothing to share.
+	 */
+	if ((len % inblksz) != 0 &&
+	    (len < inzp->z_size - inoff || len < outzp->z_size - outoff))
+		len = P2ALIGN_TYPED(len, inblksz, uint64_t);
+	if (len == 0)
+		goto unlock;
+
+	/*
+	 * When every destination block already shares its source block (or
+	 * both are holes), the ranges were cloned or deduped before and the
+	 * clone would only reinstall the pointers the destination already
+	 * has - dirtying every block, restamping its logical birth (which
+	 * makes the next incremental send carry it again) and churning the
+	 * BRT for an end state that is already on disk.  Dedupe tools cannot
+	 * see ZFS-level sharing, so they will keep finding the same identical
+	 * files; make rededuping them free.
+	 */
+	if (shared) {
+		done = len;
+		goto unlock;
+	}
+
+	error = zfs_clone_range_locked(inzp, inoff, outzp, outoff, len, cr,
+	    outlr, B_TRUE, &done);
+
+unlock:
+	zfs_rangelock_exit(outlr);
+	zfs_rangelock_exit(inlr);
+
+	if (error == 0) {
+		if (done > 0) {
+			/*
+			 * No zil_commit() here: a dedupe logs nothing, so
+			 * there is no itx to wait for even with sync=always.
+			 */
+			ZFS_ACCESSTIME_STAMP(inzfsvfs, inzp);
+		}
+		*lenp = done;
+	}
+
+out:
 	zfs_exit_two(inzfsvfs, outzfsvfs, FTAG);
 
 	return (error);
@@ -2170,6 +2964,7 @@ EXPORT_SYMBOL(zfs_getsecattr);
 EXPORT_SYMBOL(zfs_setsecattr);
 EXPORT_SYMBOL(zfs_clone_range);
 EXPORT_SYMBOL(zfs_clone_range_replay);
+EXPORT_SYMBOL(zfs_dedupe_range);
 
 ZFS_MODULE_PARAM(zfs_vnops, zfs_vnops_, read_chunk_size, U64, ZMOD_RW,
 	"Bytes to read per chunk");

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -34,7 +34,18 @@ tags = ['functional', 'acl', 'posix-sa']
 [tests/functional/block_cloning:Linux]
 tests = ['block_cloning_ficlone', 'block_cloning_ficlonerange',
     'block_cloning_ficlonerange_partial', 'block_cloning_disabled_ficlone',
-    'block_cloning_disabled_ficlonerange']
+    'block_cloning_disabled_ficlonerange', 'block_cloning_fideduperange',
+    'block_cloning_fideduperange_blksz',
+    'block_cloning_fideduperange_compress',
+    'block_cloning_fideduperange_differs',
+    'block_cloning_fideduperange_eof',
+    'block_cloning_fideduperange_mtime',
+    'block_cloning_fideduperange_partial',
+    'block_cloning_fideduperange_replay',
+    'block_cloning_fideduperange_sparse',
+    'block_cloning_fideduperange_subblock',
+    'block_cloning_fideduperange_tail',
+    'block_cloning_disabled_fideduperange']
 tags = ['functional', 'block_cloning']
 
 [tests/functional/chattr:Linux]

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -3640,6 +3640,34 @@ function stat_size #<path>
 	esac
 }
 
+function stat_blksz #<path>
+{
+	typeset path=$1
+
+	case "$UNAME" in
+	FreeBSD)
+		stat -f %k "$path"
+		;;
+	*)
+		stat -c %o "$path"
+		;;
+	esac
+}
+
+function stat_blocks #<path>
+{
+	typeset path=$1
+
+	case "$UNAME" in
+	FreeBSD)
+		stat -f %b "$path"
+		;;
+	*)
+		stat -c %b "$path"
+		;;
+	esac
+}
+
 function stat_mtime #<path>
 {
 	typeset path=$1

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -533,9 +533,21 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/block_cloning/block_cloning_disabled_copyfilerange_clone.ksh \
 	functional/block_cloning/block_cloning_disabled_ficlone.ksh \
 	functional/block_cloning/block_cloning_disabled_ficlonerange.ksh \
+	functional/block_cloning/block_cloning_disabled_fideduperange.ksh \
 	functional/block_cloning/block_cloning_ficlone.ksh \
 	functional/block_cloning/block_cloning_ficlonerange.ksh \
 	functional/block_cloning/block_cloning_ficlonerange_partial.ksh \
+	functional/block_cloning/block_cloning_fideduperange.ksh \
+	functional/block_cloning/block_cloning_fideduperange_blksz.ksh \
+	functional/block_cloning/block_cloning_fideduperange_compress.ksh \
+	functional/block_cloning/block_cloning_fideduperange_differs.ksh \
+	functional/block_cloning/block_cloning_fideduperange_eof.ksh \
+	functional/block_cloning/block_cloning_fideduperange_mtime.ksh \
+	functional/block_cloning/block_cloning_fideduperange_partial.ksh \
+	functional/block_cloning/block_cloning_fideduperange_replay.ksh \
+	functional/block_cloning/block_cloning_fideduperange_sparse.ksh \
+	functional/block_cloning/block_cloning_fideduperange_subblock.ksh \
+	functional/block_cloning/block_cloning_fideduperange_tail.ksh \
 	functional/block_cloning/block_cloning_cross_enc_dataset.ksh \
 	functional/block_cloning/block_cloning_replay.ksh \
 	functional/block_cloning/block_cloning_replay_encrypted.ksh \

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_disabled_fideduperange.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_disabled_fideduperange.ksh
@@ -1,0 +1,52 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2026 by MorganaFuture. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/block_cloning/block_cloning.kshlib
+
+verify_runnable "global"
+
+claim="The FIDEDUPERANGE ioctl fails when block cloning is disabled."
+
+log_assert $claim
+
+function cleanup
+{
+	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+}
+
+log_onexit cleanup
+
+log_must zpool create -o feature@block_cloning=disabled $TESTPOOL $DISKS
+
+log_must dd if=/dev/urandom of=/$TESTPOOL/file1 bs=128K count=4
+log_must dd if=/$TESTPOOL/file1 of=/$TESTPOOL/file2 bs=128K count=4
+log_must sync_pool $TESTPOOL
+
+log_mustnot clonefile -d /$TESTPOOL/file1 /$TESTPOOL/file2 0 0 524288
+
+log_pass $claim

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_fideduperange.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_fideduperange.ksh
@@ -1,0 +1,64 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2026 by MorganaFuture. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/block_cloning/block_cloning.kshlib
+
+verify_runnable "global"
+
+claim="The FIDEDUPERANGE ioctl shares blocks between two identical files."
+
+log_assert $claim
+
+function cleanup
+{
+	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+}
+
+log_onexit cleanup
+
+log_must zpool create -o feature@block_cloning=enabled -O recordsize=128k $TESTPOOL $DISKS
+
+# Two independent copies of the same data: file2 gets its own blocks.
+log_must dd if=/dev/urandom of=/$TESTPOOL/file1 bs=128K count=4
+log_must dd if=/$TESTPOOL/file1 of=/$TESTPOOL/file2 bs=128K count=4
+log_must sync_pool $TESTPOOL
+
+# They are identical but not yet sharing any blocks.
+log_must have_same_content /$TESTPOOL/file1 /$TESTPOOL/file2
+typeset blocks=$(get_same_blocks $TESTPOOL file1 $TESTPOOL file2)
+log_must [ -z "$blocks" ]
+
+# Deduplicate the whole file; every block should now be shared.
+log_must clonefile -d /$TESTPOOL/file1 /$TESTPOOL/file2 0 0 524288
+log_must sync_pool $TESTPOOL
+
+log_must have_same_content /$TESTPOOL/file1 /$TESTPOOL/file2
+blocks=$(get_same_blocks $TESTPOOL file1 $TESTPOOL file2)
+log_must [ "$blocks" = "0 1 2 3" ]
+
+log_pass $claim

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_fideduperange_blksz.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_fideduperange_blksz.ksh
@@ -1,0 +1,84 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2026 by MorganaFuture. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/block_cloning/block_cloning.kshlib
+
+verify_runnable "global"
+
+claim="The FIDEDUPERANGE ioctl rejects files with differing block sizes."
+
+log_assert $claim
+
+function cleanup
+{
+	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+}
+
+log_onexit cleanup
+
+log_must zpool create -o feature@block_cloning=enabled $TESTPOOL $DISKS
+
+# Two files with identical content but different block sizes.  The clone step
+# can only replace whole destination blocks with whole source blocks, so such a
+# pair can never be deduped however equal its bytes are.
+log_must zfs set recordsize=128K $TESTPOOL
+log_must dd if=/dev/urandom of=/$TESTPOOL/file1 bs=128K count=4
+log_must zfs set recordsize=64K $TESTPOOL
+log_must dd if=/$TESTPOOL/file1 of=/$TESTPOOL/file2 bs=64K count=8
+log_must sync_pool $TESTPOOL
+
+# Confirm the setup really produced different block sizes, otherwise the test
+# would pass for the wrong reason.
+typeset inblksz=$(stat_blksz /$TESTPOOL/file1)
+typeset outblksz=$(stat_blksz /$TESTPOOL/file2)
+log_must [ "$inblksz" = "131072" ]
+log_must [ "$outblksz" = "65536" ]
+
+typeset digest=$(xxh128digest /$TESTPOOL/file2)
+
+# The request must be refused outright.  It must not be reported as merely
+# differing: the bytes are identical, it is the layout that cannot be deduped.
+# Assign without typeset so $? is the exit status of clonefile itself.
+typeset out
+typeset ret
+out=$(clonefile -d /$TESTPOOL/file1 /$TESTPOOL/file2 0 0 524288 2>&1)
+ret=$?
+log_note "clonefile exited $ret saying: $out"
+log_must [ $ret -ne 0 ]
+echo "$out" | grep -q "Invalid argument" || \
+    log_fail "expected EINVAL, got: $out"
+echo "$out" | grep -q "range differs" && \
+    log_fail "reported DIFFERS for identical bytes: $out"
+
+log_must sync_pool $TESTPOOL
+
+log_must [ "$digest" = "$(xxh128digest /$TESTPOOL/file2)" ]
+typeset blocks=$(get_same_blocks $TESTPOOL file1 $TESTPOOL file2)
+log_must [ -z "$blocks" ]
+
+log_pass $claim

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_fideduperange_compress.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_fideduperange_compress.ksh
@@ -1,0 +1,75 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2026 by MorganaFuture. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/block_cloning/block_cloning.kshlib
+
+verify_runnable "global"
+
+claim="FIDEDUPERANGE dedupes identical data stored with different compression."
+
+log_assert $claim
+
+function cleanup
+{
+	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+}
+
+log_onexit cleanup
+
+log_must zpool create -o feature@block_cloning=enabled -O recordsize=128k $TESTPOOL $DISKS
+
+# The same bytes written either side of a compression property change: file1
+# is stored verbatim, file2 compressed.  Their block pointers therefore differ
+# in compression, psize and checksum, while the data they hold is identical.
+# A block-pointer comparison must not conclude anything from that; only
+# reading the data can settle it, and it must settle it as equal.
+log_must zfs set compression=off $TESTPOOL
+log_must file_write -o create -f /$TESTPOOL/file1 -b 131072 -c 4 -d 1
+log_must zfs set compression=lz4 $TESTPOOL
+log_must file_write -o create -f /$TESTPOOL/file2 -b 131072 -c 4 -d 1
+log_must sync_pool $TESTPOOL
+
+# Confirm the setup: file2 must really be stored smaller, or the two files
+# would have identical block pointers and the test would prove nothing.
+typeset b1=$(stat_blocks /$TESTPOOL/file1)
+typeset b2=$(stat_blocks /$TESTPOOL/file2)
+log_note "allocated blocks: file1=$b1 file2=$b2"
+log_must [ "$b2" -lt "$b1" ]
+
+log_must have_same_content /$TESTPOOL/file1 /$TESTPOOL/file2
+log_must [ -z "$(get_same_blocks $TESTPOOL file1 $TESTPOOL file2)" ]
+
+# Identical data must dedupe, however differently it happens to be stored.
+log_must clonefile -d /$TESTPOOL/file1 /$TESTPOOL/file2 0 0 524288
+log_must sync_pool $TESTPOOL
+
+log_must have_same_content /$TESTPOOL/file1 /$TESTPOOL/file2
+typeset blocks=$(get_same_blocks $TESTPOOL file1 $TESTPOOL file2)
+log_must [ "$blocks" = "0 1 2 3" ]
+
+log_pass $claim

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_fideduperange_differs.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_fideduperange_differs.ksh
@@ -1,0 +1,69 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2026 by MorganaFuture. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/block_cloning/block_cloning.kshlib
+
+verify_runnable "global"
+
+claim="The FIDEDUPERANGE ioctl does not share blocks between differing files."
+
+log_assert $claim
+
+function cleanup
+{
+	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+}
+
+log_onexit cleanup
+
+log_must zpool create -o feature@block_cloning=enabled -O recordsize=128k $TESTPOOL $DISKS
+
+log_must dd if=/dev/urandom of=/$TESTPOOL/file1 bs=128K count=4
+log_must dd if=/dev/urandom of=/$TESTPOOL/file2 bs=128K count=4
+log_must sync_pool $TESTPOOL
+
+typeset digest=$(xxh128digest /$TESTPOOL/file2)
+
+# The ranges differ, so the ioctl must report DIFFERS specifically, not just
+# any failure, and change nothing.
+# Assign without typeset so $? is the exit status of clonefile itself.
+typeset out
+typeset ret
+out=$(clonefile -d /$TESTPOOL/file1 /$TESTPOOL/file2 0 0 524288 2>&1)
+ret=$?
+log_note "clonefile exited $ret saying: $out"
+log_must [ $ret -ne 0 ]
+echo "$out" | grep -q "range differs" || \
+    log_fail "expected DIFFERS, got: $out"
+log_must sync_pool $TESTPOOL
+
+log_must [ "$digest" = "$(xxh128digest /$TESTPOOL/file2)" ]
+typeset blocks=$(get_same_blocks $TESTPOOL file1 $TESTPOOL file2)
+log_must [ -z "$blocks" ]
+
+log_pass $claim

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_fideduperange_eof.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_fideduperange_eof.ksh
@@ -1,0 +1,81 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2026 by MorganaFuture. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/block_cloning/block_cloning.kshlib
+
+verify_runnable "global"
+
+claim="The FIDEDUPERANGE ioctl rejects a range running past the destination EOF."
+
+log_assert $claim
+
+function cleanup
+{
+	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+}
+
+log_onexit cleanup
+
+log_must zpool create -o feature@block_cloning=enabled -O recordsize=128k \
+    $TESTPOOL $DISKS
+
+# file2 holds the first three blocks of file1, so everything the request below
+# actually covers is identical.  That is what makes this test meaningful: were
+# the range trimmed to the destination EOF instead of refused, the trimmed part
+# would compare equal and the dedupe would report success.
+log_must dd if=/dev/urandom of=/$TESTPOOL/file1 bs=128K count=4
+log_must dd if=/$TESTPOOL/file1 of=/$TESTPOOL/file2 bs=128K count=3
+log_must sync_pool $TESTPOOL
+
+log_must [ "$(stat_size /$TESTPOOL/file1)" = "524288" ]
+log_must [ "$(stat_size /$TESTPOOL/file2)" = "393216" ]
+
+typeset digest=$(xxh128digest /$TESTPOOL/file2)
+
+# The source range ends exactly at file1's EOF, while the destination range
+# runs one block past file2's.  A shortened dedupe cannot be reported as such
+# (the ioctl hands back the length it was asked for), so the request has to
+# fail rather than share what happens to fit.
+# Assign without typeset so $? is the exit status of clonefile itself.
+typeset out
+typeset ret
+out=$(clonefile -d /$TESTPOOL/file1 /$TESTPOOL/file2 262144 262144 262144 2>&1)
+ret=$?
+log_note "clonefile exited $ret saying: $out"
+log_must [ $ret -ne 0 ]
+echo "$out" | grep -q "Invalid argument" || \
+    log_fail "expected EINVAL, got: $out"
+echo "$out" | grep -q "range differs" && \
+    log_fail "reported DIFFERS for identical bytes: $out"
+
+log_must sync_pool $TESTPOOL
+
+log_must [ "$digest" = "$(xxh128digest /$TESTPOOL/file2)" ]
+log_must [ -z "$(get_same_blocks $TESTPOOL file1 $TESTPOOL file2)" ]
+
+log_pass $claim

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_fideduperange_mtime.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_fideduperange_mtime.ksh
@@ -1,0 +1,70 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2026 by MorganaFuture. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/block_cloning/block_cloning.kshlib
+
+verify_runnable "global"
+
+claim="FIDEDUPERANGE leaves the destination's mtime and ctime unchanged."
+
+log_assert $claim
+
+function cleanup
+{
+	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+}
+
+log_onexit cleanup
+
+log_must zpool create -o feature@block_cloning=enabled -O recordsize=128k $TESTPOOL $DISKS
+
+log_must dd if=/dev/urandom of=/$TESTPOOL/file1 bs=128K count=4
+log_must dd if=/$TESTPOOL/file1 of=/$TESTPOOL/file2 bs=128K count=4
+log_must sync_pool $TESTPOOL
+
+typeset mtime0=$(stat_mtime /$TESTPOOL/file2)
+typeset ctime0=$(stat_ctime /$TESTPOOL/file2)
+
+# Sleep so that, were the timestamps updated, they would move to a later
+# second and the comparison below would notice.
+sleep 2
+
+# Unlike a copy, a dedupe does not change the file content, so per the Linux
+# REMAP_FILE_DEDUP convention it must not update mtime/ctime.
+log_must clonefile -d /$TESTPOOL/file1 /$TESTPOOL/file2 0 0 524288
+log_must sync_pool $TESTPOOL
+
+typeset blocks=$(get_same_blocks $TESTPOOL file1 $TESTPOOL file2)
+log_must [ "$blocks" = "0 1 2 3" ]
+
+typeset mtime1=$(stat_mtime /$TESTPOOL/file2)
+typeset ctime1=$(stat_ctime /$TESTPOOL/file2)
+log_must [ "$mtime0" = "$mtime1" ]
+log_must [ "$ctime0" = "$ctime1" ]
+
+log_pass $claim

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_fideduperange_partial.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_fideduperange_partial.ksh
@@ -1,0 +1,60 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2026 by MorganaFuture. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/block_cloning/block_cloning.kshlib
+
+verify_runnable "global"
+
+claim="The FIDEDUPERANGE ioctl shares only the requested matching range."
+
+log_assert $claim
+
+function cleanup
+{
+	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+}
+
+log_onexit cleanup
+
+log_must zpool create -o feature@block_cloning=enabled -O recordsize=128k $TESTPOOL $DISKS
+
+# file2 is a copy of file1 with a different first block; only block 1
+# (offset 131072) is identical between the two files.
+log_must dd if=/dev/urandom of=/$TESTPOOL/file1 bs=128K count=4
+log_must dd if=/$TESTPOOL/file1 of=/$TESTPOOL/file2 bs=128K count=4
+log_must dd if=/dev/urandom of=/$TESTPOOL/file2 bs=128K count=1 conv=notrunc
+log_must sync_pool $TESTPOOL
+
+# Deduplicate just the matching block.
+log_must clonefile -d /$TESTPOOL/file1 /$TESTPOOL/file2 131072 131072 131072
+log_must sync_pool $TESTPOOL
+
+typeset blocks=$(get_same_blocks $TESTPOOL file1 $TESTPOOL file2)
+log_must [ "$blocks" = "1" ]
+
+log_pass $claim

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_fideduperange_replay.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_fideduperange_replay.ksh
@@ -1,0 +1,105 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2026 by MorganaFuture. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/block_cloning/block_cloning.kshlib
+
+#
+# DESCRIPTION:
+#	A FIDEDUPERANGE is not logged to the ZIL, so a crash before the txg
+#	syncs loses only the block sharing.  In particular replaying the log
+#	must not restamp the deduped file's timestamps.
+#
+# STRATEGY:
+#	1. Create a file system with a slog and two identical files
+#	2. Freeze the pool
+#	3. Dedupe one file against the other
+#	4. Unmount and export, then import to replay the intent log
+#	5. The content and the timestamps must be exactly as they were
+#
+
+verify_runnable "global"
+
+export VDIR=$TEST_BASE_DIR/disk-fidedupe
+export VDEV="$VDIR/a $VDIR/b $VDIR/c"
+export LDEV="$VDIR/e $VDIR/f"
+log_must rm -rf $VDIR
+log_must mkdir -p $VDIR
+log_must truncate -s $MINVDEVSIZE $VDEV $LDEV
+
+claim="A deduped file's timestamps survive an intent log replay."
+
+log_assert $claim
+
+function cleanup
+{
+	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+	rm -rf $TESTDIR $VDIR
+}
+
+log_onexit cleanup
+
+log_must zpool create -o feature@block_cloning=enabled $TESTPOOL $VDEV \
+    log mirror $LDEV
+log_must zfs create -o recordsize=128k $TESTPOOL/$TESTFS
+
+log_must dd if=/dev/urandom of=/$TESTPOOL/$TESTFS/file1 \
+    oflag=sync bs=128K count=4
+log_must dd if=/$TESTPOOL/$TESTFS/file1 of=/$TESTPOOL/$TESTFS/file2 \
+    oflag=sync bs=128K count=4
+sync_pool $TESTPOOL
+
+typeset digest=$(xxh128digest /$TESTPOOL/$TESTFS/file2)
+typeset mtime=$(stat_mtime /$TESTPOOL/$TESTFS/file2)
+typeset ctime=$(stat_ctime /$TESTPOOL/$TESTFS/file2)
+
+# Checkpoint for ZIL replay.
+log_must zpool freeze $TESTPOOL
+
+log_must clonefile -d /$TESTPOOL/$TESTFS/file1 /$TESTPOOL/$TESTFS/file2 \
+    0 0 524288
+
+log_must zfs unmount /$TESTPOOL/$TESTFS
+
+# The dedupe must have left nothing behind to replay.
+log_note "Verify transactions to replay:"
+log_must zdb -iv $TESTPOOL/$TESTFS
+zdb -iv $TESTPOOL/$TESTFS 2>&1 | grep -q "TX_CLONE_RANGE" && \
+    log_fail "dedupe logged a TX_CLONE_RANGE record"
+
+log_must zpool export $TESTPOOL
+
+# Import to unfreeze and replay the log.  It has to be `zpool import -f`
+# because we can't write a frozen pool's labels.
+log_must zpool import -f -d $VDIR $TESTPOOL
+
+# Nothing the dedupe did may show through: same bytes, same times.
+log_must [ "$digest" = "$(xxh128digest /$TESTPOOL/$TESTFS/file2)" ]
+log_must [ "$mtime" = "$(stat_mtime /$TESTPOOL/$TESTFS/file2)" ]
+log_must [ "$ctime" = "$(stat_ctime /$TESTPOOL/$TESTFS/file2)" ]
+
+log_pass $claim

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_fideduperange_sparse.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_fideduperange_sparse.ksh
@@ -1,0 +1,75 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2026 by MorganaFuture. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/block_cloning/block_cloning.kshlib
+
+verify_runnable "global"
+
+claim="FIDEDUPERANGE compares the grown tail of a truncated file correctly."
+
+log_assert $claim
+
+function cleanup
+{
+	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+}
+
+log_onexit cleanup
+
+log_must zpool create -o feature@block_cloning=enabled -O recordsize=128k $TESTPOOL $DISKS
+
+# Two files written small and then truncated well out.  The truncate grows the
+# block, so almost all of what gets compared is tail that was never written by
+# anyone: the file's own bytes end at 1000 and the rest of the block reads back
+# as zeros.  Both files are built the same way, so they must compare equal.
+log_must file_write -o create -f /$TESTPOOL/file1 -b 1000 -c 1 -d 0
+log_must file_write -o create -f /$TESTPOOL/file2 -b 1000 -c 1 -d 0
+log_must truncate -s 65536 /$TESTPOOL/file1
+log_must truncate -s 65536 /$TESTPOOL/file2
+log_must sync_pool $TESTPOOL
+
+typeset blksz=$(stat_blksz /$TESTPOOL/file1)
+log_note "block size: $blksz, size: $(stat_size /$TESTPOOL/file1)"
+
+# Both tails are zeros, so the two files are identical and must dedupe.
+log_must have_same_content /$TESTPOOL/file1 /$TESTPOOL/file2
+log_must clonefile -d /$TESTPOOL/file1 /$TESTPOOL/file2 0 0 $blksz
+log_must sync_pool $TESTPOOL
+log_must have_same_content /$TESTPOOL/file1 /$TESTPOOL/file2
+
+# Now make the tails differ, and the same request must report DIFFERS.
+log_must dd if=/dev/urandom of=/$TESTPOOL/file2 bs=1 count=16 seek=2000 \
+    conv=notrunc
+log_must sync_pool $TESTPOOL
+
+typeset digest=$(xxh128digest /$TESTPOOL/file2)
+log_mustnot clonefile -d /$TESTPOOL/file1 /$TESTPOOL/file2 0 0 $blksz
+log_must sync_pool $TESTPOOL
+log_must [ "$digest" = "$(xxh128digest /$TESTPOOL/file2)" ]
+
+log_pass $claim

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_fideduperange_subblock.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_fideduperange_subblock.ksh
@@ -1,0 +1,74 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2026 by MorganaFuture. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/block_cloning/block_cloning.kshlib
+
+verify_runnable "global"
+
+claim="FIDEDUPERANGE compares the whole range, so a differing sub-block reports DIFFERS."
+
+log_assert $claim
+
+function cleanup
+{
+	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+}
+
+log_onexit cleanup
+
+log_must zpool create -o feature@block_cloning=enabled -O recordsize=128k $TESTPOOL $DISKS
+
+# Two single-block (128K) files that differ only in their first 4K.  A dedupe
+# request shorter than the record size is rounded down to nothing by block
+# alignment; the ioctl must still compare the requested bytes and report the
+# ranges as differing rather than silently claiming they are the same.
+log_must dd if=/dev/urandom of=/$TESTPOOL/file1 bs=128K count=1
+log_must dd if=/$TESTPOOL/file1 of=/$TESTPOOL/file2 bs=128K count=1
+log_must dd if=/dev/urandom of=/$TESTPOOL/file2 bs=4K count=1 conv=notrunc
+log_must sync_pool $TESTPOOL
+
+typeset digest=$(xxh128digest /$TESTPOOL/file2)
+
+# The first 4K differ, so the ioctl must report DIFFERS specifically, not
+# just any failure, and share nothing.
+# Assign without typeset so $? is the exit status of clonefile itself.
+typeset out
+typeset ret
+out=$(clonefile -d /$TESTPOOL/file1 /$TESTPOOL/file2 0 0 4096 2>&1)
+ret=$?
+log_note "clonefile exited $ret saying: $out"
+log_must [ $ret -ne 0 ]
+echo "$out" | grep -q "range differs" || \
+    log_fail "expected DIFFERS, got: $out"
+log_must sync_pool $TESTPOOL
+
+log_must [ "$digest" = "$(xxh128digest /$TESTPOOL/file2)" ]
+typeset blocks=$(get_same_blocks $TESTPOOL file1 $TESTPOOL file2)
+log_must [ -z "$blocks" ]
+
+log_pass $claim

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_fideduperange_tail.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_fideduperange_tail.ksh
@@ -1,0 +1,72 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2026 by MorganaFuture. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/block_cloning/block_cloning.kshlib
+
+verify_runnable "global"
+
+claim="FIDEDUPERANGE compares only the bytes the range covers in a trailing block."
+
+log_assert $claim
+
+function cleanup
+{
+	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+}
+
+log_onexit cleanup
+
+log_must zpool create -o feature@block_cloning=enabled -O recordsize=128k $TESTPOOL $DISKS
+
+# Two 256K (2 x 128K block) files that agree over the first 132K and differ
+# from 132K on.  A 132K dedupe request covers all of block 0 and only the
+# first 4K of block 1, so the bytes it covers are identical even though the
+# two block 1s are not: it must report the ranges as the same.  Comparing any
+# byte past the requested 132K would wrongly report DIFFERS.
+log_must dd if=/dev/urandom of=/$TESTPOOL/file1 bs=128K count=2
+log_must dd if=/$TESTPOOL/file1 of=/$TESTPOOL/file2 bs=128K count=2
+log_must dd if=/dev/urandom of=/$TESTPOOL/file2 bs=4K count=31 seek=33 \
+    conv=notrunc
+log_must sync_pool $TESTPOOL
+
+log_must [ -z "$(get_same_blocks $TESTPOOL file1 $TESTPOOL file2)" ]
+
+# The covered bytes match, so the dedupe succeeds.  Only whole blocks can be
+# shared, so the request is aligned down to block 0; block 1 keeps its own
+# (differing) content.
+log_must clonefile -d /$TESTPOOL/file1 /$TESTPOOL/file2 0 0 135168
+log_must sync_pool $TESTPOOL
+
+typeset blocks=$(get_same_blocks $TESTPOOL file1 $TESTPOOL file2)
+log_must [ "$blocks" = "0" ]
+
+# The dedupe must not have disturbed the part of file2 outside the range.
+log_must cmp -n 135168 /$TESTPOOL/file1 /$TESTPOOL/file2
+log_mustnot cmp -s /$TESTPOOL/file1 /$TESTPOOL/file2
+
+log_pass $claim


### PR DESCRIPTION
### Motivation and Context

Closes #11065.

Linux's `FIDEDUPERANGE` ioctl lets out-of-band dedupe tools (e.g. `duperemove`,
`bees`) ask the filesystem to share byte-identical file ranges. On ZFS the ioctl
returned `EOPNOTSUPP`. This implements it on top of block cloning (BRT), so
matching ranges share storage without the memory cost of the dedup table.

### Description

- Split `zfs_clone_range()` into a `zfs_clone_range_precheck()` and a
  `zfs_clone_range_locked()` helper so the dedupe path can reuse the locked
  clone loop.
- Add `zfs_dedupe_range()`: it compares `[inoff, inoff+len)` and
  `[outoff, outoff+len)` and, only if they are byte-for-byte identical, clones
  the source blocks over the destination, all under a single
  `RL_READER`/`RL_WRITER` rangelock hold, so the bytes that get cloned are
  exactly the bytes that were compared. Source and destination must share a
  block size, which the clone step requires anyway.
- The comparison settles a block from its block pointers when it can: equal
  strong checksums prove it identical, and, for verbatim-stored blocks, unequal
  checksums prove it different. Only what the pointers cannot settle is read,
  and the read compares the dbufs in place rather than copying them out.
- Wire `zpl_file_range.c`: the `remap_file_range(REMAP_FILE_DEDUP)` path (>=4.20)
  and the pre-4.20 `dedupe_file_range` fop. `-EBADE` maps to
  `FILE_DEDUPE_RANGE_DIFFERS`; `REMAP_FILE_CAN_SHORTEN` is honored. Both remap
  paths take the two inode locks in address order so opposite-direction dedupes
  can't deadlock.
- A dedupe leaves the destination content unchanged, so it does not update
  mtime/ctime, strip setid bits, or write back any other attribute, and it is
  not logged to the ZIL: losing it to a crash costs only the sharing, which is
  all the ioctl promises, and avoids restamping timestamps on replay.
- The full requested range is compared before it is aligned down to a block
  boundary, so a differing trailing sub-block reports `DIFFERS` rather than
  being silently rounded away and reported identical.

### How Has This Been Tested?

`block_cloning` ZTS cases covering whole-file dedupe, differing files, partial
and sub-block requests, the feature-disabled path, mtime/ctime staying put, a
trailing block only partly covered by the range, mismatched block sizes,
identical data stored with different compression, a truncated file's grown
tail, and an intent-log replay of a dedupe.

Ran the `block_cloning` group on Linux (Ubuntu, aarch64, `--enable-debug`): all
pass and the existing clone tests are unaffected. Each commit builds and passes
the group on its own. BRT sharing was confirmed via `get_same_blocks`.

### Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)

### Checklist:
- [x] My code follows the OpenZFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **contributing** document.
- [x] I have added tests to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
