### PR TITLE
zvol: avoid media change on volume resize

### DIFF
--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -333,8 +333,8 @@ zvol_update_volsize(uint64_t volsize, objset_t *os)
 }
 
 /*
- * Set ZFS_PROP_VOLSIZE set entry point.  Note that modifying the volume
- * size will result in a udev "change" event being generated.
+ * Set ZFS_PROP_VOLSIZE entry point.  When the zvol is open, modifying the
+ * volume size updates the in-kernel gendisk capacity.
  */
 int
 zvol_set_volsize(const char *name, uint64_t volsize)
@@ -381,7 +381,13 @@ zvol_set_volsize(const char *name, uint64_t volsize)
 	error = zvol_update_volsize(volsize, os);
 	if (error == 0 && zv != NULL) {
 		zv->zv_volsize = volsize;
-		zv->zv_changed = 1;
+		/*
+		 * The gendisk capacity is updated below by
+		 * zvol_os_update_volsize().  Do not report a normal zvol resize
+		 * as DISK_EVENT_MEDIA_CHANGE because newer Linux block layers
+		 * may treat media change as device replacement and mark mounted
+		 * block devices dead.
+		 */
 	}
 out:
 	kmem_free(doi, sizeof (dmu_object_info_t));


### PR DESCRIPTION
### Motivation and Context

Fixes #18758.

A normal zvol resize only needs to update the in-kernel gendisk
capacity.  The current code also marks the zvol as changed, which is
reported through `.check_events` as `DISK_EVENT_MEDIA_CHANGE`.

On newer Linux block layers, `disk_check_media_change()` may treat this
as media replacement and call `bdev_mark_dead()` for mounted block
devices.  This can invalidate or shut down a filesystem mounted on the
zvol when `zfs set volsize=...` is used.

### Description

Stop reporting normal zvol resize as `DISK_EVENT_MEDIA_CHANGE`.  The
capacity is still updated by `zvol_os_update_volsize()`, so userspace can
observe the new block device size with tools such as `lsblk` and
`blockdev`.  Filesystems should be grown explicitly afterwards, for
example with `xfs_growfs` or `resize2fs`.

### How Has This Been Tested?

Tested on Rocky Linux 9.7 with Linux 5.14.0-611.5.1.el9_7.x86_64.

* Created a zvol, formatted it with XFS, mounted it, wrote test data,
  grew the zvol from 1G to 2G, verified `lsblk` and `blockdev` saw the
  larger block device, verified the existing data checksum, ran
  `xfs_growfs`, and verified `df` reported the larger filesystem.
* Repeated the same flow with ext4 and online `resize2fs`.
* No XFS shutdown, I/O error, or device-dead messages were observed in
  `dmesg` during the tests.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the comments to describe the new behavior.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
