### PR TITLE
ZTS: migration/setup: clear stale zfs_member label before new_fs

### DIFF
--- a/tests/zfs-tests/tests/functional/migration/setup.ksh
+++ b/tests/zfs-tests/tests/functional/migration/setup.ksh
@@ -58,8 +58,28 @@ log_must zfs set mountpoint=$TESTDIR $TESTPOOL/$TESTFS
 rm -rf $NONZFS_TESTDIR  || log_unresolved Could not remove $NONZFS_TESTDIR
 mkdir -p $NONZFS_TESTDIR || log_unresolved Could not create $NONZFS_TESTDIR
 
+#
+# $NONZFS_DISK may still carry a zfs_member label from a pool used by an
+# earlier test.  'zpool destroy' leaves the vdev labels in place and new_fs
+# only overwrites the front of the device, so the trailing labels can
+# survive.  libblkid then probes the device as ambiguous (both the new
+# filesystem and zfs_member) and the auto-detecting mount below fails
+# intermittently.  Wipe any residual signatures first so the new filesystem
+# is unambiguous.  Skip the single-disk case, where $NONZFS_DISK is the same
+# device the test pool was just created on.
+#
+if is_linux && [[ "$NONZFS_DISK" != "$ZFS_DISK" ]]; then
+	log_must wipefs -a ${DEV_DSKDIR}/$NONZFS_DISK
+fi
+
 new_fs ${DEV_DSKDIR}/$NONZFS_DISK ||
 	log_untested "Unable to setup a $NEWFS_DEFAULT_FS file system"
+
+#
+# Let udev settle so the device node reflects the new filesystem before the
+# auto-detecting mount consults it.
+#
+block_device_wait ${DEV_DSKDIR}/$NONZFS_DISK
 
 log_must mount ${DEV_DSKDIR}/$NONZFS_DISK $NONZFS_TESTDIR
 


### PR DESCRIPTION
### Motivation and Context

Closes #18492.

During a full ZTS run, functional/migration/setup fails intermittently at
the mount of the non-ZFS device. That device is usually one an earlier test
used as a pool vdev. `zpool destroy` leaves the vdev labels in place and
`new_fs` only rewrites the front of the device, so trailing zfs_member
labels can survive. libblkid then sees the device as ambiguous (the new
filesystem and zfs_member) and the auto-detecting `mount` refuses, which
shows up as a spurious setup failure. It has been reported by more than one
person and still reproduces on 2.4.x.

### Description

Before laying down the new filesystem, wipe any residual signatures on the
non-ZFS device with `wipefs -a` so it carries a single, unambiguous type,
then `block_device_wait` so udev settles before the auto-detecting mount.
The wipe is skipped in the single-disk case, where the non-ZFS device is the
same one the test pool was just created on, so the live pool is never
touched.

I looked at the other directions raised in the issue thread first:
platform-specific `*_fs` wrapper helpers in libtest.shlib with an explicit
`mount -t ext4`, and a cross-platform `zpool labelclear`. I went with a
targeted `wipefs -a` because it only runs on the multi-disk Linux path, it
removes every stale signature rather than just a ZFS label, and it does not
risk hiding a real problem the way clearing labels everywhere might. If the
wrapper-helper route is preferred I can switch to that; opening as a draft
to get direction.

### How Has This Been Tested?

Linux. After a pool create and destroy the scratch loop device still carries
a zfs_member label (`blkid -p` reports zfs_member); `wipefs -a` removes it so
the following filesystem is the only signature and the mount succeeds. The
full functional/migration group passes with the change on a multi-disk
loopback config.

### Types of changes
- [x] Test suite change

### Checklist
- [x] My code follows the OpenZFS code style requirements.
- [x] I have signed off my commit.
