### PR TITLE
ZIL: Store aligned full-block sync writes indirectly

### DIFF
--- a/include/sys/zil.h
+++ b/include/sys/zil.h
@@ -660,8 +660,9 @@ extern void	zil_set_logbias(zilog_t *zilog, uint64_t slogval);
 
 extern uint64_t	zil_max_copied_data(zilog_t *zilog);
 extern uint64_t	zil_max_log_data(zilog_t *zilog, size_t hdrsize);
-extern itx_wr_state_t zil_write_state(zilog_t *zilog, uint64_t size,
-    uint32_t blocksize, boolean_t o_direct, boolean_t commit);
+extern itx_wr_state_t zil_write_state(zilog_t *zilog, uint64_t offset,
+    uint64_t size, uint32_t blocksize, boolean_t blk_fixed,
+    boolean_t o_direct, boolean_t commit);
 
 extern void zil_sums_init(zil_sums_t *zs);
 extern void zil_sums_fini(zil_sums_t *zs);

--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -1897,6 +1897,9 @@ Largest write size to store the data directly into the ZIL if
 .Sy logbias Ns = Ns Sy latency .
 Larger writes may be written indirectly similar to
 .Sy logbias Ns = Ns Sy throughput .
+Writes that exactly cover one or more aligned blocks whose size cannot change
+are always written indirectly regardless of this threshold, since they can be
+written to the pool only once and never inflate a later rewrite.
 In presence of SLOG this parameter is ignored, as if it was set to infinity,
 storing all written data into ZIL to not depend on regular vdev latency.
 .

--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -1898,10 +1898,25 @@ Largest write size to store the data directly into the ZIL if
 Larger writes may be written indirectly similar to
 .Sy logbias Ns = Ns Sy throughput .
 Writes that exactly cover one or more aligned blocks whose size cannot change
-are always written indirectly regardless of this threshold, since they can be
-written to the pool only once and never inflate a later rewrite.
+may instead be written indirectly below this threshold; see
+.Sy zvol_immediate_write_sz .
 In presence of SLOG this parameter is ignored, as if it was set to infinity,
 storing all written data into ZIL to not depend on regular vdev latency.
+.
+.It Sy zvol_immediate_write_sz Ns = Ns Sy 0 Ns B Pq uint
+For fixed-block (zvol) datasets, the smallest block size for which a
+synchronous write that exactly covers one or more aligned blocks is written
+indirectly instead of being copied into the ZIL, even when it is smaller than
+.Sy zfs_immediate_write_sz .
+Such a write can be stored indirectly safely, since the block reaches the pool
+only once and a later rewrite cannot inflate it, avoiding the double write for
+small-block volumes with
+.Sy sync Ns = Ns Sy always .
+The default of
+.Sy 0
+disables this, leaving such writes to be copied into the ZIL; as with
+.Sy zfs_immediate_write_sz ,
+a dedicated SLOG also keeps the data in the ZIL.
 .
 .It Sy zil_special_is_slog Ns = Ns Sy 1 Ns | Ns 0 Pq int
 When enabled, and written blocks go to normal vdevs, treat present special

--- a/module/zfs/zfs_log.c
+++ b/module/zfs/zfs_log.c
@@ -624,8 +624,8 @@ zfs_log_write(zilog_t *zilog, dmu_tx_t *tx, int txtype,
 		return;
 	}
 
-	write_state = zil_write_state(zilog, resid, blocksize, o_direct,
-	    commit);
+	write_state = zil_write_state(zilog, off, resid, blocksize, B_FALSE,
+	    o_direct, commit);
 
 	(void) sa_lookup(zp->z_sa_hdl, SA_ZPL_GEN(ZTOZSB(zp)), &gen,
 	    sizeof (gen));

--- a/module/zfs/zil.c
+++ b/module/zfs/zil.c
@@ -2191,6 +2191,20 @@ static uint_t zil_maxcopied = 7680;
 uint_t zfs_immediate_write_sz = 32768;
 
 /*
+ * Minimum fixed (zvol) block size for which a synchronous write that exactly
+ * covers whole aligned blocks is stored indirectly (WR_INDIRECT) rather than
+ * copied into the ZIL, even when it is smaller than zfs_immediate_write_sz.
+ * Such a write is always safe to store indirectly -- dmu_sync() does no
+ * read-modify-write, the block is not rewritten at TXG commit, and a later
+ * rewrite of the same full block cannot inflate it -- so this halves the data
+ * written for small-volblocksize volumes with sync=always.  The trade-off is a
+ * loss of ZIL aggregation: at low queue depth each block becomes a separate
+ * synchronous pool write, which can raise commit latency and IOPS.  0 disables
+ * the promotion, leaving such writes to be copied into the ZIL as before.
+ */
+uint_t zvol_immediate_write_sz = 0;
+
+/*
  * When enabled and blocks go to normal vdev, treat special vdevs as SLOG,
  * writing data to ZIL (WR_COPIED/WR_NEED_COPY).  Disabling this forces the
  * indirect writes (WR_INDIRECT) to preserve special vdev throughput and
@@ -2226,8 +2240,14 @@ zil_write_state(zilog_t *zilog, uint64_t offset, uint64_t size,
 	 * the ZIL instead (WR_COPIED) would write the data twice, once into
 	 * the log and again at commit.  This is the zvol write amplification
 	 * case: a full-block sync write to a small-volblocksize volume.
+	 *
+	 * Because storing it indirectly trades ZIL aggregation for that saving
+	 * (see zvol_immediate_write_sz), the promotion is gated on the fixed
+	 * block being at least zvol_immediate_write_sz; a value of 0 disables
+	 * it entirely.
 	 */
-	boolean_t full_block = (blk_fixed && size >= blocksize &&
+	boolean_t full_block = (blk_fixed && zvol_immediate_write_sz != 0 &&
+	    blocksize >= zvol_immediate_write_sz && size >= blocksize &&
 	    P2PHASE(offset, blocksize) == 0 && P2PHASE(size, blocksize) == 0);
 
 	/*
@@ -4916,6 +4936,9 @@ ZFS_MODULE_PARAM(zfs_zil, zil_, maxcopied, UINT, ZMOD_RW,
 
 ZFS_MODULE_PARAM(zfs, zfs_, immediate_write_sz, UINT, ZMOD_RW,
 	"Largest write size to store data into ZIL");
+
+ZFS_MODULE_PARAM(zfs_vol, zvol_, immediate_write_sz, UINT, ZMOD_RW,
+	"Min fixed block size stored indirectly instead of ZIL (0=off)");
 
 ZFS_MODULE_PARAM(zfs_zil, zil_, special_is_slog, INT, ZMOD_RW,
 	"Treat special vdevs as SLOG");

--- a/module/zfs/zil.c
+++ b/module/zfs/zil.c
@@ -2210,11 +2210,25 @@ zil_max_copied_data(zilog_t *zilog)
  * pool configuration, data placement, write size, and logbias settings.
  */
 itx_wr_state_t
-zil_write_state(zilog_t *zilog, uint64_t size, uint32_t blocksize,
-    boolean_t o_direct, boolean_t commit)
+zil_write_state(zilog_t *zilog, uint64_t offset, uint64_t size,
+    uint32_t blocksize, boolean_t blk_fixed, boolean_t o_direct,
+    boolean_t commit)
 {
 	if (zilog->zl_logbias == ZFS_LOGBIAS_THROUGHPUT || o_direct)
 		return (WR_INDIRECT);
+
+	/*
+	 * A write that exactly covers one or more aligned blocks whose size
+	 * can no longer change is always safe to store indirectly, even when
+	 * it is smaller than zfs_immediate_write_sz: dmu_sync() performs no
+	 * read-modify-write, the block is not rewritten at TXG commit, and a
+	 * later rewrite of the same block cannot inflate it.  Storing it in
+	 * the ZIL instead (WR_COPIED) would write the data twice, once into
+	 * the log and again at commit.  This is the zvol write amplification
+	 * case: a full-block sync write to a small-volblocksize volume.
+	 */
+	boolean_t full_block = (blk_fixed && size >= blocksize &&
+	    P2PHASE(offset, blocksize) == 0 && P2PHASE(size, blocksize) == 0);
 
 	/*
 	 * Don't use indirect for too small writes to reduce overhead.
@@ -2224,7 +2238,7 @@ zil_write_state(zilog_t *zilog, uint64_t size, uint32_t blocksize,
 	 * is not planned, then next writes might coalesce, and so the
 	 * indirect may be perfect.
 	 */
-	boolean_t indirect = (size >= zfs_immediate_write_sz &&
+	boolean_t indirect = full_block || (size >= zfs_immediate_write_sz &&
 	    (size >= blocksize / 2 || !commit));
 
 	if (spa_has_slogs(zilog->zl_spa)) {

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -950,7 +950,8 @@ zvol_log_write(zvol_state_t *zv, dmu_tx_t *tx, uint64_t offset,
 	if (zil_replaying(zilog, tx))
 		return;
 
-	write_state = zil_write_state(zilog, size, blocksize, B_FALSE, commit);
+	write_state = zil_write_state(zilog, offset, size, blocksize, B_TRUE,
+	    B_FALSE, commit);
 
 	while (size) {
 		itx_t *itx;

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -1172,8 +1172,9 @@ tests = ['zvol_cli_001_pos', 'zvol_cli_002_pos', 'zvol_cli_003_neg']
 tags = ['functional', 'zvol', 'zvol_cli']
 
 [tests/functional/zvol/zvol_misc]
-tests = ['zvol_misc_002_pos', 'zvol_misc_hierarchy', 'zvol_misc_rename_inuse',
-    'zvol_misc_snapdev', 'zvol_misc_trim', 'zvol_misc_volmode', 'zvol_misc_zil']
+tests = ['zvol_misc_002_pos', 'zvol_misc_fullblock', 'zvol_misc_hierarchy',
+    'zvol_misc_rename_inuse', 'zvol_misc_snapdev', 'zvol_misc_trim',
+    'zvol_misc_volmode', 'zvol_misc_zil']
 tags = ['functional', 'zvol', 'zvol_misc']
 
 [tests/functional/zvol/zvol_stress]

--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -279,6 +279,7 @@ if sys.platform.startswith('freebsd'):
         'pool_checkpoint/checkpoint_indirect': ['FAIL', 12623],
         'resilver/resilver_restart_001': ['FAIL', known_reason],
         'zvol/zvol_misc/zvol_misc_volmode': ['FAIL', 16668],
+        'zvol/zvol_misc/zvol_misc_fullblock': ['SKIP', na_reason],
         'bclone/bclone_crossfs_corner_cases': ['SKIP', cfr_cross_reason],
         'bclone/bclone_crossfs_corner_cases_limited':
             ['SKIP', cfr_cross_reason],

--- a/tests/zfs-tests/include/tunables.cfg
+++ b/tests/zfs-tests/include/tunables.cfg
@@ -108,6 +108,7 @@ VDEV_MAX_AUTO_ASHIFT		vdev.max_auto_ashift		zfs_vdev_max_auto_ashift
 VDEV_MIN_MS_COUNT		vdev.min_ms_count		zfs_vdev_min_ms_count
 VDEV_DIRECT_WR_VERIFY		vdev.direct_write_verify	zfs_vdev_direct_write_verify
 VDEV_VALIDATE_SKIP		vdev.validate_skip		vdev_validate_skip
+VOL_IMMEDIATE_WRITE_SZ		vol.immediate_write_sz		zvol_immediate_write_sz
 VOL_INHIBIT_DEV			vol.inhibit_dev			zvol_inhibit_dev
 VOL_MODE			vol.mode			zvol_volmode
 VOL_RECURSIVE			vol.recursive			UNSUPPORTED

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -2448,6 +2448,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/zvol/zvol_misc/zvol_misc_005_neg.ksh \
 	functional/zvol/zvol_misc/zvol_misc_006_pos.ksh \
 	functional/zvol/zvol_misc/zvol_misc_fua.ksh \
+	functional/zvol/zvol_misc/zvol_misc_fullblock.ksh \
 	functional/zvol/zvol_misc/zvol_misc_hierarchy.ksh \
 	functional/zvol/zvol_misc/zvol_misc_rename_inuse.ksh \
 	functional/zvol/zvol_misc/zvol_misc_snapdev.ksh \

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_fullblock.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_fullblock.ksh
@@ -73,6 +73,7 @@ function cleanup
 	fi
 	poolexists $rpool && destroy_pool $rpool
 	rm -f "$slog" "$rvdev"
+	restore_tunable VOL_IMMEDIATE_WRITE_SZ
 	block_device_wait
 }
 
@@ -85,12 +86,31 @@ function indirect_count
 log_assert "Full aligned block sync writes to a ZVOL are stored indirectly"
 log_onexit cleanup
 
+save_tunable VOL_IMMEDIATE_WRITE_SZ
+
 log_must zfs create -V $VOLSIZE -b $VOLBS -o sync=always \
     -o compression=off -o volmode=dev $ZVOL
 block_device_wait $ZDEV
 
-# 1. Full aligned block sync writes: expect indirect writes.
+# 0. With the promotion disabled (the default), full block sync writes must be
+#    copied into the ZIL, not stored indirectly.
+log_must set_tunable64 VOL_IMMEDIATE_WRITE_SZ 0
 typeset before=$(indirect_count)
+log_must dd if=/dev/urandom of=$ZDEV bs=$VOLBS count=$COUNT \
+    oflag=direct conv=fdatasync
+typeset after=$(indirect_count)
+typeset delta=$((after - before))
+log_note "promotion off: indirect_count delta=$delta (expected 0)"
+if [[ $delta -ne 0 ]] ; then
+	log_fail "Full block writes used indirect with the promotion disabled " \
+	    "($delta != 0)"
+fi
+
+# Enable the promotion (minimum block size = volblocksize) for the rest.
+log_must set_tunable64 VOL_IMMEDIATE_WRITE_SZ $VOLBS
+
+# 1. Full aligned block sync writes: expect indirect writes.
+before=$(indirect_count)
 log_must dd if=/dev/urandom of=$ZDEV bs=$VOLBS count=$COUNT \
     oflag=direct conv=fdatasync
 typeset after=$(indirect_count)

--- a/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_fullblock.ksh
+++ b/tests/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_fullblock.ksh
@@ -1,0 +1,165 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2026 by MorganaFuture. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/include/kstat.shlib
+. $STF_SUITE/tests/functional/zvol/zvol_common.shlib
+
+#
+# DESCRIPTION:
+#	A synchronous write that exactly covers an aligned volblocksize block
+#	is stored indirectly (WR_INDIRECT), so the data reaches the pool only
+#	once instead of being written to the ZIL and again at TXG commit.
+#	This avoids the ZVOL write amplification reported in #17677.
+#
+# STRATEGY:
+#	1. Create a small-volblocksize ZVOL with sync=always and no SLOG.
+#	2. Full aligned block sync writes must increase zil_itx_indirect_count.
+#	3. Sub-block (partial) sync writes must NOT use indirect.
+#	4. Indirectly logged full-block writes must survive ZIL replay with
+#	   identical data (freeze, write, export, import).
+#	5. With a dedicated SLOG, even full block writes must NOT use indirect
+#	   (the SLOG latency optimization must be preserved).
+#
+
+verify_runnable "global"
+
+if ! is_linux ; then
+	log_unsupported "Requires dd oflag=direct for aligned full-block writes"
+fi
+
+typeset VOLBS=16384
+typeset COUNT=64
+typeset ZVOL="$TESTPOOL/vol"
+typeset ZDEV="$ZVOL_DEVDIR/$ZVOL"
+typeset slog="$(mktemp -p $TEST_BASE_DIR zvol_misc_fullblock_slog.XXXXXX)"
+
+# A separate pool is frozen for the replay check so it cannot disturb
+# $TESTPOOL, which is shared with the rest of the zvol_misc group.
+typeset rpool="${TESTPOOL}_replay"
+typeset rvol="$rpool/vol"
+typeset rdev="$ZVOL_DEVDIR/$rvol"
+typeset rvdev="$(mktemp -p $TEST_BASE_DIR zvol_misc_fullblock_vdev.XXXXXX)"
+
+function cleanup
+{
+	datasetexists $ZVOL && destroy_dataset $ZVOL
+	if zpool list -v $TESTPOOL | grep -q "$slog" ; then
+		log_must zpool remove $TESTPOOL "$slog"
+	fi
+	poolexists $rpool && destroy_pool $rpool
+	rm -f "$slog" "$rvdev"
+	block_device_wait
+}
+
+# Number of indirect ZIL records logged for the zvol's objset so far.
+function indirect_count
+{
+	kstat_dataset $ZVOL zil_itx_indirect_count
+}
+
+log_assert "Full aligned block sync writes to a ZVOL are stored indirectly"
+log_onexit cleanup
+
+log_must zfs create -V $VOLSIZE -b $VOLBS -o sync=always \
+    -o compression=off -o volmode=dev $ZVOL
+block_device_wait $ZDEV
+
+# 1. Full aligned block sync writes: expect indirect writes.
+typeset before=$(indirect_count)
+log_must dd if=/dev/urandom of=$ZDEV bs=$VOLBS count=$COUNT \
+    oflag=direct conv=fdatasync
+typeset after=$(indirect_count)
+typeset delta=$((after - before))
+log_note "full-block writes: indirect_count delta=$delta (expected ~$COUNT)"
+if [[ $delta -le $((COUNT / 2)) ]] ; then
+	log_fail "Full block sync writes did not use indirect writes " \
+	    "($delta <= $((COUNT / 2)))"
+fi
+
+# 2. Partial (sub-block) sync writes: must not use indirect.
+before=$(indirect_count)
+log_must dd if=/dev/urandom of=$ZDEV bs=$((VOLBS / 2)) count=$COUNT \
+    oflag=direct conv=fdatasync
+after=$(indirect_count)
+delta=$((after - before))
+log_note "partial writes: indirect_count delta=$delta (expected 0)"
+if [[ $delta -ne 0 ]] ; then
+	log_fail "Partial sync writes unexpectedly used indirect writes " \
+	    "($delta != 0)"
+fi
+
+# 3. Indirectly logged full-block writes must replay with identical data.
+#    A dedicated pool is frozen so the post-freeze writes reach disk only
+#    through the ZIL; they survive an export/import only if the WR_INDIRECT
+#    records and the blocks they reference are claimed and replayed
+#    correctly.  Using a private pool keeps the freeze from disturbing
+#    $TESTPOOL.
+log_must truncate -s 512m "$rvdev"
+log_must zpool create $rpool "$rvdev"
+log_must zfs create -V 64m -b $VOLBS -o sync=always -o compression=off \
+    -o volmode=dev $rvol
+block_device_wait $rdev
+# A pre-freeze sync write puts the ZIL header on disk so the post-freeze
+# records are reachable at import.
+log_must dd if=/dev/urandom of=$rdev bs=$VOLBS count=1 \
+    oflag=direct conv=fdatasync
+log_must sync_pool $rpool
+log_must zpool freeze $rpool
+log_must dd if=/dev/urandom of=$rdev bs=$VOLBS count=$COUNT \
+    oflag=direct conv=fdatasync
+typeset checksum=$(dd if=$rdev bs=$VOLBS count=$COUNT 2>/dev/null | \
+    xxh128digest)
+log_note "Verify transactions to replay:"
+log_must zdb -iv $rvol
+block_device_wait $rdev
+log_must zpool export $rpool
+log_must zpool import -f -d $TEST_BASE_DIR $rpool
+block_device_wait $rdev
+log_must test -b $rdev
+typeset checksum1=$(dd if=$rdev bs=$VOLBS count=$COUNT 2>/dev/null | \
+    xxh128digest)
+if [[ "$checksum1" != "$checksum" ]] ; then
+	log_fail "Indirect ZIL replay corrupted data ($checksum1 != $checksum)"
+fi
+log_must destroy_pool $rpool
+
+# 4. With a dedicated SLOG, full block writes must stay in the log.
+log_must truncate -s $MINVDEVSIZE "$slog"
+log_must zpool add $TESTPOOL log "$slog"
+before=$(indirect_count)
+log_must dd if=/dev/urandom of=$ZDEV bs=$VOLBS count=$COUNT \
+    oflag=direct conv=fdatasync
+after=$(indirect_count)
+delta=$((after - before))
+log_note "full-block writes with SLOG: indirect_count delta=$delta (expected 0)"
+if [[ $delta -ne 0 ]] ; then
+	log_fail "Full block writes bypassed the SLOG via indirect writes " \
+	    "($delta != 0)"
+fi
+
+log_pass "Full aligned block sync writes to a ZVOL are stored indirectly"


### PR DESCRIPTION
### Motivation and Context

Closes #17677.

On a zvol with `sync=always` (e.g. a VM disk image), a synchronous write that
exactly covers an aligned volblocksize block is copied into the ZIL
(`WR_COPIED`) and then written again at TXG commit — the data hits the pool
twice. For small-volblocksize zvols under a sync-heavy workload this doubles the
write volume.

### Description

Store aligned full-block sync writes indirectly (`WR_INDIRECT`) so the block
reaches the pool only once. `zil_write_state()` gains `offset`/`blk_fixed`
parameters; for a zvol (fixed volblocksize) a write whose offset and length are
whole-block aligned takes the indirect path via `dmu_sync()`, and the log record
just references the block.

The existing heuristics are preserved for everything else: a dedicated SLOG
still keeps full-block writes in the log, sub-block and misaligned writes are
unchanged, and the ZPL path is untouched (`blk_fixed = B_FALSE`).

### How Has This Been Tested?

New `zvol_misc_fullblock` ZTS case: full-block sync writes increase the objset's
`zil_itx_indirect_count`, sub-block writes do not, and a dedicated SLOG keeps
even full-block writes in the log. Because this changes which writes are logged
indirectly, the test also freezes a dedicated pool, writes full blocks, then
exports and re-imports it and checks the zvol is byte-for-byte identical — so the
`WR_INDIRECT` records are actually claimed and replayed correctly. Ran on Linux
(Ubuntu, aarch64, `--enable-debug`).

This is a **draft** — I'd like reviewer guidance on the design before polishing:
- The indirect path is currently unconditional for full-block zvol sync writes,
  so it overrides `zfs_immediate_write_sz` / `logbias=latency`. On a small
  volblocksize zvol without a SLOG this trades halved write volume for more (and
  more random) main-pool IOPS. Should it be gated behind a module parameter or a
  size floor?
- It also affects async full-block writes, and these writes bypass the DDT
  (`dmu_sync` disables dedup). Are those acceptable, or should the predicate be
  narrowed?

### Types of changes
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **contributing** document.
- [x] I have added tests to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
