### PR TITLE
Address repeated small writes leading to memory spike

### DIFF
--- a/include/sys/dbuf.h
+++ b/include/sys/dbuf.h
@@ -385,7 +385,8 @@ void dmu_buf_will_fill_flags(dmu_buf_t *db, dmu_tx_t *tx, boolean_t canfail,
 boolean_t dmu_buf_fill_done(dmu_buf_t *db, dmu_tx_t *tx, boolean_t failed);
 void dbuf_assign_arcbuf(dmu_buf_impl_t *db, arc_buf_t *buf, dmu_tx_t *tx,
     dmu_flags_t flags);
-dbuf_dirty_record_t *dbuf_dirty(dmu_buf_impl_t *db, dmu_tx_t *tx);
+dbuf_dirty_record_t *dbuf_dirty(dmu_buf_impl_t *db, dmu_tx_t *tx,
+    boolean_t recount);
 dbuf_dirty_record_t *dbuf_dirty_lightweight(dnode_t *dn, uint64_t blkid,
     dmu_tx_t *tx);
 boolean_t dbuf_undirty(dmu_buf_impl_t *db, dmu_tx_t *tx);

--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -825,7 +825,8 @@ struct blkptr *dmu_buf_get_blkptr(dmu_buf_t *db);
  * (ie. you've called dmu_tx_hold_object(tx, db->db_object)).
  */
 void dmu_buf_will_dirty(dmu_buf_t *db, dmu_tx_t *tx);
-void dmu_buf_will_dirty_flags(dmu_buf_t *db, dmu_tx_t *tx, dmu_flags_t flags);
+void dmu_buf_will_dirty_flags(dmu_buf_t *db, dmu_tx_t *tx, dmu_flags_t flags,
+    boolean_t recount);
 void dmu_buf_will_rewrite(dmu_buf_t *db, dmu_tx_t *tx);
 boolean_t dmu_buf_is_dirty(dmu_buf_t *db, dmu_tx_t *tx);
 void dmu_buf_set_crypt_params(dmu_buf_t *db_fake, boolean_t byteorder,
@@ -942,7 +943,7 @@ int dmu_write_uio(objset_t *os, uint64_t object, zfs_uio_t *uio, uint64_t size,
 int dmu_write_uio_dbuf(dmu_buf_t *zdb, zfs_uio_t *uio, uint64_t size,
 	dmu_tx_t *tx, dmu_flags_t flags);
 int dmu_write_uio_dnode(dnode_t *dn, zfs_uio_t *uio, uint64_t size,
-	dmu_tx_t *tx, dmu_flags_t flags);
+	dmu_tx_t *tx, dmu_flags_t flags, boolean_t recount);
 #endif
 struct arc_buf *dmu_request_arcbuf(dmu_buf_t *handle, int size);
 void dmu_return_arcbuf(struct arc_buf *buf);

--- a/include/sys/zil.h
+++ b/include/sys/zil.h
@@ -468,6 +468,7 @@ typedef struct itx {
 	size_t		itx_size;	/* allocated itx structure size */
 	uint64_t	itx_oid;	/* object id */
 	uint64_t	itx_gen;	/* gen number for zfs_get_data */
+	uint64_t	itx_coalesce_align;
 	lr_t		itx_lr;		/* common part of log record */
 	uint8_t		itx_lr_data[];	/* type-specific part of lr_xx_t */
 } itx_t;

--- a/module/os/freebsd/zfs/dmu_os.c
+++ b/module/os/freebsd/zfs/dmu_os.c
@@ -103,7 +103,7 @@ dmu_write_pages(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
 				else
 					flags |= DMU_PARTIAL_MORE;
 			}
-			dmu_buf_will_dirty_flags(db, tx, flags);
+			dmu_buf_will_dirty_flags(db, tx, flags, B_FALSE);
 		}
 
 		for (copied = 0; copied < tocpy; copied += PAGESIZE) {

--- a/module/os/freebsd/zfs/zvol_os.c
+++ b/module/os/freebsd/zfs/zvol_os.c
@@ -887,7 +887,7 @@ zvol_cdev_write(struct cdev *dev, struct uio *uio_s, int ioflag)
 			break;
 		}
 		error = dmu_write_uio_dnode(zv->zv_dn, &uio, bytes, tx,
-		    DMU_READ_PREFETCH);
+		    DMU_READ_PREFETCH, B_FALSE);
 		if (error == 0)
 			zvol_log_write(zv, tx, off, bytes, commit);
 		dmu_tx_commit(tx);

--- a/module/os/linux/zfs/zvol_os.c
+++ b/module/os/linux/zfs/zvol_os.c
@@ -265,7 +265,7 @@ zvol_write(zv_request_t *zvr)
 			break;
 		}
 		error = dmu_write_uio_dnode(zv->zv_dn, &uio, bytes, tx,
-		    DMU_READ_PREFETCH);
+		    DMU_READ_PREFETCH, B_FALSE);
 		if (error == 0) {
 			zvol_log_write(zv, tx, off, bytes, sync);
 		}

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -2183,11 +2183,13 @@ dbuf_new_size(dmu_buf_impl_t *db, int size, dmu_tx_t *tx)
 	if (db->db_level == 0)
 		dr->dt.dl.dr_data = buf;
 	ASSERT3U(dr->dr_txg, ==, tx->tx_txg);
-	ASSERT3U(dr->dr_accounted, ==, osize);
-	dr->dr_accounted = size;
+	uint64_t count = dr->dr_accounted / osize;
+	uint64_t oaccounted = dr->dr_accounted;
+	dr->dr_accounted = size * count;
 	mutex_exit(&db->db_mtx);
 
-	dmu_objset_willuse_space(dn->dn_objset, size - osize, tx);
+	dmu_objset_willuse_space(dn->dn_objset, dr->dr_accounted - oaccounted,
+	    tx);
 	DB_DNODE_EXIT(db);
 }
 
@@ -2211,11 +2213,12 @@ dbuf_release_bp(dmu_buf_impl_t *db)
  * dirtied again.
  */
 static void
-dbuf_redirty(dbuf_dirty_record_t *dr)
+dbuf_redirty(dbuf_dirty_record_t *dr, dmu_tx_t *recount_tx)
 {
 	dmu_buf_impl_t *db = dr->dr_dbuf;
 
 	ASSERT(MUTEX_HELD(&db->db_mtx));
+	ASSERT(DB_DNODE_HELD(db));
 
 	if (db->db_level == 0 && db->db_blkid != DMU_BONUS_BLKID) {
 		/*
@@ -2235,6 +2238,12 @@ dbuf_redirty(dbuf_dirty_record_t *dr)
 		 * modification.
 		 */
 		dr->dt.dl.dr_rewrite = B_FALSE;
+	}
+	if (recount_tx) { // TODO elseif?
+		dnode_t *dn = DB_DNODE(db);
+		dr->dr_accounted += db->db.db_size;
+		dmu_objset_willuse_space(dn->dn_objset, db->db.db_size,
+		    recount_tx);
 	}
 }
 
@@ -2304,7 +2313,8 @@ dbuf_dirty_lightweight(dnode_t *dn, uint64_t blkid, dmu_tx_t *tx)
 			return (NULL);
 		}
 
-		dbuf_dirty_record_t *parent_dr = dbuf_dirty(parent_db, tx);
+		dbuf_dirty_record_t *parent_dr = dbuf_dirty(parent_db, tx,
+		    B_FALSE);
 		dbuf_rele(parent_db, FTAG);
 		mutex_enter(&parent_dr->dt.di.dr_mtx);
 		ASSERT3U(parent_dr->dr_txg, ==, tx->tx_txg);
@@ -2319,7 +2329,7 @@ dbuf_dirty_lightweight(dnode_t *dn, uint64_t blkid, dmu_tx_t *tx)
 }
 
 dbuf_dirty_record_t *
-dbuf_dirty(dmu_buf_impl_t *db, dmu_tx_t *tx)
+dbuf_dirty(dmu_buf_impl_t *db, dmu_tx_t *tx, boolean_t recount)
 {
 	dnode_t *dn;
 	objset_t *os;
@@ -2372,9 +2382,9 @@ dbuf_dirty(dmu_buf_impl_t *db, dmu_tx_t *tx)
 	    db->db.db_object == DMU_META_DNODE_OBJECT);
 	dr_next = dbuf_find_dirty_lte(db, tx->tx_txg);
 	if (dr_next && dr_next->dr_txg == tx->tx_txg) {
-		DB_DNODE_EXIT(db);
 
-		dbuf_redirty(dr_next);
+		dbuf_redirty(dr_next, recount ? tx : NULL);
+		DB_DNODE_EXIT(db);
 		mutex_exit(&db->db_mtx);
 		return (dr_next);
 	}
@@ -2541,7 +2551,7 @@ dbuf_dirty(dmu_buf_impl_t *db, dmu_tx_t *tx)
 		if (drop_struct_rwlock)
 			rw_exit(&dn->dn_struct_rwlock);
 		ASSERT3U(db->db_level + 1, ==, parent->db_level);
-		di = dbuf_dirty(parent, tx);
+		di = dbuf_dirty(parent, tx, B_FALSE);
 		if (parent_held)
 			dbuf_rele(parent, FTAG);
 
@@ -2707,7 +2717,8 @@ dbuf_undirty(dmu_buf_impl_t *db, dmu_tx_t *tx)
 }
 
 void
-dmu_buf_will_dirty_flags(dmu_buf_t *db_fake, dmu_tx_t *tx, dmu_flags_t flags)
+dmu_buf_will_dirty_flags(dmu_buf_t *db_fake, dmu_tx_t *tx, dmu_flags_t flags,
+    boolean_t recount)
 {
 	dmu_buf_impl_t *db = (dmu_buf_impl_t *)db_fake;
 	boolean_t undirty = B_FALSE;
@@ -2740,7 +2751,9 @@ dmu_buf_will_dirty_flags(dmu_buf_t *db_fake, dmu_tx_t *tx, dmu_flags_t flags)
 				undirty = B_TRUE;
 			} else {
 				/* This dbuf is already dirty and cached. */
-				dbuf_redirty(dr);
+				DB_DNODE_ENTER(db);
+				dbuf_redirty(dr, recount ? tx : NULL);
+	DB_DNODE_EXIT(db);
 				mutex_exit(&db->db_mtx);
 				return;
 			}
@@ -2765,13 +2778,13 @@ dmu_buf_will_dirty_flags(dmu_buf_t *db_fake, dmu_tx_t *tx, dmu_flags_t flags)
 		VERIFY(!dbuf_undirty(db, tx));
 		mutex_exit(&db->db_mtx);
 	}
-	(void) dbuf_dirty(db, tx);
+	(void) dbuf_dirty(db, tx, recount);
 }
 
 void
 dmu_buf_will_dirty(dmu_buf_t *db_fake, dmu_tx_t *tx)
 {
-	dmu_buf_will_dirty_flags(db_fake, tx, DMU_READ_NO_PREFETCH);
+	dmu_buf_will_dirty_flags(db_fake, tx, DMU_READ_NO_PREFETCH, B_FALSE);
 }
 
 void
@@ -2797,7 +2810,7 @@ dmu_buf_will_rewrite(dmu_buf_t *db_fake, dmu_tx_t *tx)
 	 * The dbuf is not dirty, so we need to make it dirty and
 	 * mark it for rewrite (preserve logical birth time).
 	 */
-	dmu_buf_will_dirty_flags(db_fake, tx, DMU_READ_NO_PREFETCH);
+	dmu_buf_will_dirty_flags(db_fake, tx, DMU_READ_NO_PREFETCH, B_FALSE);
 
 	mutex_enter(&db->db_mtx);
 	dbuf_dirty_record_t *dr = dbuf_find_dirty_eq(db, tx->tx_txg);
@@ -2968,7 +2981,7 @@ dmu_buf_will_clone_or_dio(dmu_buf_t *db_fake, dmu_tx_t *tx)
 	mutex_exit(&db->db_mtx);
 
 	dbuf_noread(db, DMU_KEEP_CACHING);
-	(void) dbuf_dirty(db, tx);
+	(void) dbuf_dirty(db, tx, B_FALSE);
 }
 
 void
@@ -2982,7 +2995,7 @@ dmu_buf_will_not_fill(dmu_buf_t *db_fake, dmu_tx_t *tx)
 	mutex_exit(&db->db_mtx);
 
 	dbuf_noread(db, DMU_KEEP_CACHING);
-	(void) dbuf_dirty(db, tx);
+	(void) dbuf_dirty(db, tx, B_FALSE);
 }
 
 void
@@ -3009,7 +3022,7 @@ dmu_buf_will_fill_flags(dmu_buf_t *db_fake, dmu_tx_t *tx, boolean_t canfail,
 		 */
 		if (canfail && dr) {
 			mutex_exit(&db->db_mtx);
-			dmu_buf_will_dirty_flags(db_fake, tx, flags);
+			dmu_buf_will_dirty_flags(db_fake, tx, flags, B_FALSE);
 			return;
 		}
 		/*
@@ -3026,7 +3039,7 @@ dmu_buf_will_fill_flags(dmu_buf_t *db_fake, dmu_tx_t *tx, boolean_t canfail,
 	mutex_exit(&db->db_mtx);
 
 	dbuf_noread(db, flags);
-	(void) dbuf_dirty(db, tx);
+	(void) dbuf_dirty(db, tx, B_FALSE);
 }
 
 void
@@ -3058,7 +3071,7 @@ dmu_buf_set_crypt_params(dmu_buf_t *db_fake, boolean_t byteorder,
 	ASSERT(db->db_objset->os_raw_receive);
 
 	dmu_buf_will_dirty_flags(db_fake, tx,
-	    DMU_READ_NO_PREFETCH | DMU_READ_NO_DECRYPT);
+	    DMU_READ_NO_PREFETCH | DMU_READ_NO_DECRYPT, B_FALSE);
 
 	dr = dbuf_find_dirty_eq(db, tx->tx_txg);
 
@@ -3235,7 +3248,7 @@ dbuf_assign_arcbuf(dmu_buf_impl_t *db, arc_buf_t *buf, dmu_tx_t *tx,
 		 */
 		ASSERT(!arc_is_encrypted(buf));
 		mutex_exit(&db->db_mtx);
-		(void) dbuf_dirty(db, tx);
+		(void) dbuf_dirty(db, tx, B_FALSE);
 		memcpy(db->db.db_data, buf->b_data, db->db.db_size);
 		arc_buf_destroy(buf, db);
 		return;
@@ -3275,7 +3288,7 @@ dbuf_assign_arcbuf(dmu_buf_impl_t *db, arc_buf_t *buf, dmu_tx_t *tx,
 	db->db_state = DB_FILL;
 	DTRACE_SET_STATE(db, "filling assigned arcbuf");
 	mutex_exit(&db->db_mtx);
-	(void) dbuf_dirty(db, tx);
+	(void) dbuf_dirty(db, tx, B_FALSE);
 	dmu_buf_fill_done(&db->db, tx, B_FALSE);
 }
 

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -1362,7 +1362,7 @@ dmu_write_impl(dmu_buf_t **dbp, int numbufs, uint64_t offset, uint64_t size,
 				else
 					flags |= DMU_PARTIAL_MORE;
 			}
-			dmu_buf_will_dirty_flags(db, tx, flags);
+			dmu_buf_will_dirty_flags(db, tx, flags, B_FALSE);
 		}
 
 		ASSERT(db->db_data != NULL);
@@ -1574,7 +1574,7 @@ dmu_read_uio(objset_t *os, uint64_t object, zfs_uio_t *uio, uint64_t size,
 
 int
 dmu_write_uio_dnode(dnode_t *dn, zfs_uio_t *uio, uint64_t size, dmu_tx_t *tx,
-    dmu_flags_t flags)
+    dmu_flags_t flags, boolean_t recount)
 {
 	dmu_buf_t **dbp;
 	int numbufs;
@@ -1641,7 +1641,7 @@ top:
 				else
 					flags |= DMU_PARTIAL_MORE;
 			}
-			dmu_buf_will_dirty_flags(db, tx, flags);
+			dmu_buf_will_dirty_flags(db, tx, flags, recount);
 		}
 
 		ASSERT(db->db_data != NULL);
@@ -1694,7 +1694,7 @@ dmu_write_uio_dbuf(dmu_buf_t *zdb, zfs_uio_t *uio, uint64_t size,
 		return (0);
 
 	DB_DNODE_ENTER(db);
-	err = dmu_write_uio_dnode(DB_DNODE(db), uio, size, tx, flags);
+	err = dmu_write_uio_dnode(DB_DNODE(db), uio, size, tx, flags, B_TRUE);
 	DB_DNODE_EXIT(db);
 
 	return (err);
@@ -1719,7 +1719,7 @@ dmu_write_uio(objset_t *os, uint64_t object, zfs_uio_t *uio, uint64_t size,
 	if (err)
 		return (err);
 
-	err = dmu_write_uio_dnode(dn, uio, size, tx, flags);
+	err = dmu_write_uio_dnode(dn, uio, size, tx, flags, B_FALSE);
 
 	dnode_rele(dn, FTAG);
 

--- a/module/zfs/dnode.c
+++ b/module/zfs/dnode.c
@@ -1905,7 +1905,7 @@ dnode_setdirty(dnode_t *dn, dmu_tx_t *tx)
 	ASSERT3U(dn->dn_dirtycnt, <=, 3);
 	mutex_exit(&dn->dn_mtx);
 
-	(void) dbuf_dirty(dn->dn_dbuf, tx);
+	(void) dbuf_dirty(dn->dn_dbuf, tx, B_FALSE);
 
 	dsl_dataset_dirty(os->os_dsl_dataset, tx);
 }
@@ -2014,7 +2014,7 @@ dnode_set_nlevels_impl(dnode_t *dn, int new_nlevels, dmu_tx_t *tx)
 	/* dirty the left indirects */
 	db = dbuf_hold_level(dn, old_nlevels, 0, FTAG);
 	ASSERT(db != NULL);
-	new = dbuf_dirty(db, tx);
+	new = dbuf_dirty(db, tx, B_FALSE);
 	dbuf_rele(db, FTAG);
 
 	/* transfer the dirty records to the new indirect */

--- a/module/zfs/dsl_pool.c
+++ b/module/zfs/dsl_pool.c
@@ -820,7 +820,7 @@ dsl_pool_sync(dsl_pool_t *dp, uint64_t txg)
 
 	/*
 	 * We have written all of the accounted dirty data, so our
-	 * dp_space_towrite should now be zero. However, some seldom-used
+	 * dp_dirty_pertxg should now be zero. However, some seldom-used
 	 * code paths do not adhere to this (e.g. dbuf_undirty()). Shore up
 	 * the accounting of any dirtied space now.
 	 *

--- a/module/zfs/zfs_log.c
+++ b/module/zfs/zfs_log.c
@@ -670,6 +670,14 @@ zfs_log_write(zilog_t *zilog, dmu_tx_t *tx, int txtype,
 			}
 		}
 
+		if (wr_state == WR_NEED_COPY || wr_state == WR_INDIRECT) {
+			DB_DNODE_ENTER(db);
+			uint64_t maxblkid = DB_DNODE(db)->dn_maxblkid;
+			DB_DNODE_EXIT(db);
+			if (maxblkid > 0)
+				itx->itx_coalesce_align = blocksize;
+		}
+
 		log_size += itx->itx_size;
 		if (wr_state == WR_NEED_COPY)
 			log_size += len;

--- a/module/zfs/zil.c
+++ b/module/zfs/zil.c
@@ -2562,6 +2562,7 @@ zil_itx_create(uint64_t txtype, size_t olrsize)
 	itx->itx_callback = NULL;
 	itx->itx_callback_data = NULL;
 	itx->itx_size = itxsize;
+	itx->itx_coalesce_align = 0;
 
 	return (itx);
 }
@@ -2769,6 +2770,32 @@ zil_itx_assign(zilog_t *zilog, itx_t *itx, dmu_tx_t *tx)
 			    offsetof(itx_t, itx_node));
 			ian->ia_foid = foid;
 			avl_insert(t, ian, where);
+		}
+		itx_t *cur_tail = list_tail(&ian->ia_list);
+		if (cur_tail && cur_tail->itx_coalesce_align &&
+		    itx->itx_coalesce_align &&
+		    cur_tail->itx_lr.lrc_txtype == itx->itx_lr.lrc_txtype) {
+			ASSERT3U(itx->itx_lr.lrc_txtype, ==, TX_WRITE);
+			ASSERT3U(cur_tail->itx_lr.lrc_txtype, ==, TX_WRITE);
+			ASSERT3U(cur_tail->itx_coalesce_align, ==,
+			    itx->itx_coalesce_align);
+			lr_write_t *new_lr = (lr_write_t *)(&itx->itx_lr);
+			lr_write_t *tail_lr = (lr_write_t *)(&cur_tail->itx_lr);
+			ASSERT3U(new_lr->lr_foid, ==, tail_lr->lr_foid);
+
+			uint64_t coal = itx->itx_coalesce_align;
+			uint64_t start = tail_lr->lr_offset;
+			uint64_t end = new_lr->lr_offset + new_lr->lr_length -
+			    1;
+			if (start / coal == end / coal && new_lr->lr_offset ==
+			    tail_lr->lr_offset + tail_lr->lr_length &&
+			    dmu_tx_get_txg(tx) == cur_tail->itx_lr.lrc_txg) {
+				tail_lr->lr_length += new_lr->lr_length;
+				zil_itx_destroy(itx, 0);
+				itx = cur_tail;
+				list_remove(&ian->ia_list, cur_tail);
+			}
+
 		}
 		list_insert_tail(&ian->ia_list, itx);
 	}


### PR DESCRIPTION
Sponsored-by: Wasabi Technology, Inc.

### Motivation and Context
Each write that comes into ZFS creates an ITX in the ZIL, whether or not that write is synchronous. This is so that later, if fsync or syncfs are called, the writes can be converted into sync writes efficiently, without having to force an immediate TXG sync. When this happens, each ITX is converted into a ZIO. This is true even if there are several writes to the same block of the same object. When you're writing the whole block, that's fine: the memory used and the writes performed are equal to the total writes that userland sent to the kernel. However, if the writes are small and the recordsizes are large, we end up effectively multipling the memory use by the ratio between the two; a one-byte write to a 16MiB block still needs 16MiB of memory to store the ABD for the ZIO we create from that ITX. This can result in us needing huge amounts of memory when fsync is called, far in excess of the dirty data limits that we usually enforce. In the worst case, this can hang the system, since we can't actually complete the ZIO tree without running out of memory, and nothing ends up making forward progress.

### Description
There are two changes in this MR. First, to address the general case, we now increment the dirty data count when we redirty a dbuf through the zfs write codepath. This will prevent the system from overpromising how many writes it can actually accept in the worst case scenario. This does result in a performance decrease in some situations, however. To mitigate that, the second change coalesces sequential ITXes if they are for sequential regions of the file. This can be useful if, for example, you append lines to a logfile that is stored on a dataset with large recordsizes and occasionally fsync that file or syncfs that dataset.

Note that for the first change, it's possible we could reduce the multi-counting in some cases, but as a first pass this seemed pretty close to correct. For the second change, we don't do this if the ITX is WR_COPIED. This could be done, but for an initial implementation I went with the simpler version, whichih only handles WR_NEED_COPY and WR_INDIRECT, which don't require resizing or copying any data around.

There is also a small correction of an outdated comment.

### How Has This Been Tested?
Manual testing on a dataset with 16MiB recordsize, doing 1 byte appends repeatedly. Verified with zfs_dbgmsg debugging that if the writes are sequential we coalesce them into a single ITX, and if they are not we increment the dirty data count for each one, resulting in us staying below the dirty data threshold when syncfs is called.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
