### PR TITLE
ZTS: stop zpool_initialize tests racing initialize to completion

### DIFF
--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -218,10 +218,6 @@ maybe = {
     'cli_root/zpool_destroy/zpool_destroy_001_pos': ['SKIP', 6145],
     'cli_root/zpool_import/import_devices_missing': ['FAIL', 16669],
     'cli_root/zpool_import/zpool_import_missing_003_pos': ['SKIP', 6839],
-    'cli_root/zpool_initialize/zpool_initialize_import_export':
-        ['FAIL', 11948],
-    'cli_root/zpool_initialize/zpool_initialize_suspend_resume':
-        ['FAIL', known_reason],
     'cli_root/zpool_iostat/zpool_iostat_interval_all': ['FAIL', 18273],
     'cli_root/zpool_labelclear/zpool_labelclear_removed':
         ['FAIL', known_reason],

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_initialize/zpool_initialize_import_export.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_initialize/zpool_initialize_import_export.ksh
@@ -44,6 +44,25 @@
 
 DISK1=${DISKS%% *}
 
+function cleanup
+{
+	# Destroy the pool (stopping the initialize thread) before restoring
+	# the chunk size, so the running thread never issues a write larger
+	# than the buffer it allocated at the smaller size.
+	if poolexists $TESTPOOL; then
+		log_must zpool destroy -f $TESTPOOL
+	fi
+	[[ "$default_chunk_sz" ]] && \
+	    log_must set_tunable64 INITIALIZE_CHUNK_SIZE $default_chunk_sz
+}
+log_onexit cleanup
+
+# Make initializing slow enough that it is still running after the pool has
+# been exported and re-imported below, rather than racing to completion on a
+# small or fast vdev (see zpool_wait_initialize_*).
+default_chunk_sz=$(get_tunable INITIALIZE_CHUNK_SIZE)
+log_must set_tunable64 INITIALIZE_CHUNK_SIZE 512
+
 log_must zpool create -f $TESTPOOL $DISK1
 log_must zpool initialize $TESTPOOL
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_initialize/zpool_initialize_suspend_resume.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_initialize/zpool_initialize_suspend_resume.ksh
@@ -42,6 +42,25 @@
 
 DISK1=${DISKS%% *}
 
+function cleanup
+{
+	# Destroy the pool (stopping the initialize thread) before restoring
+	# the chunk size, so the running thread never issues a write larger
+	# than the buffer it allocated at the smaller size.
+	if poolexists $TESTPOOL; then
+		log_must zpool destroy -f $TESTPOOL
+	fi
+	[[ "$default_chunk_sz" ]] && \
+	    log_must set_tunable64 INITIALIZE_CHUNK_SIZE $default_chunk_sz
+}
+log_onexit cleanup
+
+# Make initializing slow enough that it does not race to completion before it
+# can be suspended and observed, rather than finishing on a small or fast vdev
+# (see zpool_wait_initialize_*).
+default_chunk_sz=$(get_tunable INITIALIZE_CHUNK_SIZE)
+log_must set_tunable64 INITIALIZE_CHUNK_SIZE 512
+
 log_must zpool create -f $TESTPOOL $DISK1
 log_must zpool initialize $TESTPOOL
 


### PR DESCRIPTION
### Motivation and Context

`zpool_initialize_import_export` and `zpool_initialize_suspend_resume` are
intermittently failing and are currently suppressed in
`tests/test-runner/bin/zts-report.py.in` (#11948, #17311).

Both tests create a one-disk pool, run `zpool initialize`, wait a fixed couple
of seconds, and then require initializing to still be active so it can be
observed across an export/import and suspended. On a small or fast vdev,
initializing the whole disk finishes inside that fixed-sleep window at the
default 1 MiB chunk (`zfs_initialize_chunk_size`). Once it completes, `zpool
initialize -s` fails with "there is no active initialization" and the test
fails. The window is timing-dependent, which is why it shows up as a flake.

### Description

Throttle initializing with `zfs_initialize_chunk_size`, exactly as the
`zpool_wait_initialize_*` tests already do, so it stays active long enough to
observe regardless of vdev size or speed. The tunable is saved and restored per
test.

Cleanup destroys the pool before restoring the chunk size. The initialize
thread rereads `zfs_initialize_chunk_size` on every write but allocates its
fill buffer once at the smaller size, so raising it back while the thread is
still running would issue a write larger than that buffer. `zpool destroy -f`
synchronously stops and joins the initialize thread
(`vdev_initialize_stop_all()`), so restoring the tunable afterwards is safe.

With the race removed both tests pass reliably, so their entries are dropped
from the `zts-report.py.in` "maybe" list.

### How Has This Been Tested?

Reproduced the race in a VM: with the default 1 MiB chunk the suspend step fails
with "there is no active initialization"; with the smaller chunk size
initializing is still running across the export/import and the suspend/resume
sequence, and the tunable is restored on exit.

Opening as a draft to get a full CI run on the two de-suppressed tests.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] My code follows the OpenZFS code style requirements.
- [x] I have run the ZFS Test Suite with my changes.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
