### PR TITLE
added new scheduler option WRONLY which mean scheduling on write only

### DIFF
--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -487,11 +487,13 @@ typedef enum {
  * VDEV_SCHEDULER_AUTO = Let ZFS decide - currently use scheduler on HDDs only.
  * VDEV_SCHEDULER_ON = Always queue.
  * VDEV_SCHEDULER_OFF = Never queue.
+ * VDEV_SCHEDULER_WRONLY = Queue writes, bypass others.
  */
 typedef enum {
 	VDEV_SCHEDULER_AUTO,
 	VDEV_SCHEDULER_ON,
-	VDEV_SCHEDULER_OFF
+	VDEV_SCHEDULER_OFF,
+	VDEV_SCHEDULER_WRONLY
 } vdev_scheduler_type_t;
 
 /*

--- a/module/zcommon/zpool_prop.c
+++ b/module/zcommon/zpool_prop.c
@@ -391,6 +391,7 @@ vdev_prop_init(void)
 		{ "auto",	VDEV_SCHEDULER_AUTO },
 		{ "on",		VDEV_SCHEDULER_ON },
 		{ "off",	VDEV_SCHEDULER_OFF },
+		{ "wronly",	VDEV_SCHEDULER_WRONLY },
 		{ NULL }
 	};
 
@@ -568,7 +569,7 @@ vdev_prop_init(void)
 	    "SLOW_IO_EVENTS", boolean_table, sfeatures);
 	zprop_register_index(VDEV_PROP_SCHEDULER, "scheduler",
 	    VDEV_SCHEDULER_AUTO, PROP_DEFAULT, ZFS_TYPE_VDEV,
-	    "auto | on | off", "IO_SCHEDULER",
+	    "auto | on | off | wronly", "IO_SCHEDULER",
 	    vdevschedulertype_table, sfeatures);
 	zprop_register_index(VDEV_PROP_ALLOC_BIAS, "alloc_bias",
 	    VDEV_BIAS_NONE, PROP_DEFAULT, ZFS_TYPE_VDEV,

--- a/module/zfs/vdev_queue.c
+++ b/module/zfs/vdev_queue.c
@@ -904,6 +904,9 @@ vdev_should_queue_io(zio_t *zio)
 	case VDEV_SCHEDULER_OFF:
 		should_queue = B_FALSE;
 		break;
+	case VDEV_SCHEDULER_WRONLY:
+		should_queue = (zio->io_type == ZIO_TYPE_WRITE);
+		break;
 	default:
 		should_queue = B_TRUE;
 		break;

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -1023,6 +1023,10 @@ tests = ['scrub_mirror_001_pos', 'scrub_mirror_002_pos',
     'scrub_mirror_003_pos', 'scrub_mirror_004_pos']
 tags = ['functional', 'scrub_mirror']
 
+[tests/functional/scheduler]
+tests = ['scheduler_001_pos']
+tags = ['functional', 'scheduler']
+
 [tests/functional/send_xdr_encoding]
 tests = ['xdr_bookmark_raw', 'xdr_bookmark_raw_with_write',
     'xdr_incr_from_bookmark', 'xdr_incr_from_redacted', 'xdr_raw',

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -377,6 +377,7 @@ nobase_dist_datadir_zfs_tests_tests_DATA += \
 	functional/rsend/rsend.kshlib \
 	functional/scrub_mirror/default.cfg \
 	functional/scrub_mirror/scrub_mirror_common.kshlib \
+	functional/scheduler/scheduler.cfg \
 	functional/send_xdr_encoding/send_xdr_encoding.cfg \
 	functional/send_xdr_encoding/send_xdr_encoding.kshlib \
 	functional/slog/slog.cfg \
@@ -2178,6 +2179,9 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/scrub_mirror/scrub_mirror_003_pos.ksh \
 	functional/scrub_mirror/scrub_mirror_004_pos.ksh \
 	functional/scrub_mirror/setup.ksh \
+	functional/scheduler/cleanup.ksh \
+	functional/scheduler/scheduler_001_pos.ksh \
+	functional/scheduler/setup.ksh \
 	functional/send_xdr_encoding/cleanup.ksh \
 	functional/send_xdr_encoding/setup.ksh \
 	functional/send_xdr_encoding/xdr_bookmark_raw.ksh \

--- a/tests/zfs-tests/tests/functional/scheduler/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/scheduler/cleanup.ksh
@@ -1,0 +1,22 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2026, tiehexue <tiehexue@hotmail.com>. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+default_cleanup_noexit
+log_pass

--- a/tests/zfs-tests/tests/functional/scheduler/scheduler.cfg
+++ b/tests/zfs-tests/tests/functional/scheduler/scheduler.cfg
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2026, tiehexue <tiehexue@hotmail.com>. All rights reserved.
+#
+
+# Default test file size (bytes) — 256 MiB
+export SCHEDULER_FILESIZE=268435456
+
+# Default block size (bytes) — 128 KiB
+export SCHEDULER_BS=131072
+
+# Human-readable versions for fio and dd
+export SCHEDULER_FILESIZE_HR="256M"
+export SCHEDULER_BS_HR="128K"

--- a/tests/zfs-tests/tests/functional/scheduler/scheduler_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/scheduler/scheduler_001_pos.ksh
@@ -1,0 +1,332 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2026, tiehexue <tiehexue@hotmail.com>. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/scheduler/scheduler.cfg
+
+#
+# DESCRIPTION:
+#	Benchmark all 4 vdev scheduler modes (auto, off, on, wronly) for
+#	read, write, randread, randwrite, randrw workloads using fio
+#	(iodepth=64, 30s). Compare IOPS and show the impact of each
+#	scheduling policy.
+#
+# STRATEGY:
+#	1. For each scheduler mode (auto, off, on, wronly):
+#	   Set mode on all leaf vdevs, then run 4 workloads × 30s each.
+#	2. Print a 4-way summary table with percentage changes vs auto.
+#
+
+verify_runnable "global"
+
+typeset -r IODEPTH=64
+typeset -r RUNTIME=10
+
+#
+# Auto-detect the best async I/O engine available on this platform.
+# Prefer libaio (Linux), fall back to posixaio (FreeBSD), then psync.
+#
+typeset IOENGINE
+if fio --enghelp 2>/dev/null | grep -q 'libaio'; then
+	IOENGINE="libaio"
+elif fio --enghelp 2>/dev/null | grep -q 'posixaio'; then
+	IOENGINE="posixaio"
+else
+	IOENGINE="psync"
+fi
+
+
+#
+# Run a Direct I/O fio benchmark and return IOPS.
+#
+# $1: mountpoint
+# $2: rw type (read, write, randread, randwrite)
+# $3: test filename
+# $4: label suffix
+#
+# Returns IOPS on stdout (field 8 for reads, field 49 for writes).
+#
+function bench_iops
+{
+	typeset mntpnt=$1
+	typeset rw=$2
+	typeset filename=$3
+	typeset label=$4
+
+	typeset field
+	case "$rw" in
+	read|randread)
+		field=8     # read IOPS in fio minimal output
+		;;
+	write|randwrite)
+		field=49    # write IOPS in fio minimal output
+		;;
+	randrw)
+		# total IOPS = read + write; capture both and sum below
+		;;
+	*)
+		log_fail "Unknown rw type: $rw"
+		;;
+	esac
+
+	typeset iops
+	if [[ "$rw" == "randrw" ]]; then
+		# fio minimal: field 8 = read IOPS, field 49 = write IOPS
+		typeset line
+		line=$(fio --filename="$filename" --name="$label" \
+		    --rw="$rw" --rwmixread=50 \
+		    --bs="$SCHEDULER_BS_HR" --size="$SCHEDULER_FILESIZE_HR" \
+		    --direct=1 --numjobs=1 --iodepth=$IODEPTH \
+		    --ioengine=$IOENGINE --fallocate=none \
+		    --group_reporting --minimal --runtime=$RUNTIME --time_based \
+		    2>/dev/null | grep ';')
+		typeset riops wops
+		riops=$(echo "$line" | cut -d';' -f8)
+		wops=$(echo "$line" | cut -d';' -f49)
+		iops=$(( riops + wops ))
+	else
+		iops=$(fio --filename="$filename" --name="$label" \
+		    --rw="$rw" --bs="$SCHEDULER_BS_HR" --size="$SCHEDULER_FILESIZE_HR" \
+		    --direct=1 --numjobs=1 --iodepth=$IODEPTH \
+		    --ioengine=$IOENGINE --fallocate=none \
+		    --group_reporting --minimal --runtime=$RUNTIME --time_based \
+		    2>/dev/null | grep ';' | cut -d';' -f$field)
+	fi
+
+	echo "$iops"
+}
+
+#
+# Pre-create a test file with sequential writes (buffered, for read tests).
+#
+function create_read_file
+{
+	typeset filepath=$1
+	# Use /dev/zero — fast, content irrelevant for IOPS benchmarking
+	dd if=/dev/zero of="$filepath" bs="$SCHEDULER_BS_HR" \
+	    count=$((SCHEDULER_FILESIZE / SCHEDULER_BS)) 2>/dev/null
+}
+
+function cleanup
+{
+	# Pool may already be destroyed during bench phases; ignore errors
+	destroy_pool $TESTPOOL 2>/dev/null
+	rm -f /var/tmp/sched_test*
+}
+
+log_assert "Benchmark all 4 vdev scheduler modes (auto/off/on/wronly)"
+
+log_onexit cleanup
+
+if ! is_linux && ! is_freebsd; then
+	log_note "vdev scheduler test requires Linux or FreeBSD"; log_pass
+fi
+
+log_note "Using fio ioengine: $IOENGINE"
+
+#
+# Destroy and recreate the pool fresh for each scheduler phase,
+# so pool aging/fragmentation does not skew IOPS comparisons.
+#
+function recreate_pool
+{
+	# Tear down previous pool if it exists
+	destroy_pool $TESTPOOL 2>/dev/null
+	log_must zpool create -f $TESTPOOL raidz $DISKS
+	log_must zfs create $TESTPOOL/$TESTFS
+	log_must zfs set compression=off $TESTPOOL/$TESTFS
+	log_must zfs set recordsize=$SCHEDULER_BS_HR $TESTPOOL/$TESTFS
+	log_must zfs set atime=off $TESTPOOL/$TESTFS
+	log_must zfs set xattr=sa $TESTPOOL/$TESTFS
+}
+
+#
+# Set scheduler on all leaf vdevs (uses global $TESTPOOL).
+#
+function set_all_vdev_scheduler
+{
+	typeset value=$1
+	typeset vdev
+	set -A VDEVS $(get_disklist_fullpath $TESTPOOL)
+	for vdev in "${VDEVS[@]}"; do
+		log_must zpool set scheduler=$value $TESTPOOL $vdev
+	done
+	log_note "Set scheduler=$value on all ${#VDEVS[*]} vdev(s)"
+}
+
+# Verify scheduler property is supported on first vdev
+set -A _vdevs $(get_disklist_fullpath $TESTPOOL)
+if ! zpool get scheduler $TESTPOOL ${_vdevs[0]} > /dev/null 2>&1; then
+	log_note "vdev scheduler property not supported on this platform"
+	log_pass
+fi
+
+# Destroy the setup pool and reload the zfs module for a pristine kernel state.
+# Benchmarks recreate their own pools; this just resets any accumulated
+# kernel-internal counters, slab caches, and vdev state from prior tests.
+destroy_pool $TESTPOOL 2>/dev/null
+if is_linux; then
+	if modprobe -r zfs 2>/dev/null; then
+		log_must modprobe zfs
+		log_note "Reloaded zfs kernel module — clean slate"
+	else
+		log_note "Could not unload zfs module (in use); continuing anyway"
+	fi
+elif is_freebsd; then
+	if kldunload openzfs 2>/dev/null; then
+		log_must kldload openzfs
+		log_note "Reloaded zfs kernel module — clean slate"
+	else
+		log_note "Could not unload zfs module (in use); continuing anyway"
+	fi
+fi
+
+# Workload definitions
+typeset -a workload_names workload_rw workload_needs_file
+set -A workload_names  "seq-read"  "seq-write"  "rand-read"  "rand-write"  "rand-rw"
+set -A workload_rw     "read"      "write"      "randread"   "randwrite"   "randrw"
+set -A workload_file_needed 1 0 1 0 1
+
+# Results: [workload_index] = IOPS value
+typeset -a iops_sched_auto iops_sched_off iops_sched_on iops_sched_wronly
+
+#
+# Helper: run all 4 workloads under a given scheduler mode, store IOPS.
+# Destroys and recreates the pool first to ensure a clean starting state.
+#
+function bench_scheduler_mode
+{
+	typeset mode_label=$1    # e.g. "auto"
+	typeset mode_value=$2    # e.g. "auto"
+	typeset result_array=$3  # name of the result array
+
+	typeset -n results=$result_array
+
+	log_note ""
+	log_note "============================================================"
+	log_note " Phase: scheduler = $mode_label  (fresh pool)"
+	log_note "============================================================"
+
+	recreate_pool
+	set_all_vdev_scheduler $mode_value
+	log_must zpool sync $TESTPOOL
+
+	typeset mntpnt
+	mntpnt=$(get_prop mountpoint $TESTPOOL/$TESTFS)
+
+	typeset i=0
+	while (( i < ${#workload_names[*]} )); do
+		wl_name=${workload_names[$i]}
+		wl_rw=${workload_rw[$i]}
+		need_file=${workload_file_needed[$i]}
+		testfile="$mntpnt/sched_test_${mode_label}_${wl_name}"
+
+		log_note ""
+		log_note "--- scheduler=$mode_label  workload=$wl_name  rw=$wl_rw ---"
+
+		if (( need_file )); then
+			log_note "Pre-creating test file ($SCHEDULER_FILESIZE_HR)..."
+			create_read_file "$testfile"
+			log_must zpool sync $TESTPOOL
+		fi
+
+		typeset iops_val
+		iops_val=$(bench_iops "$mntpnt" "$wl_rw" "$testfile" \
+		    "${mode_label}-${wl_name}")
+		results[$i]=$iops_val
+		log_note "  IOPS (scheduler=$mode_label): $iops_val"
+
+		rm -f "$testfile"
+		(( i++ ))
+	done
+}
+
+# ---- Run benchmarks (wronly first so it gets the freshest host state) ----
+bench_scheduler_mode "wronly" "wronly" iops_sched_wronly
+bench_scheduler_mode "on"     "on"     iops_sched_on
+bench_scheduler_mode "off"    "off"    iops_sched_off
+bench_scheduler_mode "auto"   "auto"   iops_sched_auto
+
+# ---- Summary Table (4-way comparison, baseline=auto) ----
+log_note ""
+log_note "=========================================================================="
+log_note " IOPS Comparison Summary (each phase on a fresh pool)"
+log_note "   Phase order: wronly → on → off → auto"
+log_note "   engine=$IOENGINE  iodepth=$IODEPTH  runtime=${RUNTIME}s  bs=$SCHEDULER_BS_HR"
+log_note "   disks: $DISKS"
+log_note "=========================================================================="
+log_note ""
+printf "  %-12s  %8s  %8s  %8s  %8s  %8s  %8s  %8s\n" \
+    "WORKLOAD" "AUTO" "OFF" "ON" "WRONLY" "offΔ%" "onΔ%" "wrΔ%"
+printf "  %-12s  %8s  %8s  %8s  %8s  %8s  %8s  %8s\n" \
+    "------------" "--------" "--------" "--------" "--------" "--------" "--------" "--------"
+
+function calc_pct
+{
+	typeset new=$1 base=$2
+	if [[ -n "$new" && -n "$base" ]] && (( base > 0 )); then
+		awk "BEGIN { printf \"%+.1f\", ($new - $base) * 100.0 / $base }"
+	else
+		echo "N/A"
+	fi
+}
+
+i=0
+while (( i < ${#workload_names[*]} )); do
+	wl_name=${workload_names[$i]}
+	auto_v=${iops_sched_auto[$i]:-"N/A"}
+	off_v=${iops_sched_off[$i]:-"N/A"}
+	on_v=${iops_sched_on[$i]:-"N/A"}
+	wr_v=${iops_sched_wronly[$i]:-"N/A"}
+
+	off_d=$(calc_pct "$off_v" "$auto_v")
+	on_d=$(calc_pct "$on_v" "$auto_v")
+	wr_d=$(calc_pct "$wr_v" "$auto_v")
+
+	printf "  %-12s  %8s  %8s  %8s  %8s  %7s%%  %7s%%  %7s%%\n" \
+	    "$wl_name" "$auto_v" "$off_v" "$on_v" "$wr_v" "$off_d" "$on_d" "$wr_d"
+	(( i++ ))
+done
+
+log_note ""
+log_note "=========================================================================="
+log_note " Scheduler mode behavior:"
+log_note "   auto  : Original ZFS default — queue on HDD, bypass on SSD."
+log_note "           For loop devices (non-rotational), auto = bypass."
+log_note "   off   : Bypasses vdev_queue entirely.  No lock, no tree, no"
+log_note "           aggregation.  Best raw IOPS for reads."
+log_note "   on    : Full vdev_queue: LBA ordering, aggregation, concurrency"
+log_note "           caps.  Write aggregation can merge adjacent I/Os."
+log_note "   wronly : Write-only queue — per-I/O-type decision:"
+log_note "           - Reads  → bypass (like off, zero queue overhead)"
+log_note "           - Writes → queue  (like on,  write aggregation benefit)"
+log_note "           - TRIM   → bypass"
+log_note ""
+log_note "   Ideal result: wronly reads ≈ off reads, wronly writes ≈ on writes."
+log_note "=========================================================================="
+
+log_pass "vdev scheduler 4-mode IOPS benchmark completed"

--- a/tests/zfs-tests/tests/functional/scheduler/setup.ksh
+++ b/tests/zfs-tests/tests/functional/scheduler/setup.ksh
@@ -1,0 +1,34 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2026, tiehexue <tiehexue@hotmail.com>. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/scheduler/scheduler.cfg
+
+#
+# Create a test pool with suitable settings for scheduler benchmarking:
+# - compression=off: avoid compression overhead
+# - recordsize=128k: match fio block size for aligned I/O
+# - atime=off: avoid atime updates during reads
+# - xattr=sa: avoid xattr indirection
+#
+default_raidz_setup_noexit "$DISKS"
+log_must zfs set compression=off $TESTPOOL/$TESTFS
+log_must zfs set recordsize=$SCHEDULER_BS_HR $TESTPOOL/$TESTFS
+log_must zfs set atime=off $TESTPOOL/$TESTFS
+log_must zfs set xattr=sa $TESTPOOL/$TESTFS
+log_pass


### PR DESCRIPTION
### Motivation and Context
When I am working on #18684 which try to bring "true async" I/O in zfs linux, the write IOPS is only 50% up which is not good comparing to 5x read IOPS up. So by digging into several ways, like merging in ZPL/DMU/ZIO, and go to vdev_queue.c.

So we have on/off/auto scheduler, and adding another scheduler is quite easy. In theory, merging write IO should see better IOPS. A test is added to verify if any distinct difference, and the result show YES. There should be some workload, in some specific hardware, bypass read, and queue the write will be a best policy, so I made this PR.

### Description
Added new scheduling policy, and test in various combination as following. The PR is checkout from latest master branch. There are a lot to say based on results, first of all, it is based on ZTS framework which creating file-backed loop raidz device. It is not a "formal" testing env with real hardware. However, the "distinction" of performance is worth for adding this new policy.

Some hints: 1) the test case always run WRONLY first, and destroy the pool, reload the kernel. It is believed the first run will have better IOPS, likely 5%. And decreasing this bias, the result is still meaningful; 2) with "true async", the result is a lot better; 3) FreeBSD has very high read IOPS, since md devices are memory based and ARC, and still there is difference; 4) the result is not so "stable", but, again, it does bring different performance.

NOTE:  IOPS Comparison Summary (each phase on a fresh pool)
NOTE:    Phase order: wronly → on → off → auto
NOTE:    engine=libaio  iodepth=64  runtime=10s  bs=128K
NOTE:    disks: loop0 loop1 loop2

# Linux posixaio
```markdown
| WORKLOAD  | AUTO  | OFF   | ON    | WRONLY | offΔ%  | onΔ%   | wrΔ%   |
|-----------|-------|-------|-------|--------|--------|--------|--------|
| seq-read  | 4463  | 4473  | 4577  | 4862   | +0.2%  | +2.6%  | +8.9%  |
| seq-write | 1696  | 1777  | 1959  | 2306   | +4.8%  | +15.5% | +36.0% |
| rand-read | 3764  | 4665  | 4437  | 4992   | +23.9% | +17.9% | +32.6% |
| rand-write| 1723  | 1666  | 1821  | 1987   | -3.3%  | +5.7%  | +15.3% |
| rand-rw   | 2475  | 2300  | 2465  | 2673   | -7.1%  | -0.4%  | +8.0%  |
```

# Linux libaio
```markdown
| WORKLOAD  | AUTO  | OFF   | ON    | WRONLY | offΔ%   | onΔ%   | wrΔ%   |
|-----------|-------|-------|-------|--------|---------|--------|--------|
| seq-read  | 4597  | 4774  | 4479  | 4498   | +3.9%   | -2.6%  | -2.2%  |
| seq-write | 1734  | 1708  | 1875  | 2174   | -1.5%   | +8.1%  | +25.4% |
| rand-read | 4733  | 4068  | 4383  | 4263   | -14.1%  | -7.4%  | -9.9%  |
| rand-write| 1625  | 1683  | 1693  | 2062   | +3.6%   | +4.2%  | +26.9% |
| rand-rw   | 2508  | 2362  | 2513  | 2500   | -5.8%   | +0.2%  | -0.3%  |
```

# Linux libaio + true async PR (#18684)
```markdown
| WORKLOAD  | AUTO   | OFF    | ON     | WRONLY | offΔ%   | onΔ%   | wrΔ%   |
|-----------|--------|--------|--------|--------|---------|--------|--------|
| seq-read  | 57473  | 66197  | 53838  | 73673  | +15.2%  | -6.3%  | +28.2% |
| seq-write | 4996   | 2878   | 5525   | 5865   | -42.4%  | +10.6% | +17.4% |
| rand-read | 33163  | 59953  | 36307  | 61163  | +80.8%  | +9.5%  | +84.4% |
| rand-write| 5093   | 2437   | 4775   | 5989   | -52.2%  | -6.2%  | +17.6% |
| rand-rw   | 3647   | 3767   | 3518   | 3707   | +3.3%   | -3.5%  | +1.6%  |
```

# FreeBSD posixaio
```markdown
| WORKLOAD  | AUTO   | OFF    | ON     | WRONLY | offΔ%   | onΔ%   | wrΔ%   |
|-----------|--------|--------|--------|--------|---------|--------|--------|
| seq-read  | 70986  | 83632  | 77431  | 128011 | +17.8%  | +9.1%  | +80.3% |
| seq-write | 1362   | 870    | 1141   | 1077   | -36.1%  | -16.2% | -20.9% |
| rand-read | 78771  | 86354  | 86878  | 124632 | +9.6%   | +10.3% | +58.2% |
| rand-write| 1305   | 855    | 1124   | 1233   | -34.5%  | -13.9% | -5.5%  |
| rand-rw   | 2430   | 1618   | 2758   | 2677   | -33.4%  | +13.5% | +10.2% |
```


### How Has This Been Tested?
New test cases, and personal fork CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [X] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [X] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
