### PR TITLE
zstream: open up dump API to non-dump subcommands

### DIFF
--- a/cmd/zstream/Makefile.am
+++ b/cmd/zstream/Makefile.am
@@ -14,6 +14,7 @@ zstream_SOURCES = \
 	%D%/zstream_decompress.c \
 	%D%/zstream_drop_record.c \
 	%D%/zstream_dump.c \
+	%D%/zstream_dump.h \
 	%D%/zstream_fletcher4.c \
 	%D%/zstream_fletcher4.h \
 	%D%/zstream_io.c \

--- a/cmd/zstream/zstream_chain.h
+++ b/cmd/zstream/zstream_chain.h
@@ -52,7 +52,7 @@ extern "C" {
  *		serial_validate_fletcher4(),
  *		serial_byteswap(BS_INCOMING),
  *		serial_validate_records(),
- *		serial_dump_records(&dump_args),
+ *		serial_dump_records(),
  *		serial_null_output(),
  *		chain_terminator()
  *	}
@@ -61,7 +61,7 @@ extern "C" {
  *
  *	zstream_chain_t dump_chain = {
  *		STANDARD_INPUT_STACK(infile),
- *		serial_dump_records(&dump_args),
+ *		serial_dump_records(),
  *		NULL_OUTPUT_STACK()
  *	};
  *
@@ -103,17 +103,19 @@ extern "C" {
 #define	CA_LITTLE_ENDIAN_INPUT		(1ULL << 2)
 
 #define	CA_VERBOSE			(1ULL << 0)	/* ca_command_opts */
-#define	CA_VERY_VERBOSE			(1ULL << 1)
-#define	CA_DUMP_DATA			(1ULL << 2)
-#define	CA_IGNORE_CKSUMS		(1ULL << 3)
-#define	CA_DO_NOT_VALIDATE		(1ULL << 4)
-#define	CA_FORBID_DEDUP			(1ULL << 5)
-#define	CA_REQUIRE_DEDUP		(1ULL << 6)
-#define	CA_REQUIRE_NATIVE_ENDIAN	(1ULL << 7)
-#define	CA_BYTESWAP_ON_OUTPUT		(1ULL << 8)
-#define	CA_BIG_ENDIAN_OUT		(1ULL << 9)
-#define	CA_LITTLE_ENDIAN_OUT		(1ULL << 10)
-#define	CA_OPPOSITE_ENDIAN_OUT		(1ULL << 11)
+#define	CA_DUMP_BEGIN_AND_END		(1ULL << 1)
+#define	CA_DUMP_ALL_RECORDS		(1ULL << 2)
+#define	CA_DUMP_CHECKSUMS		(1ULL << 3)
+#define	CA_DUMP_DATA			(1ULL << 4)
+#define	CA_IGNORE_CKSUMS		(1ULL << 5)
+#define	CA_DO_NOT_VALIDATE		(1ULL << 6)
+#define	CA_FORBID_DEDUP			(1ULL << 7)
+#define	CA_REQUIRE_DEDUP		(1ULL << 8)
+#define	CA_REQUIRE_NATIVE_ENDIAN	(1ULL << 9)
+#define	CA_BYTESWAP_ON_OUTPUT		(1ULL << 10)
+#define	CA_BIG_ENDIAN_OUT		(1ULL << 11)
+#define	CA_LITTLE_ENDIAN_OUT		(1ULL << 12)
+#define	CA_OPPOSITE_ENDIAN_OUT		(1ULL << 13)
 
 #define	OPTION_ENABLED(option) (!!(chain_attrs->ca_command_opts & (option)))
 #define	STREAM_HAS_FEATURE(feat) (!!(chain_attrs->ca_feature_flags & (feat)))

--- a/cmd/zstream/zstream_dump.c
+++ b/cmd/zstream/zstream_dump.c
@@ -67,7 +67,7 @@ typedef void dumper_f(drr_packet_t *item);
 typedef struct {
 	const char	*rt_typename;
 	dumper_f	*rt_dumper;
-} record_type_t;
+} record_dumper_t;
 
 static int stream_error;
 
@@ -183,6 +183,10 @@ dump_begin_record(drr_packet_t *item)
 	dmu_replay_record_t *drr = &item->dp_drr;
 	struct drr_begin *drrb = &item->dp_drr.drr_u.drr_begin;
 
+	if (!OPTION_ENABLED(CA_DUMP_BEGIN_AND_END) &&
+	    !OPTION_ENABLED(CA_DUMP_ALL_RECORDS))
+		return;
+
 	printf("BEGIN record\n");
 	printf("\thdrtype = %llu\n",
 	    DMU_GET_STREAM_HDRTYPE(drrb->drr_versioninfo));
@@ -240,6 +244,10 @@ dump_end_record(drr_packet_t *item)
 {
 	struct drr_end *drre = &item->dp_drr.drr_u.drr_end;
 
+	if (!OPTION_ENABLED(CA_DUMP_BEGIN_AND_END) &&
+	    !OPTION_ENABLED(CA_DUMP_ALL_RECORDS))
+		return;
+
 	printf("END checksum = %llx/%llx/%llx/%llx\n",
 	    (u_longlong_t)drre->drr_checksum.zc_word[0],
 	    (u_longlong_t)drre->drr_checksum.zc_word[1],
@@ -252,7 +260,7 @@ dump_object_record(drr_packet_t *item)
 {
 	struct drr_object *drro = &item->dp_drr.drr_u.drr_object;
 
-	if (OPTION_ENABLED(CA_VERBOSE)) {
+	if (OPTION_ENABLED(CA_DUMP_ALL_RECORDS)) {
 		printf("OBJECT object = %llu type = %u "
 		    "bonustype = %u blksz = %u bonuslen = %u "
 		    "dn_slots = %u raw_bonuslen = %u "
@@ -282,7 +290,7 @@ dump_freeobjects_record(drr_packet_t *item)
 {
 	struct drr_freeobjects *drrfo = &item->dp_drr.drr_u.drr_freeobjects;
 
-	if (OPTION_ENABLED(CA_VERBOSE)) {
+	if (OPTION_ENABLED(CA_DUMP_ALL_RECORDS)) {
 		printf("FREEOBJECTS firstobj = %llu numobjs = %llu\n",
 		    (u_longlong_t)drrfo->drr_firstobj,
 		    (u_longlong_t)drrfo->drr_numobjs);
@@ -294,7 +302,7 @@ dump_write_record(drr_packet_t *item)
 {
 	struct drr_write *drrw = &item->dp_drr.drr_u.drr_write;
 
-	if (OPTION_ENABLED(CA_VERBOSE)) {
+	if (OPTION_ENABLED(CA_DUMP_ALL_RECORDS)) {
 		printf("WRITE object = %llu type = %u "
 		    "checksum type = %u compression type = %u "
 		    "flags = %u offset = %llu "
@@ -322,7 +330,7 @@ dump_write_byref_record(drr_packet_t *item)
 {
 	struct drr_write_byref *drrwbr = &item->dp_drr.drr_u.drr_write_byref;
 
-	if (OPTION_ENABLED(CA_VERBOSE)) {
+	if (OPTION_ENABLED(CA_DUMP_ALL_RECORDS)) {
 		printf("WRITE_BYREF object = %llu "
 		    "checksum type = %u props = %llx "
 		    "offset = %llu length = %llu "
@@ -345,7 +353,7 @@ dump_free_record(drr_packet_t *item)
 {
 	struct drr_free *drrf = &item->dp_drr.drr_u.drr_free;
 
-	if (OPTION_ENABLED(CA_VERBOSE)) {
+	if (OPTION_ENABLED(CA_DUMP_ALL_RECORDS)) {
 		printf("FREE object = %llu "
 		    "offset = %llu length = %lld\n",
 		    (u_longlong_t)drrf->drr_object,
@@ -359,7 +367,7 @@ dump_spill_record(drr_packet_t *item)
 {
 	struct drr_spill *drrs = &item->dp_drr.drr_u.drr_spill;
 
-	if (OPTION_ENABLED(CA_VERBOSE)) {
+	if (OPTION_ENABLED(CA_DUMP_ALL_RECORDS)) {
 		printf("SPILL block for object = %llu "
 		    "length = %llu flags = %u "
 		    "compression type = %u "
@@ -383,7 +391,7 @@ dump_write_embedded_record(drr_packet_t *item)
 	struct drr_write_embedded *drrwe =
 	    &item->dp_drr.drr_u.drr_write_embedded;
 
-	if (OPTION_ENABLED(CA_VERBOSE)) {
+	if (OPTION_ENABLED(CA_DUMP_ALL_RECORDS)) {
 		printf("WRITE_EMBEDDED object = %llu "
 		    "offset = %llu length = %llu "
 		    "toguid = %llx comp = %u etype = %u "
@@ -405,7 +413,7 @@ dump_object_range_record(drr_packet_t *item)
 {
 	struct drr_object_range *drror = &item->dp_drr.drr_u.drr_object_range;
 
-	if (OPTION_ENABLED(CA_VERBOSE)) {
+	if (OPTION_ENABLED(CA_DUMP_ALL_RECORDS)) {
 		printf("OBJECT_RANGE firstobj = %llu "
 		    "numslots = %llu flags = %u "
 		    "%s\n",
@@ -421,7 +429,7 @@ dump_redact_record(drr_packet_t *item)
 {
 	struct drr_redact *drrr = &item->dp_drr.drr_u.drr_redact;
 
-	if (OPTION_ENABLED(CA_VERBOSE)) {
+	if (OPTION_ENABLED(CA_DUMP_ALL_RECORDS)) {
 		printf("REDACT object = %llu offset = "
 		    "%llu length = %llu\n",
 		    (u_longlong_t)drrr->drr_object,
@@ -430,11 +438,25 @@ dump_redact_record(drr_packet_t *item)
 	}
 }
 
+static const record_dumper_t record_dumpers[] = {
+	{ "DRR_BEGIN", 		dump_begin_record },
+	{ "DRR_OBJECT", 	dump_object_record },
+	{ "DRR_FREEOBJECTS", 	dump_freeobjects_record },
+	{ "DRR_WRITE", 		dump_write_record },
+	{ "DRR_FREE", 		dump_free_record },
+	{ "DRR_END", 		dump_end_record },
+	{ "DRR_WRITE_BYREF", 	dump_write_byref_record },
+	{ "DRR_SPILL", 		dump_spill_record },
+	{ "DRR_WRITE_EMBEDDED",	dump_write_embedded_record },
+	{ "DRR_OBJECT_RANGE",	dump_object_range_record },
+	{ "DRR_REDACT",		dump_redact_record }
+};
+
 static disposition_t
-chain_dump_record(void *item_in, void *context_in)
+chain_dump_records(void *item_in, void *context)
 {
+	(void) context;
 	drr_packet_t *item = (drr_packet_t *)item_in;
-	record_type_t *context = (record_type_t *)context_in;
 
 	if (item == NULL) {
 		return (D_OK);
@@ -444,9 +466,12 @@ chain_dump_record(void *item_in, void *context_in)
 	zio_cksum_t *cksum = &drr->drr_u.drr_checksum.drr_checksum;
 	int type = (int)drr->drr_type;
 
-	context[type].rt_dumper(item);
+	if (type < 0 || type >= DRR_NUMTYPES)
+		errx(1, "unknown record type: %d", type);
 
-	if (type != DRR_BEGIN && OPTION_ENABLED(CA_VERY_VERBOSE)) {
+	record_dumpers[type].rt_dumper(item);
+
+	if (type != DRR_BEGIN && OPTION_ENABLED(CA_DUMP_CHECKSUMS)) {
 		printf("    checksum = %llx/%llx/%llx/%llx\n",
 		    (u_longlong_t)cksum->zc_word[0],
 		    (u_longlong_t)cksum->zc_word[1],
@@ -457,16 +482,23 @@ chain_dump_record(void *item_in, void *context_in)
 	return (D_OK);
 }
 
-static chain_step_t
-serial_dump_records(record_type_t *context)
+chain_step_t
+serial_dump_records(void)
 {
+	size_t all_dumpers = sizeof (record_dumpers);
+	size_t one_dumper = sizeof (record_dumpers[0]);
+
+	if (all_dumpers / one_dumper != DRR_NUMTYPES) {
+		errx(1, "number of record_dumpers must match DRR_NUMTYPES");
+	}
+
 	chain_step_t step = {
 		.cs_type = CS_SERIAL,
 		.cs_in_size = sizeof (drr_packet_t),
 		.cs_out_size = sizeof (drr_packet_t),
-		.cs_context = context,
+		.cs_context = NULL,
 		.cs_serial = {
-			.process = chain_dump_record
+			.process = chain_dump_records
 		}
 	};
 	return (step);
@@ -479,19 +511,7 @@ zstream_do_dump(int argc, char *argv[])
 	const char *input_file = NULL;
 	int c;
 
-	record_type_t record_types[] = {
-		{ "DRR_BEGIN", 		dump_begin_record },
-		{ "DRR_OBJECT", 	dump_object_record },
-		{ "DRR_FREEOBJECTS", 	dump_freeobjects_record },
-		{ "DRR_WRITE", 		dump_write_record },
-		{ "DRR_FREE", 		dump_free_record },
-		{ "DRR_END", 		dump_end_record },
-		{ "DRR_WRITE_BYREF", 	dump_write_byref_record },
-		{ "DRR_SPILL", 		dump_spill_record },
-		{ "DRR_WRITE_EMBEDDED",	dump_write_embedded_record },
-		{ "DRR_OBJECT_RANGE",	dump_object_range_record },
-		{ "DRR_REDACT",		dump_redact_record }
-	};
+	ENABLE_OPTION(&attrs, CA_DUMP_BEGIN_AND_END);
 
 	while ((c = getopt(argc, argv, ":vCd")) != -1) {
 		switch (c) {
@@ -500,14 +520,16 @@ zstream_do_dump(int argc, char *argv[])
 			break;
 		case 'v':
 			if (attrs.ca_command_opts & CA_VERBOSE) {
-				ENABLE_OPTION(&attrs, CA_VERY_VERBOSE);
+				ENABLE_OPTION(&attrs, CA_DUMP_CHECKSUMS);
 			} else {
 				ENABLE_OPTION(&attrs, CA_VERBOSE);
+				ENABLE_OPTION(&attrs, CA_DUMP_ALL_RECORDS);
 			}
 			break;
 		case 'd':
 			ENABLE_OPTION(&attrs, CA_VERBOSE);
-			ENABLE_OPTION(&attrs, CA_VERY_VERBOSE);
+			ENABLE_OPTION(&attrs, CA_DUMP_ALL_RECORDS);
+			ENABLE_OPTION(&attrs, CA_DUMP_CHECKSUMS);
 			ENABLE_OPTION(&attrs, CA_DUMP_DATA);
 			break;
 		case ':':
@@ -527,7 +549,7 @@ zstream_do_dump(int argc, char *argv[])
 
 	zstream_chain_t dump_chain = {
 		STANDARD_INPUT_STACK(input_file),
-		serial_dump_records(record_types),
+		serial_dump_records(),
 		NULL_OUTPUT_STACK()
 	};
 
@@ -546,7 +568,7 @@ zstream_do_dump(int argc, char *argv[])
 	printf("SUMMARY:\n");
 	for (int i = 0; i < DRR_NUMTYPES; i++) {
 		int type = print_order[i];
-		record_type_t *rec = &record_types[type];
+		const record_dumper_t *rec = &record_dumpers[type];
 		record_stats_t *stats = &attrs.ca_stats_in[type];
 		printf("\tTotal %s records = %llu (%llu bytes)\n",
 		    rec->rt_typename,

--- a/cmd/zstream/zstream_dump.h
+++ b/cmd/zstream/zstream_dump.h
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: CDDL-1.0
+/*
+ * CDDL HEADER START
+ *
+ * This file and its contents are supplied under the terms of the Common
+ * Development and Distribution License ("CDDL"), version 1.0. You may only use
+ * this file in accordance with the terms of version 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this source. A
+ * copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2026 by Garth Snyder. All rights reserved.
+ */
+
+#ifndef _ZSTREAM_DUMP_H
+#define	_ZSTREAM_DUMP_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "zstream_chain.h"
+
+chain_step_t
+serial_dump_records(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* _ZSTREAM_DUMP_H */

--- a/cmd/zstream/zstream_modules.h
+++ b/cmd/zstream/zstream_modules.h
@@ -31,6 +31,7 @@ extern "C" {
 
 #include "zstream_byteswap.h"
 #include "zstream_chain.h"
+#include "zstream_dump.h"
 #include "zstream_fletcher4.h"
 #include "zstream_io.h"
 #include "zstream_recompress.h"


### PR DESCRIPTION
The upcoming `zstream raw` would like to dump records as part of its operation when a `-v` flag is passed.

This PR adds `zstream_dump.h` and publicly declares the `serial_dump_records()` chain module for access by other parts of `zstream.` It also makes a couple of other changes to make the dump module more friendly toward clients.

- The record-type table no longer has to be passed into `zstream_dump_records()` as a context struct. It's now a file static.

- `zstream dump` has command-line options for "verbose", "very verbose", and "dump data", which each enable one or more functions. This patch replaces the generic CA_VERBOSE and CA_VERY_VERBOSE internal flags with options that request specific behaviors:

```
CA_DUMP_BEGIN_AND_END
CA_DUMP_ALL_RECORDS
CA_DUMP_CHECKSUMS
CA_DUMP_DATA
```

The finer granularity allows other commands to select exactly the output they want without having to map through `zstream dump`'s own command line definitions. For example, if neither CA_DUMP_BEGIN_AND_END nor CA_DUMP_ALL_RECORDS is turned on, `serial_dump_records()` becomes a silent no-op, a behavior that was not possible before.

There are no user-facing changes to the `zstream dump` command.

### How Has This Been Tested?
This is effectively a change to the `zstream dump` implementation, which is extensively tested by the ZTS. There are several tests that compare the output of `zstream dump` to known-good output of previous versions.

Use of `serial_dump_records()` by an outside clients is in the current draft of `zstream raw`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
