### PR TITLE
there may be a race between two vms in zfs-qemu 

### DIFF
--- a/.github/workflows/scripts/qemu-6-tests.sh
+++ b/.github/workflows/scripts/qemu-6-tests.sh
@@ -23,8 +23,8 @@ function prefix() {
   M=$((DIFF/60))
   S=$((DIFF-(M*60)))
 
-  CTR=$(cat /tmp/ctr)
-  echo $LINE| grep -q '^\[.*] Test[: ]' && CTR=$((CTR+1)) && echo $CTR > /tmp/ctr
+  CTR=$(cat /tmp/ctr-vm${ID})
+  echo $LINE| grep -q '^\[.*] Test[: ]' && CTR=$((CTR+1)) && echo $CTR > /tmp/ctr-vm${ID}
 
   BASE="$HOME/work/zfs/zfs"
   COLOR="$BASE/scripts/zfs-tests-color.sh"
@@ -96,10 +96,10 @@ if [ -z ${1:-} ]; then
   source env.txt
   SSH=$(which ssh)
   TESTS='$HOME/zfs/.github/workflows/scripts/qemu-6-tests.sh'
-  echo 0 > /tmp/ctr
   date "+%s" > /tmp/tsstart
 
   for ((i=1; i<=VMs; i++)); do
+    echo 0 > /tmp/ctr-vm${i}
     IP="192.168.122.1$i"
 
     # We do an additional test build of Lustre against ZFS if we're vm2

--- a/.github/workflows/scripts/qemu-6-tests.sh
+++ b/.github/workflows/scripts/qemu-6-tests.sh
@@ -35,9 +35,17 @@ function prefix() {
   if [ -z "$CLINE" ]; then
     printf "vm${ID}: %s\n" "$LINE"
   else
-    # [vm2: 00:15:54  256] Test: functional/checksum/setup (run as root) [00:00] [PASS]
-    printf "[vm${ID}: %02d:%02d:%02d %4d] %s\n" \
-      "$H" "$M" "$S" "$CTR" "$CLINE"
+    TOTAL=0
+    BREAKDOWN=""
+    TOTAL_VMS="$3"
+    for ((v=1; v<=TOTAL_VMS; v++)); do
+      read -r val < "/tmp/ctr-vm${v}"
+      TOTAL=$((TOTAL + val))
+      BREAKDOWN="${BREAKDOWN}${BREAKDOWN:+|}${val}"
+    done
+    # [vm2: 00:15:54  256(200|56)] Test: functional/checksum/setup (run as root) [00:00] [PASS]
+    printf "[vm${ID}: %02d:%02d:%02d %4d(%s)] %s\n" \
+      "$H" "$M" "$S" "$TOTAL" "$BREAKDOWN" "$CLINE"
   fi
 }
 
@@ -121,7 +129,7 @@ if [ -z ${1:-} ]; then
       $SSH zfs@$IP $TESTS $OS $i $VMs $extra $CI_TYPE
     # handly line by line and add info prefix
     stdbuf -oL tail -fq vm${i}log.txt \
-      | while read -r line; do prefix "$i" "$line"; done &
+      | while read -r line; do prefix "$i" "$line" "$VMs"; done &
     echo $! > vm${i}log.pid
     # don't mix up the initial --- Configuration --- part
     sleep 0.13


### PR DESCRIPTION
### Motivation and Context
CI test failed with very rare messages.

CTR is shared by two VMs, and the test cases have a 'global' counter. However after this commit, vm1 or vm2  does counting independently, and in Test Summary, the total number is still correctly combining. So just make vm1/vm2 using separated CTR by appending its ID, if no other reason that we need a global counter.

### Description
```shell
[vm1: 00:23:57    1] Test: functional/cli_root/zfs_rename/zfs_rename_013_pos (run as root) [00:00] [PASS]
.github/workflows/scripts/qemu-6-tests.sh: line 27: 1
6: syntax error in expression (error token is "6")
.github/workflows/scripts/qemu-6-tests.sh: line 27: 1
6: syntax error in expression (error token is "6")
.github/workflows/scripts/qemu-6-tests.sh: line 135: kill: (21594) - No such process
```

### How Has This Been Tested?
CI test pass

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [X] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
