### PR TITLE
ZTS: make zpool_iostat_interval_all teardown deterministic

### DIFF
--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -227,7 +227,6 @@ maybe = {
     'cli_root/zpool_destroy/zpool_destroy_001_pos': ['SKIP', 6145],
     'cli_root/zpool_import/import_devices_missing': ['FAIL', 16669],
     'cli_root/zpool_import/zpool_import_missing_003_pos': ['SKIP', 6839],
-    'cli_root/zpool_iostat/zpool_iostat_interval_all': ['FAIL', 18273],
     'cli_root/zpool_labelclear/zpool_labelclear_removed':
         ['FAIL', known_reason],
     'cli_root/zpool_trim/setup': ['SKIP', trim_reason],

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_iostat/zpool_iostat_interval_all.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_iostat/zpool_iostat_interval_all.ksh
@@ -60,8 +60,19 @@ expect_iostat "POOLBOTH"
 log_must zpool create pool2 $vdev2
 delay_iostat
 
+# Export the pools one at a time rather than with a single "zpool export -a".
+# iostat samples every 0.1s and "export -a" tears the pools down
+# sequentially, so it would sometimes catch the intermediate one-pool state
+# and emit an extra chunk that is not in the expected output. Exporting each
+# pool explicitly makes that transition deterministic, mirroring the
+# one-pool-at-a-time imports below.
+expect_iostat "HEADER"
+expect_iostat "POOL2"
+log_must zpool export pool1
+delay_iostat
+
 expect_iostat "NOPOOL"
-log_must zpool export -a
+log_must zpool export pool2
 delay_iostat
 
 expect_iostat "HEADER"


### PR DESCRIPTION
### Motivation and Context

`cli_root/zpool_iostat/zpool_iostat_interval_all` is intermittently failing
and is currently suppressed in `tests/test-runner/bin/zts-report.py.in`
(#18273).

The test runs `zpool iostat -T u <pools> 0.1` in the background and compares
its output, parsed into a sequence of "chunks", against a fixed expected
sequence as pools are created, imported, exported and destroyed. Every step
changes the visible pool list by exactly one pool except the teardown, which
uses a single `zpool export -a`.

`export -a` exports the pools one after another rather than atomically, so
there is a brief window in which one pool is already gone and the other is
not. At the 0.1s sampling interval iostat occasionally catches that
intermediate single-pool state and emits an extra chunk that is not in the
expected sequence, and the test fails. Whether a sample lands in the window
depends on timing, which is why it shows up as a flake.

### Description

Export the two pools explicitly, one at a time, and add the intermediate
single-pool state to the expected output — the same one-pool-at-a-time shape
the imports and destroys elsewhere in the test already use. The teardown
transition becomes deterministic and the spurious extra chunk can no longer
appear.

With the race removed the test's entry is dropped from the
`zts-report.py.in` "maybe" list.

### How Has This Been Tested?

Looped the teardown in a VM (150 iterations each):

- With `zpool export -a`, iostat emitted a spurious extra single-pool chunk
  during teardown in 17 of 150 runs — the failure mode from #18273.
- With the two explicit ordered exports, every run produced the expected
  `POOLBOTH -> POOL2 -> NOPOOL` teardown; no spurious chunk in any run.

Opening as a draft to get a full CI run on the de-suppressed test.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] My code follows the OpenZFS code style requirements.
- [x] I have run the ZFS Test Suite with my changes.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
