### PR TITLE
libzfs/crypto: keep in-flight key from network in memory

### DIFF
--- a/lib/libzfs/libzfs_crypto.c
+++ b/lib/libzfs/libzfs_crypto.c
@@ -584,45 +584,31 @@ get_key_material_https(libzfs_handle_t *hdl, const char *uri,
 		goto end;
 	}
 
-	int kfd;
-#ifdef O_TMPFILE
-	kfd = open(getenv("TMPDIR") ?: "/tmp",
-	    O_RDWR | O_TMPFILE | O_EXCL | O_CLOEXEC, 0600);
-	if (kfd != -1)
-		goto kfdok;
-#endif
+	/* max len + optional newline + terminator */
+	char keybuf[MAX_PASSPHRASE_LEN+2];
+	memset(keybuf, 0, sizeof (keybuf));
 
-	char *path;
-	if (asprintf(&path,
-	    "%s/libzfs-XXXXXXXX.https", getenv("TMPDIR") ?: "/tmp") == -1) {
-		ret = ENOMEM;
-		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN, "%s"),
-		    zfs_strerror(ret));
-		goto end;
-	}
-
-	kfd = mkostemps(path, strlen(".https"), O_CLOEXEC);
-	if (kfd == -1) {
+	/*
+	 * Open a stream over keybuf. The "length" of the stream is
+	 * WRAPPING_KEY_LEN for raw keys, which is checked and enforced in
+	 * get_key_material_stream() and validate_key(). For "line" formats,
+	 * the entire buffer is allowed, which has enough room for the
+	 * longest possible passphrase, newline and terminator.
+	 */
+	if ((stream = fmemopen(keybuf,
+	    keyformat == ZFS_KEYFORMAT_RAW ?
+	    WRAPPING_KEY_LEN : sizeof (keybuf), "r+")) == NULL) {
 		ret = errno;
 		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-		    "Couldn't create temporary file %s: %s"),
-		    path, zfs_strerror(ret));
-		free(path);
+		    "Couldn't open memory stream: %s"), zfs_strerror(ret));
 		goto end;
 	}
-	(void) unlink(path);
-	free(path);
 
-#ifdef O_TMPFILE
-kfdok:
-#endif
-	if ((stream = fdopen(kfd, "r+")) == NULL) {
-		ret = errno;
-		(void) close(kfd);
-		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-		    "Couldn't reopen temporary file: %s"), zfs_strerror(ret));
-		goto end;
-	}
+	/*
+	 * Disable buffering on in-memory stream, so that curl sees errors
+	 * (eg writing past the end) immediately.
+	 */
+	setbuf(stream, NULL);
 
 	char errbuf[CURL_ERROR_SIZE] = "";
 	char *cainfo = getenv("SSL_CA_CERT_FILE"); /* matches fetch(3) */

--- a/lib/libzfs/libzfs_crypto.c
+++ b/lib/libzfs/libzfs_crypto.c
@@ -280,7 +280,7 @@ libzfs_getpassphrase(zfs_keyformat_t keyformat, boolean_t is_reenter,
     boolean_t new_key, const char *fsname,
     char **restrict res, size_t *restrict reslen)
 {
-	FILE *f = stdin;
+	FILE *stream = stdin;
 	size_t buflen = 0;
 	ssize_t bytes;
 	int ret = 0;
@@ -313,19 +313,19 @@ libzfs_getpassphrase(zfs_keyformat_t keyformat, boolean_t is_reenter,
 	(void) fflush(stdout);
 
 	/* disable the terminal echo for key input */
-	(void) tcgetattr(fileno(f), &old_term);
+	(void) tcgetattr(fileno(stream), &old_term);
 
 	new_term = old_term;
 	new_term.c_lflag &= ~(ECHO | ECHOE | ECHOK | ECHONL);
 
-	ret = tcsetattr(fileno(f), TCSAFLUSH, &new_term);
+	ret = tcsetattr(fileno(stream), TCSAFLUSH, &new_term);
 	if (ret != 0) {
 		ret = errno;
 		errno = 0;
 		goto out;
 	}
 
-	bytes = getline(res, &buflen, f);
+	bytes = getline(res, &buflen, stream);
 	if (bytes < 0) {
 		ret = errno;
 		errno = 0;
@@ -342,7 +342,7 @@ libzfs_getpassphrase(zfs_keyformat_t keyformat, boolean_t is_reenter,
 
 out:
 	/* reset the terminal */
-	(void) tcsetattr(fileno(f), TCSAFLUSH, &old_term);
+	(void) tcsetattr(fileno(stream), TCSAFLUSH, &old_term);
 	(void) sigaction(SIGINT, &osigint, NULL);
 	(void) sigaction(SIGTSTP, &osigtstp, NULL);
 
@@ -422,7 +422,7 @@ out:
 }
 
 static int
-get_key_material_raw(FILE *fd, zfs_keyformat_t keyformat,
+get_key_material_stream(FILE *stream, zfs_keyformat_t keyformat,
     uint8_t **buf, size_t *len_out)
 {
 	int ret = 0;
@@ -434,7 +434,7 @@ get_key_material_raw(FILE *fd, zfs_keyformat_t keyformat,
 	if (keyformat != ZFS_KEYFORMAT_RAW) {
 		ssize_t bytes;
 
-		bytes = getline((char **)buf, &buflen, fd);
+		bytes = getline((char **)buf, &buflen, stream);
 		if (bytes < 0) {
 			ret = errno;
 			errno = 0;
@@ -463,8 +463,8 @@ get_key_material_raw(FILE *fd, zfs_keyformat_t keyformat,
 			goto out;
 		}
 
-		n = fread(*buf, 1, WRAPPING_KEY_LEN + 1, fd);
-		if (n == 0 || ferror(fd)) {
+		n = fread(*buf, 1, WRAPPING_KEY_LEN + 1, stream);
+		if (n == 0 || ferror(stream)) {
 			/* size errors are handled by the calling function */
 			free(*buf);
 			*buf = NULL;
@@ -485,13 +485,13 @@ get_key_material_file(libzfs_handle_t *hdl, const char *uri,
     uint8_t **restrict buf, size_t *restrict len_out)
 {
 	(void) fsname, (void) newkey;
-	FILE *f = NULL;
+	FILE *stream = NULL;
 	int ret = 0;
 
 	if (strlen(uri) < 7)
 		return (EINVAL);
 
-	if ((f = fopen(uri + 7, "re")) == NULL) {
+	if ((stream = fopen(uri + 7, "re")) == NULL) {
 		ret = errno;
 		errno = 0;
 		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
@@ -499,9 +499,9 @@ get_key_material_file(libzfs_handle_t *hdl, const char *uri,
 		return (ret);
 	}
 
-	ret = get_key_material_raw(f, keyformat, buf, len_out);
+	ret = get_key_material_stream(stream, keyformat, buf, len_out);
 
-	(void) fclose(f);
+	(void) fclose(stream);
 
 	return (ret);
 }
@@ -513,7 +513,7 @@ get_key_material_https(libzfs_handle_t *hdl, const char *uri,
 {
 	(void) fsname, (void) newkey;
 	int ret = 0;
-	FILE *key = NULL;
+	FILE *stream = NULL;
 	boolean_t is_http = strncmp(uri, "http:", strlen("http:")) == 0;
 
 	if (strlen(uri) < (is_http ? 7 : 8)) {
@@ -570,8 +570,8 @@ get_key_material_https(libzfs_handle_t *hdl, const char *uri,
 #endif
 
 #if LIBFETCH_IS_FETCH
-	key = fetchGetURL(uri, "");
-	if (key == NULL) {
+	stream = fetchGetURL(uri, "");
+	if (stream == NULL) {
 		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
 		    "Couldn't GET %s: %s"),
 		    uri, fetchLastErrString);
@@ -616,7 +616,7 @@ get_key_material_https(libzfs_handle_t *hdl, const char *uri,
 #ifdef O_TMPFILE
 kfdok:
 #endif
-	if ((key = fdopen(kfd, "r+")) == NULL) {
+	if ((stream = fdopen(kfd, "r+")) == NULL) {
 		ret = errno;
 		(void) close(kfd);
 		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
@@ -632,7 +632,7 @@ kfdok:
 	(void) curl_easy_setopt(curl, CURLOPT_URL, uri);
 	(void) curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
 	(void) curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, 30000L);
-	(void) curl_easy_setopt(curl, CURLOPT_WRITEDATA, key);
+	(void) curl_easy_setopt(curl, CURLOPT_WRITEDATA, stream);
 	(void) curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, errbuf);
 	if (cainfo != NULL)
 		(void) curl_easy_setopt(curl, CURLOPT_CAINFO, cainfo);
@@ -660,7 +660,7 @@ kfdok:
 			    uri, resp);
 			ret = ENOENT;
 		} else
-			rewind(key);
+			rewind(stream);
 	}
 
 	curl_easy_cleanup(curl);
@@ -672,10 +672,10 @@ kfdok:
 
 end:
 	if (ret == 0)
-		ret = get_key_material_raw(key, keyformat, buf, len_out);
+		ret = get_key_material_stream(stream, keyformat, buf, len_out);
 
-	if (key != NULL)
-		fclose(key);
+	if (stream != NULL)
+		fclose(stream);
 
 	return (ret);
 }
@@ -714,7 +714,7 @@ get_key_material(libzfs_handle_t *hdl, boolean_t do_verify, boolean_t newkey,
 			    do_verify, newkey, &km, &kmlen);
 		} else {
 			/* fetch the key material into the buffer */
-			ret = get_key_material_raw(stdin, keyformat, &km,
+			ret = get_key_material_stream(stdin, keyformat, &km,
 			    &kmlen);
 		}
 


### PR DESCRIPTION
_[Sponsors: TrueNAS]_

### Motivation and Context

I was reading `libzfs_crypto.c` and saw tempfile stuff and thought, what is this?

For `keylocation=http[s]://...`, with libcurl, we open a tempfile and pass the `FILE*` to libcurl to replace its default of `stdout`. Once completed, we `rewind()` and then read the key material from it.

All the tempfile dances are fine, except that `TMPDIR` or the default `/tmp` may actually be on durable storage, in which case the key material may be written to the disk, even if the file is not linked.

Thankfully, it's pretty rare on Linux for `/tmp` to not be a `tmpfs`, but it's still not great.

### Description

Rework to use a buffer on the stack, and then `fmemopen` to create a `FILE*` over it. This is the smallest possible change I can think of to fix this without touching much else.

Though I have done some light renaming to make it clear we're operating on a stream and not a file descriptor or anything else, which was a little hard to follow before.

### How Has This Been Tested?

`zfs_load-key` and `zfs_change-key` exercised a few times on Linux, remainder of the test suite passed once.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
