### PR TITLE
libzfs: clarify the raw incremental "IV set guid mismatch" error

### DIFF
--- a/include/sys/dmu_recv.h
+++ b/include/sys/dmu_recv.h
@@ -55,6 +55,8 @@ typedef struct dmu_recv_cookie {
 	boolean_t drc_raw;
 	boolean_t drc_clone;
 	boolean_t drc_spill;
+	/* This non-raw incremental diverges the ivset of a raw lineage. */
+	boolean_t drc_ivset_diverged;
 	nvlist_t *drc_keynvl;
 	uint64_t drc_fromsnapobj;
 	uint64_t drc_ivset_guid;

--- a/include/sys/dsl_dataset.h
+++ b/include/sys/dsl_dataset.h
@@ -130,6 +130,15 @@ struct zfs_bookmark_phys;
 #define	DS_FIELD_IVSET_GUID	"com.datto:ivset_guid"
 
 /*
+ * This field, when present, marks a snapshot that was received raw. A later
+ * non-raw incremental receive onto such a snapshot re-stamps its ivset guid
+ * and so diverges it from the sending lineage, which makes any subsequent raw
+ * incremental fail with an IV set guid mismatch; the field lets the receive
+ * warn about that as it happens instead of only failing later (see #8758).
+ */
+#define	DS_FIELD_RAW_RECEIVED	"org.openzfs:raw_received"
+
+/*
  * DS_FLAG_CI_DATASET is set if the dataset contains a file system whose
  * name lookups should be performed case-insensitively.
  */

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -393,7 +393,13 @@ typedef enum {
 
 typedef enum {
 	ZPROP_ERR_NOCLEAR = 0x1, /* failure to clear existing props */
-	ZPROP_ERR_NORESTORE = 0x2 /* failure to restore props on error */
+	ZPROP_ERR_NORESTORE = 0x2, /* failure to restore props on error */
+	/*
+	 * A non-raw incremental was received onto a raw-received lineage,
+	 * diverging its IV set, so that a later raw incremental will fail with
+	 * an IV set guid mismatch (see #8758). A warning, not a property error.
+	 */
+	ZPROP_ERR_IVSET_DIVERGED = 0x4
 } zprop_errflags_t;
 
 typedef int (*zprop_func)(int, void *);

--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -5284,9 +5284,17 @@ zfs_receive_one(libzfs_handle_t *hdl, int infd, const char *tosnap,
 			break;
 		case ZFS_ERR_FROM_IVSET_GUID_MISMATCH:
 			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-			    "IV set guid mismatch. See the 'zfs receive' "
-			    "man page section\n discussing the limitations "
-			    "of raw encrypted send streams."));
+			    "IV set guid mismatch. The incremental source "
+			    "snapshot on the\ndestination no longer has the "
+			    "IV set it was sent with, most commonly\nbecause "
+			    "it was received as a non-raw (plain) stream. Raw "
+			    "replication\ncan be resumed by rolling the "
+			    "destination back to the most recent\nsnapshot "
+			    "that was received raw and taking the raw "
+			    "incremental from\nthere, or by receiving a new "
+			    "full raw (zfs send -w) stream. See the\n'zfs "
+			    "receive' man page section discussing the "
+			    "limitations of raw\nencrypted send streams."));
 			(void) zfs_error(hdl, EZFS_BADSTREAM, errbuf);
 			break;
 		case ZFS_ERR_SPILL_BLOCK_FLAG_MISSING:

--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -5364,6 +5364,16 @@ zfs_receive_one(libzfs_handle_t *hdl, int infd, const char *tosnap,
 		    "failed to restore original properties on %s"), name);
 		(void) fprintf(stderr, "\n");
 	}
+	if (prop_errflags & ZPROP_ERR_IVSET_DIVERGED) {
+		(void) fprintf(stderr, dgettext(TEXT_DOMAIN, "Warning: "
+		    "the snapshot '%s' is based on was received as a raw "
+		    "stream, but\nthis incremental is not raw; it re-encrypts "
+		    "the data with a new IV set,\nso a later raw (zfs send -w) "
+		    "incremental based on it will fail with an\nIV set guid "
+		    "mismatch. Send this incremental raw as well to keep raw\n"
+		    "replication working."), destsnap);
+		(void) fprintf(stderr, "\n");
+	}
 
 	if (err || ioctl_err) {
 		err = -1;

--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -1347,7 +1347,8 @@ lzc_receive_with_header(const char *snapname, nvlist_t *props,
  * The 'read_bytes' value will be set to the total number of bytes read.
  *
  * The 'errflags' value will contain zprop_errflags_t flags which are
- * used to describe any failures.
+ * used to describe any failures, including ZPROP_ERR_IVSET_DIVERGED which
+ * warns that a non-raw incremental diverged a raw-received IV set.
  *
  * The 'action_handle' and 'cleanup_fd' are no longer used, and are ignored.
  *

--- a/man/man8/zfs-receive.8
+++ b/man/man8/zfs-receive.8
@@ -191,6 +191,14 @@ When an incremental raw receive is performed on
 top of an existing snapshot, ZFS will check to confirm that the "from"
 snapshot on both the source and destination were using the same IV set,
 ensuring the new IV set is consistent.
+Note that receiving a non-raw stream on top of a raw received file system is
+allowed, but replaces the IV set of the newly received snapshot with a
+different one.
+Any subsequent raw incremental receive based on such a snapshot will
+therefore fail with an "IV set guid mismatch" error.
+Raw replication can be resumed by rolling the destination back to the most
+recent snapshot that was received raw and taking the raw incremental from
+there, or by receiving a new full raw stream.
 .Pp
 The name of the snapshot
 .Pq and file system, if a full stream is received

--- a/module/zfs/dmu_recv.c
+++ b/module/zfs/dmu_recv.c
@@ -478,6 +478,22 @@ recv_begin_check_existing_impl(dmu_recv_begin_arg_t *drba, dsl_dataset_t *ds,
 		if (obj == 0)
 			return (SET_ERROR(ENODEV));
 
+		/*
+		 * A non-raw incremental onto a snapshot that was itself
+		 * received raw re-stamps the new snapshot's ivset guid, so it
+		 * no longer matches the sending lineage and a later raw
+		 * incremental would be rejected (#8758). Note it here so the
+		 * receive can warn about it as it happens.
+		 */
+		if (encrypted && !raw) {
+			uint64_t rawrecv = 0;
+			(void) zap_lookup(dp->dp_meta_objset, snap->ds_object,
+			    DS_FIELD_RAW_RECEIVED, sizeof (uint64_t), 1,
+			    &rawrecv);
+			if (rawrecv != 0)
+				drba->drba_cookie->drc_ivset_diverged = B_TRUE;
+		}
+
 		if (drba->drba_cookie->drc_force) {
 			drba->drba_cookie->drc_fromsnapobj = obj;
 		} else {
@@ -1178,8 +1194,24 @@ dmu_recv_resume_begin_check(void *arg, dmu_tx_t *tx)
 		return (SET_ERROR(EINVAL));
 	}
 
-	if (ds->ds_prev != NULL && drrb->drr_fromguid != 0)
+	if (ds->ds_prev != NULL && drrb->drr_fromguid != 0) {
 		drc->drc_fromsnapobj = ds->ds_prev->ds_object;
+
+		/*
+		 * As in recv_begin_check_existing_impl(): if this non-raw
+		 * incremental resumes onto a raw-received snapshot, note that
+		 * it is diverging the IV set so the receive can warn (#8758).
+		 */
+		if (ds->ds_dir->dd_crypto_obj != 0 &&
+		    !(drc->drc_featureflags & DMU_BACKUP_FEATURE_RAW)) {
+			uint64_t rawrecv = 0;
+			(void) zap_lookup(dp->dp_meta_objset,
+			    drc->drc_fromsnapobj, DS_FIELD_RAW_RECEIVED,
+			    sizeof (uint64_t), 1, &rawrecv);
+			if (rawrecv != 0)
+				drc->drc_ivset_diverged = B_TRUE;
+		}
+	}
 
 	/*
 	 * If we're resuming, and the send is redacted, then the original send
@@ -3804,6 +3836,22 @@ dmu_recv_end_sync(void *arg, dmu_tx_t *tx)
 		VERIFY0(zap_update(dp->dp_meta_objset, newsnapobj,
 		    DS_FIELD_IVSET_GUID, sizeof (uint64_t), 1,
 		    &drc->drc_ivset_guid, tx));
+	}
+
+	/*
+	 * Mark a raw-received snapshot so a later non-raw incremental onto it
+	 * can warn that it is diverging the IV set (see #8758). This is not
+	 * gated on drc_ivset_guid, so streams from older senders that omit it
+	 * (received under zfs_disable_ivset_guid_check) are still marked.
+	 * Snapshots on pools written before this change simply lack the key
+	 * and receive no warning.
+	 */
+	if (!drc->drc_heal && drc->drc_raw) {
+		uint64_t one = 1;
+		dmu_object_zapify(dp->dp_meta_objset, newsnapobj,
+		    DMU_OT_DSL_DATASET, tx);
+		VERIFY0(zap_update(dp->dp_meta_objset, newsnapobj,
+		    DS_FIELD_RAW_RECEIVED, sizeof (uint64_t), 1, &one, tx));
 	}
 
 	/*

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -5681,6 +5681,14 @@ zfs_ioc_recv_impl(char *tofs, char *tosnap, const char *origin,
 	tofs_was_redacted = dsl_get_redacted(drc.drc_ds);
 
 	/*
+	 * dmu_recv_begin() found this to be a non-raw incremental onto a
+	 * raw-received lineage, which diverges its IV set (see #8758). Flag it
+	 * so libzfs can warn the user.
+	 */
+	if (drc.drc_ivset_diverged)
+		*errflags |= ZPROP_ERR_IVSET_DIVERGED;
+
+	/*
 	 * Set properties before we receive the stream so that they are applied
 	 * to the new data. Note that we must call dmu_recv_stream() if
 	 * dmu_recv_begin() succeeds.

--- a/tests/zfs-tests/tests/functional/rsend/send_mixed_raw.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send_mixed_raw.ksh
@@ -32,9 +32,16 @@
 #	3. Perform a non-raw send of the second snapshot to one of
 #	   the other datasets. Perform a raw send from this dataset to
 #	   the last one.
-#	4. Attempt to raw send the final snapshot of the first dataset
+#	4. Verify that the snapshot received non-raw in step 3 kept the
+#	   guid of its source but was assigned a fresh IV set guid.
+#	   This silent divergence is what makes the raw incremental
+#	   receives below fail (issue #8758).
+#	5. Attempt to raw send the final snapshot of the first dataset
 #	   to the other 2 datasets, which should fail.
-#	5. Repeat steps 1-4, but using bookmarks for incremental sends.
+#	6. Verify that the same raw send is accepted once the IV set
+#	   guid check is disabled, and that the raw receive then stamps
+#	   the sender's IV set guid onto the new snapshot.
+#	7. Repeat steps 1-5, but using bookmarks for incremental sends.
 #
 #
 # A                 B             C     notes
@@ -49,6 +56,7 @@ verify_runnable "both"
 
 function cleanup
 {
+    set_tunable32 DISABLE_IVSET_GUID_CHECK 0
     datasetexists $TESTPOOL/$TESTFS3 && \
         destroy_dataset $TESTPOOL/$TESTFS3 -r
     datasetexists $TESTPOOL/$TESTFS2 && \
@@ -79,15 +87,56 @@ log_must eval "zfs send -w $TESTPOOL/$TESTFS2@1 |" \
     "zfs receive $TESTPOOL/$TESTFS3"
 log_must eval "echo $passphrase | zfs load-key $TESTPOOL/$TESTFS3"
 
+# A raw receive preserves both the dataset guid and the IV set guid.
+typeset src_guid=$(get_prop guid $TESTPOOL/$TESTFS1@1)
+typeset dst_guid=$(get_prop guid $TESTPOOL/$TESTFS2@1)
+typeset src_ivset=$(get_prop ivsetguid $TESTPOOL/$TESTFS1@1)
+typeset dst_ivset=$(get_prop ivsetguid $TESTPOOL/$TESTFS2@1)
+# Guard against get_prop returning "-"/empty, which would make the
+# equality/inequality checks below pass vacuously.
+[[ -n "$src_ivset" && "$src_ivset" != "-" && \
+    -n "$dst_ivset" && "$dst_ivset" != "-" ]] || \
+    log_fail "missing IV set guid: '$src_ivset' '$dst_ivset'"
+[[ "$src_guid" == "$dst_guid" ]] || \
+    log_fail "guid differs after raw receive: $src_guid vs $dst_guid"
+[[ "$src_ivset" == "$dst_ivset" ]] || \
+    log_fail "ivsetguid differs after raw receive: $src_ivset vs $dst_ivset"
+
 log_must eval "zfs send -i $TESTPOOL/$TESTFS1@1 $TESTPOOL/$TESTFS1@2 |" \
     "zfs receive $TESTPOOL/$TESTFS2"
 log_must eval "zfs send -w -i $TESTPOOL/$TESTFS2@1 $TESTPOOL/$TESTFS2@2 |" \
     "zfs receive $TESTPOOL/$TESTFS3"
 
+# A non-raw incremental receive copies the dataset guid from the send
+# stream but generates a fresh IV set guid on the destination. The two
+# snapshots look identical to guid-matching tools while their IV sets
+# have silently diverged; this is what makes the raw incremental
+# receives below fail (issue #8758).
+src_guid=$(get_prop guid $TESTPOOL/$TESTFS1@2)
+dst_guid=$(get_prop guid $TESTPOOL/$TESTFS2@2)
+src_ivset=$(get_prop ivsetguid $TESTPOOL/$TESTFS1@2)
+dst_ivset=$(get_prop ivsetguid $TESTPOOL/$TESTFS2@2)
+[[ "$src_guid" == "$dst_guid" ]] || \
+    log_fail "guid differs after non-raw receive: $src_guid vs $dst_guid"
+[[ "$src_ivset" != "$dst_ivset" ]] || \
+    log_fail "ivsetguid unexpectedly matches after non-raw receive"
+
 log_mustnot eval "zfs send -w -i $TESTPOOL/$TESTFS1@2 $TESTPOOL/$TESTFS1@3 |" \
     "zfs receive $TESTPOOL/$TESTFS2"
 log_mustnot eval "zfs send -w -i $TESTPOOL/$TESTFS2@2 $TESTPOOL/$TESTFS2@3 |" \
     "zfs receive $TESTPOOL/$TESTFS3"
+
+# The IV set guid check is the only gate: with the check disabled the
+# same raw incremental is accepted, and the raw receive stamps the
+# sender's IV set guid onto the newly created snapshot.
+log_must set_tunable32 DISABLE_IVSET_GUID_CHECK 1
+log_must eval "zfs send -w -i $TESTPOOL/$TESTFS1@2 $TESTPOOL/$TESTFS1@3 |" \
+    "zfs receive $TESTPOOL/$TESTFS2"
+log_must set_tunable32 DISABLE_IVSET_GUID_CHECK 0
+src_ivset=$(get_prop ivsetguid $TESTPOOL/$TESTFS1@3)
+dst_ivset=$(get_prop ivsetguid $TESTPOOL/$TESTFS2@3)
+[[ "$src_ivset" == "$dst_ivset" ]] || \
+    log_fail "ivsetguid differs after raw receive: $src_ivset vs $dst_ivset"
 
 log_must zfs destroy -r $TESTPOOL/$TESTFS3
 log_must zfs destroy -r $TESTPOOL/$TESTFS2

--- a/tests/zfs-tests/tests/functional/rsend/send_mixed_raw.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send_mixed_raw.ksh
@@ -54,9 +54,12 @@
 
 verify_runnable "both"
 
+typeset recverr=$TEST_BASE_DIR/send_mixed_raw.err.$$
+
 function cleanup
 {
     set_tunable32 DISABLE_IVSET_GUID_CHECK 0
+    rm -f $recverr
     datasetexists $TESTPOOL/$TESTFS3 && \
         destroy_dataset $TESTPOOL/$TESTFS3 -r
     datasetexists $TESTPOOL/$TESTFS2 && \
@@ -122,9 +125,14 @@ dst_ivset=$(get_prop ivsetguid $TESTPOOL/$TESTFS2@2)
     log_fail "ivsetguid unexpectedly matches after non-raw receive"
 
 log_mustnot eval "zfs send -w -i $TESTPOOL/$TESTFS1@2 $TESTPOOL/$TESTFS1@3 |" \
-    "zfs receive $TESTPOOL/$TESTFS2"
+    "zfs receive $TESTPOOL/$TESTFS2 2>$recverr"
 log_mustnot eval "zfs send -w -i $TESTPOOL/$TESTFS2@2 $TESTPOOL/$TESTFS2@3 |" \
     "zfs receive $TESTPOOL/$TESTFS3"
+
+# The error must name the IV set divergence and the non-raw receive
+# that caused it, so that the failure is diagnosable from the message.
+log_must grep -q "IV set guid mismatch" $recverr
+log_must grep -q "non-raw" $recverr
 
 # The IV set guid check is the only gate: with the check disabled the
 # same raw incremental is accepted, and the raw receive stamps the

--- a/tests/zfs-tests/tests/functional/rsend/send_mixed_raw.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send_mixed_raw.ksh
@@ -55,11 +55,12 @@
 verify_runnable "both"
 
 typeset recverr=$TEST_BASE_DIR/send_mixed_raw.err.$$
+typeset recvwarn=$TEST_BASE_DIR/send_mixed_raw.warn.$$
 
 function cleanup
 {
     set_tunable32 DISABLE_IVSET_GUID_CHECK 0
-    rm -f $recverr
+    rm -f $recverr $recvwarn
     datasetexists $TESTPOOL/$TESTFS3 && \
         destroy_dataset $TESTPOOL/$TESTFS3 -r
     datasetexists $TESTPOOL/$TESTFS2 && \
@@ -106,9 +107,17 @@ typeset dst_ivset=$(get_prop ivsetguid $TESTPOOL/$TESTFS2@1)
     log_fail "ivsetguid differs after raw receive: $src_ivset vs $dst_ivset"
 
 log_must eval "zfs send -i $TESTPOOL/$TESTFS1@1 $TESTPOOL/$TESTFS1@2 |" \
-    "zfs receive $TESTPOOL/$TESTFS2"
+    "zfs receive $TESTPOOL/$TESTFS2 2>$recvwarn"
+
+# The receive above is a non-raw incremental onto a snapshot that was
+# itself received raw, so it warns as it happens that it is diverging the
+# IV set and will break a later raw incremental (issue #8758).
+log_must grep -q "Warning:" $recvwarn
+
+# The matching raw incremental must not warn: it does not diverge anything.
 log_must eval "zfs send -w -i $TESTPOOL/$TESTFS2@1 $TESTPOOL/$TESTFS2@2 |" \
-    "zfs receive $TESTPOOL/$TESTFS3"
+    "zfs receive $TESTPOOL/$TESTFS3 2>$recvwarn"
+log_mustnot grep -q "Warning:" $recvwarn
 
 # A non-raw incremental receive copies the dataset guid from the send
 # stream but generates a fresh IV set guid on the destination. The two


### PR DESCRIPTION
### Motivation and Context

Fixes the confusing failure mode behind #8758. Raw encrypted incremental
replication can silently enter a state where every subsequent `zfs send -w`
is rejected with:

```
cannot receive incremental stream: IV set guid mismatch.
```

The error names neither the cause nor a remedy, so it is routinely
misread as spontaneous corruption — users end up destroying and
re-sending multi-terabyte datasets.

### Description

The trigger is a single **non-raw** incremental receive into an
otherwise raw-received encrypted dataset (e.g. a replication tool that
falls back to, or is misconfigured to omit, `-w` for one run). A non-raw
receive copies the sender's dataset guid onto the new snapshot but
re-encrypts the data with the destination's own key and a freshly
generated IV set. The snapshot therefore looks identical to guid-matching
tools while its IV set has diverged, and any later raw incremental built
on top of it is (correctly) rejected — receiving it would mix two
incompatible ciphertext lineages.

The `ZFS_ERR_FROM_IVSET_GUID_MISMATCH` check itself is doing the right
thing, so this change is purely diagnostic:

- **libzfs**: rewrite the error to name the non-raw-receive cause and the
  recovery (roll the destination back to the most recent raw-received
  snapshot and take the raw incremental from there, or receive a new full
  raw stream).
- **zfs-receive.8**: document the same pitfall in the existing IV-set
  section.
- **ZTS**: `send_mixed_raw` already exercised the failing sequence but only
  asserted the final failure. Extend it to pin the mechanism (a raw receive
  preserves guid+ivsetguid; a non-raw receive keeps the guid but diverges
  the ivsetguid; the ivset check is the sole gate, provable by toggling
  `zfs_disable_ivset_guid_check`) and to assert the new message names the
  cause.

Deliberately out of scope: rejecting the poisoning non-raw receive up
front. There is no persistent "raw-received lineage" marker to key that
on, and mixing raw/non-raw receives is intentionally supported
(`dmu_objset.c`), so a hard reject would fight existing design intent and
over-reject a legitimate workflow. That is a larger design discussion;
this PR only makes the existing, correct rejection diagnosable.

### How Has This Been Tested?

Built on Linux (Ubuntu, aarch64) and replayed the `send_mixed_raw`
sequence against the freshly built tools: the extended guid/ivsetguid
assertions hold and the rejected raw incremental prints the new message
(both added greps match). `cstyle.pl` clean on `libzfs_sendrecv.c`; no new
`mandoc -T lint` warnings on `zfs-receive.8`.

### Types of changes
- [x] Documentation / diagnostics (non-breaking)
- [x] Test coverage

### Checklist
- [x] My code follows the OpenZFS code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All commit messages are signed off.
