### PR TITLE
zio_crypt: avoid buffer copy when ABDs are already linear

### DIFF
--- a/module/os/linux/zfs/zio_crypt.c
+++ b/module/os/linux/zfs/zio_crypt.c
@@ -2029,6 +2029,9 @@ error:
 /*
  * Simple wrapper around zio_do_crypt_data() to work with abd's instead of
  * linear buffers.
+ *
+ * When both ABDs are linear, we avoid the abd_borrow_buf_copy() overhead
+ * by working directly with the underlying buffers.
  */
 int
 zio_do_crypt_abd(boolean_t encrypt, zio_crypt_key_t *key, dmu_object_type_t ot,
@@ -2038,6 +2041,19 @@ zio_do_crypt_abd(boolean_t encrypt, zio_crypt_key_t *key, dmu_object_type_t ot,
 	int ret;
 	void *ptmp, *ctmp;
 
+	/*
+	 * Fast path: both ABDs are linear, so we can pass their buffers
+	 * directly to zio_do_crypt_data() without any copying.
+	 */
+	if (abd_is_linear(pabd) && abd_is_linear(cabd)) {
+		ptmp = abd_to_buf(pabd);
+		ctmp = abd_to_buf(cabd);
+
+		return (zio_do_crypt_data(encrypt, key, ot, byteswap, salt, iv,
+		    mac, datalen, ptmp, ctmp, no_crypt));
+	}
+
+	/* Slow path: at least one ABD is scattered. */
 	if (encrypt) {
 		ptmp = abd_borrow_buf_copy(pabd, datalen);
 		ctmp = abd_borrow_buf(cabd, datalen);


### PR DESCRIPTION
In zio_do_crypt_abd(), the code unconditionally uses abd_borrow_buf_copy() to linearize ABDs before encryption/decryption. On the read path, disk I/O typically produces linear ABDs, making this a redundant full-block memcpy.

Add an abd_is_linear() check to use abd_to_buf() directly when both ABDs are already contiguous, skipping the copy entirely. This eliminates 2 memory copies per encrypted block on the common path.

### Motivation and Context
On the ZFS read path for encrypted datasets, disk I/O typically produces linear ABDs. The current [zio_do_crypt_abd()](cci:1://file:///c:/Users/spalayur/OneDrive%20-%20MaxLinear,%20Inc/General/Panther/software/ZFS/openzfs-upstream/module/os/linux/zfs/zio_crypt.c:2028:0-2089:1) implementation unconditionally calls `abd_borrow_buf_copy()` which allocates a temporary buffer and performs a full-block memcpy, even when the ABD is already contiguous in memory. This results in unnecessary CPU overhead and memory bandwidth consumption for every encrypted block read.

### Description
Add a fast path that checks if both the plaintext and ciphertext ABDs are linear using `abd_is_linear()`. When both are linear, use `abd_to_buf()` to obtain direct pointers to the underlying buffers and pass them to [zio_do_crypt_data()](cci:1://file:///c:/Users/spalayur/OneDrive%20-%20MaxLinear,%20Inc/General/Panther/software/ZFS/zflush-git/zflush/zflush-sdk/module/os/linux/zfs/zio_crypt.c:1909:0-2057:1), bypassing the borrow/copy/return cycle entirely.

This eliminates 2 redundant memcpy operations per encrypted block on the common read path.

### How Has This Been Tested?
- Tested on Linux with encrypted ZFS datasets (aes-256-gcm)
- Verified correct encryption/decryption behavior with various record sizes
- Confirmed no data corruption or functional regressions
- Performance improvement observed on read-heavy encrypted workloads

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).