### PR TITLE
nvpair: nvpair_native_string_array() should check the size of string array

### DIFF
--- a/module/nvpair/nvpair.c
+++ b/module/nvpair/nvpair.c
@@ -1121,7 +1121,7 @@ i_get_value_size(data_type_t type, const void *data, uint_t nelem,
 				if (newsize == max_size)
 					return (-1);	/* not terminated */
 
-				value_sz += newsize + 1; /* +1 for NULL */
+				value_sz += newsize + 1; /* +1 for '\0' */
 				max_size -= newsize + 1;
 			}
 		}
@@ -2980,9 +2980,11 @@ nvpair_native_embedded_array(nvstream_t *nvs, nvpair_t *nvp)
 	return (nvs_embedded_nvl_array(nvs, nvp, NULL));
 }
 
-static void
+static int
 nvpair_native_string_array(nvstream_t *nvs, nvpair_t *nvp)
 {
+	int ret = 0;
+
 	switch (nvs->nvs_op) {
 	case NVS_OP_ENCODE: {
 		nvs_native_t *native = (nvs_native_t *)nvs->nvs_private;
@@ -2997,17 +2999,36 @@ nvpair_native_string_array(nvstream_t *nvs, nvpair_t *nvp)
 		break;
 	}
 	case NVS_OP_DECODE: {
+		int32_t remaining, decode_len = NVP_SIZE(nvp);
 		char **strp = (void *)NVP_VALUE(nvp);
 		char *buf = ((char *)strp + NVP_NELEM(nvp) * sizeof (uint64_t));
-		int i;
+		int i, arrays;
 
-		for (i = 0; i < NVP_NELEM(nvp); i++) {
-			strp[i] = buf;
-			buf += strlen(buf) + 1;
+		/*
+		 * get length of string array.
+		 */
+		remaining = ((char *)nvp + decode_len) - buf;
+		if (decode_len < 0 || remaining < 0) {
+			ret = EFAULT;
+			break;
 		}
+
+		arrays = 0;
+		for (i = 0; i < NVP_NELEM(nvp); i++) {
+			size_t len = strnlen(buf, remaining) + 1;
+			if (len <= remaining) {
+				strp[i] = buf;
+				buf += len;
+				remaining -= len;
+				arrays++;
+			}
+		}
+		if (arrays != NVP_NELEM(nvp) || remaining != 0)
+			ret = EFAULT;
 		break;
 	}
 	}
+	return (ret);
 }
 
 static int
@@ -3058,7 +3079,7 @@ nvs_native_nvp_op(nvstream_t *nvs, nvpair_t *nvp)
 		ret = nvpair_native_embedded_array(nvs, nvp);
 		break;
 	case DATA_TYPE_STRING_ARRAY:
-		nvpair_native_string_array(nvs, nvp);
+		ret = nvpair_native_string_array(nvs, nvp);
 		break;
 	default:
 		break;


### PR DESCRIPTION
nvpair_native_string_array() does trust strlen() while decoding string array, we should use pair size for upper limit and strnlen() instead.

Sponsored-by: Edgecast Cloud LLC

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Similar problem as in #18604

<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

Make sure we do not access memory past nvpair size.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Run libzfs_input_checks, normal zfs usage.

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
