### PR TITLE
dsl_deadlist: recover instead of panicking on a damaged deadlist

### DIFF
--- a/cmd/zhack.c
+++ b/cmd/zhack.c
@@ -47,6 +47,7 @@
 #include <sys/vdev_impl.h>
 #include <sys/fs/zfs.h>
 #include <sys/dmu_objset.h>
+#include <sys/dsl_dataset.h>
 #include <sys/dsl_pool.h>
 #include <sys/zio_checksum.h>
 #include <sys/zio_compress.h>
@@ -112,7 +113,11 @@ usage(void)
 	    "    <device> : path to vdev\n"
 	    "\n"
 	    "    metaslab leak <pool>\n"
-	    "        apply allocation map from zdb to specified pool\n");
+	    "        apply allocation map from zdb to specified pool\n"
+	    "\n"
+	    "    deadlist dup <pool> <snapshot>\n"
+	    "        inject a duplicate mintxg entry into a snapshot's "
+	    "deadlist\n");
 	exit(1);
 }
 
@@ -810,6 +815,100 @@ zhack_do_metaslab(int argc, char **argv)
 	return (0);
 }
 
+/*
+ * Inject a duplicate mintxg entry into a snapshot's deadlist ZAP, simulating
+ * the on-disk damage that trips the avl_add() panic in
+ * dsl_deadlist_load_tree() (issue #16685).  Deadlist keys are the hex string
+ * of the entry's mintxg (see FORMAT_INT_KEY / zfs_strtonum), so a second ZAP
+ * entry whose name is that hex string with a leading '0' decodes to the same
+ * mintxg while remaining a distinct ZAP name.  The injected entry reuses the
+ * bpobj of the entry it shadows so it points at a valid object.
+ */
+static void
+zhack_deadlist_dup_sync(void *arg, dmu_tx_t *tx)
+{
+	dsl_pool_t *dp = dmu_tx_pool(tx);
+	objset_t *mos = dp->dp_meta_objset;
+	const char *snapname = arg;
+	dsl_dataset_t *ds;
+	zap_cursor_t zc;
+	zap_attribute_t *za;
+	uint64_t dlobj, bpobj;
+	char dupname[32];
+
+	VERIFY0(dsl_dataset_hold(dp, snapname, FTAG, &ds));
+	dlobj = dsl_dataset_phys(ds)->ds_deadlist_obj;
+
+	za = zap_attribute_alloc();
+	zap_cursor_init(&zc, mos, dlobj);
+	if (zap_cursor_retrieve(&zc, za) != 0)
+		fatal(dp->dp_spa, FTAG, "deadlist %llu of %s is empty",
+		    (u_longlong_t)dlobj, snapname);
+
+	bpobj = za->za_first_integer;
+	(void) snprintf(dupname, sizeof (dupname), "0%s", za->za_name);
+	(void) fprintf(stderr, "injecting duplicate deadlist entry: object "
+	    "%llu, existing key '%s', duplicate key '%s' -> bpobj %llu\n",
+	    (u_longlong_t)dlobj, za->za_name, dupname, (u_longlong_t)bpobj);
+
+	VERIFY0(zap_add(mos, dlobj, dupname, sizeof (uint64_t), 1, &bpobj, tx));
+
+	zap_cursor_fini(&zc);
+	zap_attribute_free(za);
+	dsl_dataset_rele(ds, FTAG);
+
+	spa_history_log_internal(dp->dp_spa, "zhack deadlist dup", tx,
+	    "snapshot=%s", snapname);
+}
+
+static void
+zhack_do_deadlist_dup(int argc, char **argv)
+{
+	char *target, *snapshot;
+	spa_t *spa;
+
+	argc--;
+	argv++;
+	if (argc < 2) {
+		(void) fprintf(stderr, "error: missing pool or snapshot\n");
+		usage();
+	}
+	target = argv[0];
+	snapshot = argv[1];
+
+	zhack_spa_open(target, B_FALSE, FTAG, &spa);
+
+	VERIFY0(dsl_sync_task(spa_name(spa), NULL, zhack_deadlist_dup_sync,
+	    snapshot, 1, ZFS_SPACE_CHECK_NORMAL));
+
+	spa_close(spa, FTAG);
+}
+
+static int
+zhack_do_deadlist(int argc, char **argv)
+{
+	char *subcommand;
+
+	argc--;
+	argv++;
+	if (argc == 0) {
+		(void) fprintf(stderr,
+		    "error: no deadlist operation specified\n");
+		usage();
+	}
+
+	subcommand = argv[0];
+	if (strcmp(subcommand, "dup") == 0) {
+		zhack_do_deadlist_dup(argc, argv);
+	} else {
+		(void) fprintf(stderr, "error: unknown subcommand: %s\n",
+		    subcommand);
+		usage();
+	}
+
+	return (0);
+}
+
 #define	ASHIFT_UBERBLOCK_SHIFT(ashift)	\
 	MIN(MAX(ashift, UBERBLOCK_SHIFT), \
 	MAX_UBERBLOCK_SHIFT)
@@ -1376,6 +1475,8 @@ main(int argc, char **argv)
 		return (zhack_do_label(argc, argv));
 	} else if (strcmp(subcommand, "metaslab") == 0) {
 		rv = zhack_do_metaslab(argc, argv);
+	} else if (strcmp(subcommand, "deadlist") == 0) {
+		rv = zhack_do_deadlist(argc, argv);
 	} else {
 		(void) fprintf(stderr, "error: unknown subcommand: %s\n",
 		    subcommand);

--- a/include/sys/dsl_deadlist.h
+++ b/include/sys/dsl_deadlist.h
@@ -53,6 +53,7 @@ typedef struct dsl_deadlist {
 	avl_tree_t dl_cache; /* contains dsl_deadlist_cache_entry_t */
 	boolean_t dl_havetree;
 	boolean_t dl_havecache;
+	boolean_t dl_needrepair; /* stray names to delete (#16685) */
 	struct dmu_buf *dl_dbuf;
 	dsl_deadlist_phys_t *dl_phys;
 	kmutex_t dl_lock;

--- a/module/zfs/dsl_deadlist.c
+++ b/module/zfs/dsl_deadlist.c
@@ -130,6 +130,108 @@ dsl_deadlist_cache_compare(const void *arg1, const void *arg2)
 	return (TREE_CMP(dlce1->dlce_mintxg, dlce2->dlce_mintxg));
 }
 
+/*
+ * Set of mintxgs already folded in, used by dsl_deadlist_merge() to skip a
+ * second entry decoding to an already-merged mintxg when the source deadlist
+ * is damaged (see #16685).
+ */
+typedef struct dsl_deadlist_seen {
+	uint64_t	dds_mintxg;
+	avl_node_t	dds_node;
+} dsl_deadlist_seen_t;
+
+static int
+dsl_deadlist_seen_compare(const void *arg1, const void *arg2)
+{
+	const dsl_deadlist_seen_t *s1 = arg1;
+	const dsl_deadlist_seen_t *s2 = arg2;
+
+	return (TREE_CMP(s1->dds_mintxg, s2->dds_mintxg));
+}
+
+/*
+ * A deadlist entry is keyed by the canonical "%llx" rendering of its mintxg;
+ * that is the only form zap_add_int_key() ever writes.  zfs_strtonum() also
+ * decodes variant spellings (e.g. with a redundant leading '0') to the same
+ * mintxg, but those can only appear through on-disk damage (#16685).
+ */
+static boolean_t
+dsl_deadlist_name_canonical(const char *zapname, uint64_t mintxg)
+{
+	char name[20];
+
+	(void) snprintf(name, sizeof (name), "%llx", (longlong_t)mintxg);
+	return (strcmp(name, zapname) == 0);
+}
+
+/*
+ * A "stray" deadlist entry is a damage artifact: its ZAP name is a
+ * non-canonical rendering of a mintxg whose canonical entry also exists.
+ * Since a ZAP cannot hold two entries with the same name, when a canonical
+ * entry is present the other entry(ies) decoding to that mintxg are strays
+ * (#16685).  If the canonical name itself was damaged there may be no
+ * canonical entry; we conservatively treat none as stray in that case and
+ * leave the duplicate for the merge/free paths, which tolerate it directly.
+ */
+static boolean_t
+dsl_deadlist_entry_is_stray(objset_t *os, uint64_t dlobj,
+    const zap_attribute_t *za)
+{
+	char name[20];
+	uint64_t mintxg = zfs_strtonum(za->za_name, NULL);
+
+	(void) snprintf(name, sizeof (name), "%llx", (longlong_t)mintxg);
+	if (strcmp(name, za->za_name) == 0)
+		return (B_FALSE);
+	return (zap_contains(os, dlobj, name) == 0);
+}
+
+/*
+ * Delete from the deadlist ZAP the stray names found (and tolerated) by
+ * dsl_deadlist_load_tree(), which keeps only the canonically-named entry
+ * in-core and sets dl_needrepair.  Called from the first subsequent
+ * tx-carrying operation, this makes the damage self-healing; left on disk,
+ * a stray would end up pointing at a dangling object once an operation
+ * moves or frees the bpobj of its canonical twin.  Restart the scan after
+ * each removal rather than removing entries behind a live ZAP cursor.
+ */
+static void
+dsl_deadlist_repair(dsl_deadlist_t *dl, dmu_tx_t *tx)
+{
+	zap_attribute_t *za = zap_attribute_alloc();
+	boolean_t removed = B_TRUE;
+
+	ASSERT(MUTEX_HELD(&dl->dl_lock));
+
+	while (removed) {
+		zap_cursor_t zc;
+		int error;
+
+		removed = B_FALSE;
+		for (zap_cursor_init(&zc, dl->dl_os, dl->dl_object);
+		    (error = zap_cursor_retrieve(&zc, za)) == 0;
+		    zap_cursor_advance(&zc)) {
+			if (!dsl_deadlist_entry_is_stray(dl->dl_os,
+			    dl->dl_object, za))
+				continue;
+			zfs_dbgmsg("removing stray entry '%s' (mintxg %llu, "
+			    "bpobj %llu) from deadlist %llu", za->za_name,
+			    (u_longlong_t)zfs_strtonum(za->za_name, NULL),
+			    (u_longlong_t)za->za_first_integer,
+			    (u_longlong_t)dl->dl_object);
+			VERIFY0(zap_remove(dl->dl_os, dl->dl_object,
+			    za->za_name, tx));
+			removed = B_TRUE;
+			break;
+		}
+		if (!removed)
+			VERIFY3U(error, ==, ENOENT);
+		zap_cursor_fini(&zc);
+	}
+	zap_attribute_free(za);
+	dl->dl_needrepair = B_FALSE;
+}
+
 static void
 dsl_deadlist_load_tree(dsl_deadlist_t *dl)
 {
@@ -171,6 +273,45 @@ dsl_deadlist_load_tree(dsl_deadlist_t *dl)
 		dle->dle_mintxg = zfs_strtonum(za->za_name, NULL);
 
 		/*
+		 * A well-formed deadlist has exactly one entry per mintxg.
+		 * A duplicate means the on-disk deadlist ZAP is damaged: two
+		 * entries decode to the same mintxg, which the AVL tree can't
+		 * hold.  Historically avl_add() then tripped its assertion and
+		 * panicked the syncing thread on every load, wedging the whole
+		 * pool (#16685).  Report it instead, and when recovery is
+		 * enabled keep only the canonically-named entry (the one ZFS
+		 * really wrote) and mark the deadlist for repair, so that the
+		 * next tx-carrying operation deletes the stray name from disk.
+		 */
+		avl_index_t where;
+		dsl_deadlist_entry_t *found =
+		    avl_find(&dl->dl_tree, dle, &where);
+		if (found != NULL) {
+			zfs_panic_recover("zfs: duplicate mintxg %llu in "
+			    "deadlist %llu (bpobj %llu)",
+			    (u_longlong_t)dle->dle_mintxg,
+			    (u_longlong_t)dl->dl_object,
+			    (u_longlong_t)za->za_first_integer);
+			if (dsl_deadlist_name_canonical(za->za_name,
+			    dle->dle_mintxg)) {
+				/*
+				 * This entry is the canonical one, so the one
+				 * already in the tree is the stray; repoint
+				 * the kept node at this entry's bpobj (it is
+				 * opened in the second pass below).
+				 */
+				found->dle_bpobj.bpo_object =
+				    za->za_first_integer;
+				dmu_prefetch_dnode(dl->dl_os,
+				    found->dle_bpobj.bpo_object,
+				    ZIO_PRIORITY_SYNC_READ);
+			}
+			dl->dl_needrepair = B_TRUE;
+			kmem_free(dle, sizeof (*dle));
+			continue;
+		}
+
+		/*
 		 * Prefetch all the bpobj's so that we do that i/o
 		 * in parallel.  Then open them all in a second pass.
 		 */
@@ -178,7 +319,7 @@ dsl_deadlist_load_tree(dsl_deadlist_t *dl)
 		dmu_prefetch_dnode(dl->dl_os, dle->dle_bpobj.bpo_object,
 		    ZIO_PRIORITY_SYNC_READ);
 
-		avl_add(&dl->dl_tree, dle);
+		avl_insert(&dl->dl_tree, dle, where);
 	}
 	VERIFY3U(error, ==, ENOENT);
 	zap_cursor_fini(&zc);
@@ -235,13 +376,39 @@ dsl_deadlist_load_cache(dsl_deadlist_t *dl)
 		dlce->dlce_mintxg = zfs_strtonum(za->za_name, NULL);
 
 		/*
+		 * See the duplicate-mintxg handling in load_tree (#16685).
+		 * The cache is only used for space statistics and is
+		 * rebuilt on demand, so just keep the canonically-named
+		 * entry; the repair is left to load_tree.
+		 */
+		avl_index_t where;
+		dsl_deadlist_cache_entry_t *found =
+		    avl_find(&dl->dl_cache, dlce, &where);
+		if (found != NULL) {
+			zfs_panic_recover("zfs: duplicate mintxg %llu in "
+			    "deadlist %llu (bpobj %llu)",
+			    (u_longlong_t)dlce->dlce_mintxg,
+			    (u_longlong_t)dl->dl_object,
+			    (u_longlong_t)za->za_first_integer);
+			if (dsl_deadlist_name_canonical(za->za_name,
+			    dlce->dlce_mintxg)) {
+				found->dlce_bpobj = za->za_first_integer;
+				dmu_prefetch_dnode(dl->dl_os,
+				    found->dlce_bpobj,
+				    ZIO_PRIORITY_SYNC_READ);
+			}
+			kmem_free(dlce, sizeof (*dlce));
+			continue;
+		}
+
+		/*
 		 * Prefetch all the bpobj's so that we do that i/o
 		 * in parallel.  Then open them all in a second pass.
 		 */
 		dlce->dlce_bpobj = za->za_first_integer;
 		dmu_prefetch_dnode(dl->dl_os, dlce->dlce_bpobj,
 		    ZIO_PRIORITY_SYNC_READ);
-		avl_add(&dl->dl_cache, dlce);
+		avl_insert(&dl->dl_cache, dlce, where);
 	}
 	VERIFY3U(error, ==, ENOENT);
 	zap_cursor_fini(&zc);
@@ -326,6 +493,7 @@ dsl_deadlist_open(dsl_deadlist_t *dl, objset_t *os, uint64_t object)
 	dl->dl_phys = dl->dl_dbuf->db_data;
 	dl->dl_havetree = B_FALSE;
 	dl->dl_havecache = B_FALSE;
+	dl->dl_needrepair = B_FALSE;
 	return (0);
 }
 
@@ -403,6 +571,25 @@ dsl_deadlist_free(objset_t *os, uint64_t dlobj, dmu_tx_t *tx)
 	    (error = zap_cursor_retrieve(&zc, za)) == 0;
 	    zap_cursor_advance(&zc)) {
 		uint64_t obj = za->za_first_integer;
+
+		/*
+		 * A stray entry (#16685) typically references the same bpobj
+		 * as its canonical twin; freeing it here as well would
+		 * double-free that bpobj (or, had it referenced the empty
+		 * bpobj, over-decrement the feature refcount).  Skip it: the
+		 * ZAP entry goes away with the object freed below, and if the
+		 * stray referenced a distinct bpobj that object is
+		 * intentionally leaked rather than risk a double free (per
+		 * zfs_recover semantics).
+		 */
+		if (zfs_recover &&
+		    dsl_deadlist_entry_is_stray(os, dlobj, za)) {
+			zfs_panic_recover("zfs: duplicate mintxg %llu in "
+			    "deadlist %llu (bpobj %llu)",
+			    (u_longlong_t)zfs_strtonum(za->za_name, NULL),
+			    (u_longlong_t)dlobj, (u_longlong_t)obj);
+			continue;
+		}
 		if (obj == dmu_objset_pool(os)->dp_empty_bpobj)
 			bpobj_decr_empty(os, tx);
 		else
@@ -475,6 +662,8 @@ dsl_deadlist_insert(dsl_deadlist_t *dl, const blkptr_t *bp, boolean_t bp_freed,
 
 	mutex_enter(&dl->dl_lock);
 	dsl_deadlist_load_tree(dl);
+	if (dl->dl_needrepair)
+		dsl_deadlist_repair(dl, tx);
 
 	dmu_buf_will_dirty(dl->dl_dbuf, tx);
 
@@ -536,6 +725,8 @@ dsl_deadlist_add_key(dsl_deadlist_t *dl, uint64_t mintxg, dmu_tx_t *tx)
 
 	mutex_enter(&dl->dl_lock);
 	dsl_deadlist_load_tree(dl);
+	if (dl->dl_needrepair)
+		dsl_deadlist_repair(dl, tx);
 
 	obj = bpobj_alloc_empty(dl->dl_os, SPA_OLD_MAXBLOCKSIZE, tx);
 	VERIFY0(bpobj_open(&dle->dle_bpobj, dl->dl_os, obj));
@@ -559,6 +750,8 @@ dsl_deadlist_remove_key(dsl_deadlist_t *dl, uint64_t mintxg, dmu_tx_t *tx)
 		return;
 	mutex_enter(&dl->dl_lock);
 	dsl_deadlist_load_tree(dl);
+	if (dl->dl_needrepair)
+		dsl_deadlist_repair(dl, tx);
 
 	dle_tofind.dle_mintxg = mintxg;
 	dle = avl_find(&dl->dl_tree, &dle_tofind, NULL);
@@ -594,6 +787,8 @@ dsl_deadlist_remove_entry(dsl_deadlist_t *dl, uint64_t mintxg, dmu_tx_t *tx)
 
 	mutex_enter(&dl->dl_lock);
 	dsl_deadlist_load_tree(dl);
+	if (dl->dl_needrepair)
+		dsl_deadlist_repair(dl, tx);
 
 	dle_tofind.dle_mintxg = mintxg;
 	dle = avl_find(&dl->dl_tree, &dle_tofind, NULL);
@@ -814,6 +1009,25 @@ dsl_deadlist_insert_bpobj(dsl_deadlist_t *dl, uint64_t obj, uint64_t birth,
 
 	ASSERT(MUTEX_HELD(&dl->dl_lock));
 
+	/*
+	 * A damaged deadlist can hold a stray entry pointing at a bpobj that
+	 * no longer exists or that is no longer a bpobj -- e.g. a duplicate
+	 * whose twin was already consumed by an earlier operation and whose
+	 * object number has possibly been reused since.  Skip it under
+	 * recovery rather than tripping the assertions in bpobj_open()
+	 * (#16685).
+	 */
+	if (zfs_recover) {
+		dmu_object_info_t doi;
+		if (dmu_object_info(dl->dl_os, obj, &doi) != 0 ||
+		    doi.doi_type != DMU_OT_BPOBJ) {
+			zfs_panic_recover("zfs: deadlist %llu references "
+			    "invalid bpobj %llu", (u_longlong_t)dl->dl_object,
+			    (u_longlong_t)obj);
+			return;
+		}
+	}
+
 	VERIFY0(bpobj_open(&bpo, dl->dl_os, obj));
 	VERIFY0(bpobj_space(&bpo, &used, &comp, &uncomp));
 	bpobj_close(&bpo);
@@ -888,7 +1102,38 @@ dsl_deadlist_merge(dsl_deadlist_t *dl, uint64_t obj, dmu_tx_t *tx)
 	za = zap_attribute_alloc();
 	pza = zap_attribute_alloc();
 
+	/*
+	 * A damaged source deadlist can hold two entries that decode to the
+	 * same mintxg (#16685): the canonically-named one that ZFS really
+	 * wrote and a stray (see dsl_deadlist_entry_is_stray()).  Folding
+	 * both in would double-count and, since they typically reference the
+	 * same bpobj, double-free that bpobj.  Under recovery, fold in only
+	 * one entry per mintxg -- the canonical one, whichever order the ZAP
+	 * cursor returns them in -- and just delete the other name.  A healthy
+	 * source has exactly one entry per mintxg, so this would never skip
+	 * anything (in particular it must not dedup by bpobj: many healthy
+	 * entries share dp_empty_bpobj, and each fold of one must decrement
+	 * the SPA_FEATURE_EMPTY_BPOBJ refcount).  Without recovery none of
+	 * this machinery runs, so a healthy merge is bit-identical to the
+	 * historical code.
+	 */
+	boolean_t recover = zfs_recover;
+	avl_tree_t seen;
+	if (recover) {
+		avl_create(&seen, dsl_deadlist_seen_compare,
+		    sizeof (dsl_deadlist_seen_t),
+		    offsetof(dsl_deadlist_seen_t, dds_node));
+	}
+
 	mutex_enter(&dl->dl_lock);
+
+	/* If the target deadlist itself is damaged, repair it first. */
+	if (recover) {
+		dsl_deadlist_load_tree(dl);
+		if (dl->dl_needrepair)
+			dsl_deadlist_repair(dl, tx);
+	}
+
 	/*
 	 * Prefetch up to 128 deadlists first and then more as we progress.
 	 * The limit is a balance between ARC use and diminishing returns.
@@ -902,8 +1147,40 @@ dsl_deadlist_merge(dsl_deadlist_t *dl, uint64_t obj, dmu_tx_t *tx)
 	for (zap_cursor_init(&zc, dl->dl_os, obj);
 	    (error = zap_cursor_retrieve(&zc, za)) == 0;
 	    zap_cursor_advance(&zc)) {
-		dsl_deadlist_insert_bpobj(dl, za->za_first_integer,
-		    zfs_strtonum(za->za_name, NULL), tx);
+		uint64_t mintxg = zfs_strtonum(za->za_name, NULL);
+		boolean_t fold = B_TRUE;
+
+		if (recover) {
+			dsl_deadlist_seen_t seek = { .dds_mintxg = mintxg };
+			avl_index_t where;
+
+			if (dsl_deadlist_entry_is_stray(dl->dl_os, obj, za)) {
+				/* The stray precedes its canonical twin. */
+				fold = B_FALSE;
+			} else if (avl_find(&seen, &seek, &where) != NULL) {
+				/*
+				 * The canonical entry for this mintxg was
+				 * already folded in (and removed from the ZAP,
+				 * which is why the stray check above cannot
+				 * see it).
+				 */
+				fold = B_FALSE;
+			} else {
+				dsl_deadlist_seen_t *s = kmem_alloc(
+				    sizeof (*s), KM_SLEEP);
+				s->dds_mintxg = mintxg;
+				avl_insert(&seen, s, where);
+			}
+		}
+		if (fold) {
+			dsl_deadlist_insert_bpobj(dl, za->za_first_integer,
+			    mintxg, tx);
+		} else {
+			zfs_panic_recover("zfs: duplicate mintxg %llu in "
+			    "deadlist %llu (bpobj %llu)",
+			    (u_longlong_t)mintxg, (u_longlong_t)obj,
+			    (u_longlong_t)za->za_first_integer);
+		}
 		VERIFY0(zap_remove(dl->dl_os, obj, za->za_name, tx));
 		if (perror == 0) {
 			dsl_deadlist_prefetch_bpobj(dl, pza->za_first_integer,
@@ -915,6 +1192,14 @@ dsl_deadlist_merge(dsl_deadlist_t *dl, uint64_t obj, dmu_tx_t *tx)
 	VERIFY3U(error, ==, ENOENT);
 	zap_cursor_fini(&zc);
 	zap_cursor_fini(&pzc);
+
+	if (recover) {
+		void *cookie = NULL;
+		dsl_deadlist_seen_t *s;
+		while ((s = avl_destroy_nodes(&seen, &cookie)) != NULL)
+			kmem_free(s, sizeof (*s));
+		avl_destroy(&seen);
+	}
 
 	VERIFY0(dmu_bonus_hold(dl->dl_os, obj, FTAG, &bonus));
 	dlp = bonus->db_data;
@@ -944,6 +1229,8 @@ dsl_deadlist_move_bpobj(dsl_deadlist_t *dl, bpobj_t *bpo, uint64_t mintxg,
 	mutex_enter(&dl->dl_lock);
 	dmu_buf_will_dirty(dl->dl_dbuf, tx);
 	dsl_deadlist_load_tree(dl);
+	if (dl->dl_needrepair)
+		dsl_deadlist_repair(dl, tx);
 
 	dle_tofind.dle_mintxg = mintxg;
 	dle = avl_find(&dl->dl_tree, &dle_tofind, &where);

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -392,7 +392,8 @@ tags = ['functional', 'cli_root', 'zfs_wait']
 
 [tests/functional/cli_root/zhack]
 tests = ['zhack_label_repair_001', 'zhack_label_repair_002',
-    'zhack_label_repair_003', 'zhack_label_repair_004', 'zhack_metaslab_leak']
+    'zhack_label_repair_003', 'zhack_label_repair_004', 'zhack_metaslab_leak',
+    'zhack_deadlist_dup']
 pre =
 post =
 tags = ['functional', 'cli_root', 'zhack']

--- a/tests/zfs-tests/include/tunables.cfg
+++ b/tests/zfs-tests/include/tunables.cfg
@@ -79,6 +79,7 @@ READ_SIT_OUT_SECS		vdev.read_sit_out_secs		vdev_read_sit_out_secs
 SIT_OUT_CHECK_INTERVAL		vdev.raidz_outlier_check_interval_ms	vdev_raidz_outlier_check_interval_ms
 SIT_OUT_INSENSITIVITY		vdev.raidz_outlier_insensitivity	vdev_raidz_outlier_insensitivity
 REBUILD_SCRUB_ENABLED		rebuild_scrub_enabled		zfs_rebuild_scrub_enabled
+RECOVER				recover				zfs_recover
 REMOVAL_SUSPEND_PROGRESS	vdev.removal_suspend_progress	zfs_removal_suspend_progress
 REMOVE_MAX_SEGMENT		vdev.remove_max_segment		zfs_remove_max_segment
 RESILVER_MIN_TIME_MS		resilver_min_time_ms		zfs_resilver_min_time_ms

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1077,6 +1077,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zhack/zhack_label_repair_003.ksh \
 	functional/cli_root/zhack/zhack_label_repair_004.ksh \
 	functional/cli_root/zhack/zhack_metaslab_leak.ksh \
+	functional/cli_root/zhack/zhack_deadlist_dup.ksh \
 	functional/cli_root/zpool_add/add_nested_replacing_spare.ksh \
 	functional/cli_root/zpool_add/add-o_ashift.ksh \
 	functional/cli_root/zpool_add/add_prop_ashift.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zhack/zhack_deadlist_dup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zhack/zhack_deadlist_dup.ksh
@@ -1,0 +1,133 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2026 by MorganaFuture. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# A deadlist ZAP that has been damaged so two entries decode to the same
+# mintxg used to trip an assertion in dsl_deadlist_load_tree() (avl_add) and
+# panic the syncing thread, wedging the pool on import and on snapshot
+# destroy (#16685).  With the recovery tunable (zfs_recover) enabled the
+# canonically-named entry is kept, the stray name is deleted from disk, and
+# the pool remains usable instead.
+#
+# STRATEGY:
+# For each destroy ordering (damaged snapshot's neighbor first, damaged
+# snapshot itself first), on a fresh pool:
+# 1. Create a pool on a file vdev and churn a dataset so a middle snapshot's
+#    deadlist holds real entries.
+# 2. Export the pool and inject a duplicate mintxg entry into that snapshot's
+#    deadlist with "zhack deadlist dup".
+# 3. With zfs_recover enabled, import the pool and destroy the snapshots in
+#    the given order, confirming each destroy recovers rather than panicking
+#    and the pool stays healthy and writable.
+# 4. Verify with zdb that the recovered pool's deadlists load cleanly and
+#    no blocks were leaked or double-freed.
+#
+
+verify_runnable "global"
+
+# Keep the vdev in its own directory: the leak check below runs
+# "zdb -e -p <dir>", which scans every label in <dir> and matches pools by
+# name.  $TEST_BASE_DIR is shared with the test suite's own file vdevs (which
+# back a pool also named $TESTPOOL), so pointing zdb at it would find more than
+# one matching pool and fail before checking anything.
+typeset VDEVDIR=$TEST_BASE_DIR/zhack_deadlist_dup
+typeset VDEV=$VDEVDIR/vdev
+typeset FS=$TESTPOOL/fs
+typeset saved_recover=""
+
+function cleanup
+{
+	[[ -n $saved_recover ]] && set_tunable32 RECOVER $saved_recover
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
+	rm -rf $VDEVDIR
+}
+
+log_assert "A duplicate mintxg in a deadlist is recovered instead of panicking"
+log_onexit cleanup
+
+# Enable recovery so a damaged deadlist is repaired rather than panicking
+# the pool.  The default (fatal) behavior is intentionally left unchanged,
+# so recovery must be requested explicitly.
+saved_recover=$(get_tunable RECOVER)
+log_must set_tunable32 RECOVER 1
+
+# test_order <first snapshot to destroy> <second snapshot to destroy>
+function test_order
+{
+	typeset first=$1
+	typeset second=$2
+
+	log_must mkdir -p $VDEVDIR
+	log_must truncate -s 512M $VDEV
+	log_must zpool create $TESTPOOL $VDEV
+	log_must zfs create $FS
+
+	# Churn (write, snapshot, free) so snap2's deadlist has real entries.
+	for i in 1 2 3; do
+		log_must dd if=/dev/urandom of=/$FS/f bs=1M count=8
+		log_must zpool sync $TESTPOOL
+		log_must zfs snapshot $FS@snap$i
+		log_must rm -f /$FS/f
+	done
+	log_must zpool sync $TESTPOOL
+
+	log_must zpool export $TESTPOOL
+
+	# Inject a second deadlist entry whose name decodes to an existing
+	# mintxg of snap2's deadlist.
+	log_must zhack -d $VDEV deadlist dup $TESTPOOL $FS@snap2
+
+	log_must zpool import -d $VDEV $TESTPOOL
+
+	# Destroying the neighbor loads snap2's damaged deadlist via
+	# dsl_deadlist_move_bpobj(), which must recover, keep the canonical
+	# entry, and delete the stray name from disk.  Destroying snap2
+	# itself merges its damaged deadlist (dsl_deadlist_merge), which
+	# must fold in only the canonical entry.  Both orderings must
+	# succeed rather than panic the syncing thread.
+	log_must zfs destroy $FS@$first
+	log_must zfs destroy $FS@$second
+	log_must datasetexists $FS@snap3
+
+	# The pool and the remaining snapshot must still be intact and
+	# writable.
+	log_must dd if=/dev/urandom of=/$FS/after bs=1M count=4
+	log_must zpool sync $TESTPOOL
+	log_must check_state $TESTPOOL "" "ONLINE"
+	log_must eval "zpool status -x $TESTPOOL | grep -q 'is healthy'"
+
+	# The damage must be gone from disk: zdb loads every deadlist (a
+	# surviving stray would reference a dangling object and fail), and
+	# the leak check confirms nothing was leaked or double-freed.
+	log_must zpool export $TESTPOOL
+	log_must eval "zdb -e -p $VDEVDIR -b $TESTPOOL | \
+	    grep -q 'No leaks'"
+
+	log_must zpool import -d $VDEV $TESTPOOL
+	log_must destroy_pool $TESTPOOL
+	log_must rm -rf $VDEVDIR
+}
+
+# (a) destroy the damaged snapshot's neighbor first, then the snapshot itself
+test_order snap1 snap2
+# (b) destroy the damaged snapshot first
+test_order snap2 snap1
+
+log_pass "A duplicate mintxg in a deadlist is recovered instead of panicking"


### PR DESCRIPTION
### Motivation and Context

Fixes #16685. On a pool whose deadlist ZAP is damaged so that two entries
decode to the same mintxg, `dsl_deadlist_load_tree()` feeds the duplicate to
`avl_add()`, whose `VERIFY(avl_find(...) == NULL)` then panics the syncing
thread. The failing deadlist is loaded on every import and on every attempt to
destroy the affected snapshot, so the pool becomes unusable and the panic
recurs (the reporter hit it during an ordinary `zfs destroy` of an
auto-snapshot; the same signature is tracked in illumos #15306).

The in-tree deadlist mutators can't create such a duplicate — each keys
strictly by mintxg and `zap_add_int_key()` would return `EEXIST` first — so it
is pre-existing on-disk damage that only surfaces once the deadlist is fully
loaded.

Note this addresses the original (FreeBSD, `dsl_deadlist`) panic from #16685.
The Linux `zfsctl_snapshot_mount` automount panic later attached to the same
issue is a separate bug, already fixed by #17943.

### Description

Recovery is deterministic, fatal by default, and enabled by the existing
`zfs_recover` tunable, following the precedent of the damaged-`blk_birth`
handling already in `dsl_deadlist_insert()`. The key observation is that
`zap_add_int_key()` only ever writes the canonical `"%llx"` rendering of a
mintxg, and a ZAP cannot hold two entries with the same name, so when a
canonical entry is present the other entry decoding to that mintxg is a stray.

- `dsl_deadlist_load_tree()` / `_load_cache()` keep the canonically-named entry
  (whichever order the ZAP cursor returns the pair in) and drop the stray from
  the in-core tree, so the kept entry always opens a valid bpobj.
- `load_tree()` also flags the deadlist for repair; the next tx-carrying
  operation deletes the stray name from the ZAP, so the damage self-heals.
  Left on disk the stray would dangle once its canonical twin's bpobj is moved
  or freed.
- `dsl_deadlist_merge()` folds in only one entry per mintxg. Deduplication is
  by mintxg, never by bpobj: many healthy entries share `dp_empty_bpobj` and
  each fold must decrement the `SPA_FEATURE_EMPTY_BPOBJ` refcount.
- `dsl_deadlist_free()` skips strays, and `dsl_deadlist_insert_bpobj()`
  tolerates an entry whose object is missing or is not a bpobj.

All recovery paths are gated behind `zfs_recover`, so with the default
`zfs_recover=0` the touched functions execute the historical instructions and
healthy pools are unaffected. The stray's space may be leaked (per
`zfs_recover` semantics); in the common case it aliases its twin's bpobj and
nothing is lost.

A `zhack deadlist dup` subcommand injects the colliding entry so the behavior
can be exercised in a test.

### How Has This Been Tested?

New ZTS test `functional/cli_root/zhack/zhack_deadlist_dup` injects a duplicate
into a snapshot's deadlist and destroys the damaged snapshot both after a
neighbor and directly, asserting the pool stays healthy and `zdb -b` reports no
leaks.

Manually in a VM (debug build): the unpatched module panics at `avl_add()` and
wedges `txg_sync`; with this change and `zfs_recover=1` both destroy orderings
succeed and `zdb -b` reports "No leaks". A broad healthy-pool workload
(snapshots, clones/promote, send/recv, scrub, filesystem destroy) is
bit-identical to an unpatched module — same `zdb -b` verdict and the same
`com.delphix:empty_bpobj` refcount — with `zfs_recover=0`.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] My code follows the OpenZFS code style requirements.
- [x] I have run the ZFS Test Suite with my changes.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
