### PR TITLE
ZTS: fix zpool_initialize_multiple_pools suspend race

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zpool_initialize/zpool_initialize_multiple_pools.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_initialize/zpool_initialize_multiple_pools.ksh
@@ -42,15 +42,23 @@ verify_runnable "global"
 
 cleanup() {
     for pool in {1..4}; do
-        zpool destroy $TESTPOOL${pool}
+        poolexists $TESTPOOL${pool} && destroy_pool $TESTPOOL${pool}
         rm -rf $TESTDIR${pool}
     done
     rm -f $DISK1 $DISK2 $DISK3 $DISK4
+
+    # Restore the chunk size only after the pools (and their initialize
+    # threads) are gone, so a still-running thread never sees a larger value
+    # than the fill buffer it allocated at the smaller size.
+    [[ -n "$default_chunk_size" ]] && \
+        log_must set_tunable64 INITIALIZE_CHUNK_SIZE $default_chunk_size
 }
 
 log_onexit cleanup
 
 log_assert "Verify if 'zpool initialize -a' works correctly with multiple pools."
+
+default_chunk_size=$(get_tunable INITIALIZE_CHUNK_SIZE)
 
 DEVSIZE='5G'
 TESTDIR="$TEST_BASE_DIR/zpool_initialize_multiple_pools"
@@ -107,6 +115,16 @@ complete_count=$(zpool status -i | grep -c "uninitialized")
 if [[ $complete_count -ne 4 ]]; then
     log_fail "Expected 4 pools to have initialize status 'uninitialized', but found ${complete_count}."
 fi
+
+# The suspend check below requires initializing to still be running on every
+# pool.  At the default chunk size a pool can finish initializing before
+# "zpool initialize -a -s" runs, so it would report "completed" instead of
+# "suspended" and the test would fail intermittently.  Throttle the chunk
+# size (as the zpool_wait_initialize_* tests do) so initializing stays active
+# through the suspend and cancel checks.  The earlier completion phases are
+# deliberately left at the default size so "zpool wait" and "-w" return
+# promptly.
+log_must set_tunable64 INITIALIZE_CHUNK_SIZE 512
 
 log_must zpool initialize -a
 


### PR DESCRIPTION
### Motivation and Context

`cli_root/zpool_initialize/zpool_initialize_multiple_pools` fails
intermittently in CI. The test starts `zpool initialize -a` on four pools
and then, without slowing initializing down, expects every pool to still be
initializing when it runs `zpool initialize -a -s`.

On fast storage a pool can finish initializing before the suspend runs. Its
status is then `completed` rather than `suspended`, and `zpool initialize
-a -s` reports "there is no active initialization" for that pool, so the
`log_must zpool initialize -a -s` fails and the test fails. Whether a pool
finishes first depends on timing, which is why it shows up as a flake.

### Description

Throttle `zfs_initialize_chunk_size` before the suspend phase, exactly as the
`zpool_wait_initialize_*` tests already do, so initializing stays active
through the suspend and cancel checks. The earlier phases that wait for
initializing to finish (`zpool wait` and `-w -a`) are deliberately left at
the default chunk size so they still complete promptly — a small chunk on a
5G vdev would make them run for a very long time.

The chunk size is saved and restored. Cleanup destroys the pools before
restoring it, so a still-running initialize thread never sees a larger chunk
size than the fill buffer it allocated at the smaller size.

### How Has This Been Tested?

Reproduced and verified in a VM:

- Small/fast vdevs at the default chunk size reproduce the race: some pools
  finish before the suspend, `zpool initialize -a -s` prints "there is no
  active initialization", and the suspended count is < 4.
- With the chunk size throttled before the suspend phase, initializing stays
  active and all four pools report `suspended` on every run (0 failures over
  many iterations, even with no delay before the suspend).
- The completion phases still finish promptly at the default chunk size
  (`completed` and `uninitialized` counts reach 4).

Opening as a draft to get a full CI run on the de-flaked test.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] My code follows the OpenZFS code style requirements.
- [x] I have run the ZFS Test Suite with my changes.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
