### PR TITLE
ZTS: add scrub-from-txg into the runfile

### DIFF
--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -457,7 +457,7 @@ tags = ['functional', 'cli_root', 'zpool_detach']
 [tests/functional/cli_root/zpool_events]
 tests = ['zpool_events_clear', 'zpool_events_cliargs', 'zpool_events_follow',
     'zpool_events_poolname', 'zpool_events_errors', 'zpool_events_duplicates',
-    'zpool_events_clear_retained']
+    'zpool_events_clear_retained', 'zpool_events_scrub_txg_continue_from_last']
 tags = ['functional', 'cli_root', 'zpool_events']
 
 [tests/functional/cli_root/zpool_export]
@@ -570,7 +570,7 @@ tests = ['zpool_scrub_001_neg', 'zpool_scrub_002_pos', 'zpool_scrub_003_pos',
     'zpool_error_scrub_001_pos', 'zpool_error_scrub_002_pos',
     'zpool_error_scrub_003_pos', 'zpool_error_scrub_004_pos',
     'zpool_scrub_date_range_001', 'zpool_scrub_date_range_002',
-    'zpool_scrub_thorough']
+    'zpool_scrub_thorough', 'zpool_scrub_txg_continue_from_last']
 tags = ['functional', 'cli_root', 'zpool_scrub']
 
 [tests/functional/cli_root/zpool_set]

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_txg_continue_from_last.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_txg_continue_from_last.ksh
@@ -49,44 +49,47 @@
 
 verify_runnable "global"
 
+VDEV0=$TEST_BASE_DIR/scrub_txg_vdev0
+VDEV1=$TEST_BASE_DIR/scrub_txg_vdev1
+
 function cleanup
 {
 	log_must zinject -c all
-	log_must rm -f $mntpnt/f1
-	log_must rm -f $mntpnt/f2
+	destroy_pool $TESTPOOL2
+	log_must rm -f $VDEV0 $VDEV1
 }
 
 log_onexit cleanup
 
 log_assert "Verify scrub -C."
 
-# last_scrubbed_txg must be 0, so recreate the pool in case an earlier
-# test has already scrubbed it.
-destroy_pool $TESTPOOL
-log_must default_mirror_setup_noexit $DISK1 $DISK2
+# last_scrubbed_txg persists once a scrub completes, so the pool must be
+# one no other test has scrubbed.
+log_must truncate -s $MINVDEVSIZE $VDEV0 $VDEV1
+log_must zpool create -f $TESTPOOL2 mirror $VDEV0 $VDEV1
 
 # Create one file.
-mntpnt=$(get_prop mountpoint $TESTPOOL/$TESTFS)
+mntpnt=$(get_prop mountpoint $TESTPOOL2)
 
 log_must file_write -b 1048576 -c 10 -o create -d 0 -f $mntpnt/f1
-log_must sync_pool $TESTPOOL true
-f1txg=$(get_last_txg_synced $TESTPOOL)
+log_must sync_pool $TESTPOOL2 true
+f1txg=$(get_last_txg_synced $TESTPOOL2)
 
 # Verify that last_scrubbed_txg isn't set.
-zpoollasttxg=$(zpool get -H -o value last_scrubbed_txg $TESTPOOL)
+zpoollasttxg=$(zpool get -H -o value last_scrubbed_txg $TESTPOOL2)
 log_must [ $zpoollasttxg -eq 0 ]
 
 # Run scrub.
-log_must zpool scrub -w $TESTPOOL
+log_must zpool scrub -w $TESTPOOL2
 
 # Verify that last_scrubbed_txg is set.
-zpoollasttxg=$(zpool get -H -o value last_scrubbed_txg $TESTPOOL)
+zpoollasttxg=$(zpool get -H -o value last_scrubbed_txg $TESTPOOL2)
 log_must [ $zpoollasttxg -ne 0 ]
 
 # Create second file.
 log_must file_write -b 1048576 -c 10 -o create -d 0 -f $mntpnt/f2
-log_must sync_pool $TESTPOOL true
-f2txg=$(get_last_txg_synced $TESTPOOL)
+log_must sync_pool $TESTPOOL2 true
+f2txg=$(get_last_txg_synced $TESTPOOL2)
 
 # Make sure that the sync txg are different.
 log_must [ $f1txg -ne $f2txg ]
@@ -96,15 +99,15 @@ log_must zinject -a -t data -e io -T read $mntpnt/f1
 log_must zinject -a -t data -e io -T read $mntpnt/f2
 
 # Run scrub from last saved point.
-log_must zpool scrub -w -C $TESTPOOL
+log_must zpool scrub -w -C $TESTPOOL2
 
 # Verify that only newer file was detected.
-log_mustnot eval "zpool status -v $TESTPOOL | grep '$mntpnt/f1'"
-log_must eval "zpool status -v $TESTPOOL | grep '$mntpnt/f2'"
+log_mustnot eval "zpool status -v $TESTPOOL2 | grep '$mntpnt/f1'"
+log_must eval "zpool status -v $TESTPOOL2 | grep '$mntpnt/f2'"
 
 # Verify that both files are corrupted.
-log_must zpool scrub -w $TESTPOOL
-log_must eval "zpool status -v $TESTPOOL | grep '$mntpnt/f1'"
-log_must eval "zpool status -v $TESTPOOL | grep '$mntpnt/f2'"
+log_must zpool scrub -w $TESTPOOL2
+log_must eval "zpool status -v $TESTPOOL2 | grep '$mntpnt/f1'"
+log_must eval "zpool status -v $TESTPOOL2 | grep '$mntpnt/f2'"
 
 log_pass "Verified scrub -C show expected status."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_txg_continue_from_last.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_scrub/zpool_scrub_txg_continue_from_last.ksh
@@ -60,6 +60,11 @@ log_onexit cleanup
 
 log_assert "Verify scrub -C."
 
+# last_scrubbed_txg must be 0, so recreate the pool in case an earlier
+# test has already scrubbed it.
+destroy_pool $TESTPOOL
+log_must default_mirror_setup_noexit $DISK1 $DISK2
+
 # Create one file.
 mntpnt=$(get_prop mountpoint $TESTPOOL/$TESTFS)
 


### PR DESCRIPTION
### Motivation and Context

`zpool_scrub_txg_continue_from_last` (#16301) and `zpool_events_scrub_txg_continue_from_last` (#17432) are listed in Makefile.am but not referenced in common.run. The scripts are never executed by the CI.

### Description

Add the two tests in `tests/runfiles/common.run`.

Running `zpool_scrub_txg_continue_from_last` in its runfile position fails because it assumes the `last_scrubbed_txg` is initially 0, which is only true on a pool with no scrub history. However earlier tests in the test group scrub` $TESTPOOL`. 
The solution is to create a second dedicated pool so it passes regardless of its execution position.

### How Has This Been Tested?
Tested on Linux with ZFS master branch and 7.2-rc2 kernel.

```
Test: .../cli_root/zpool_events/zpool_events_scrub_txg_continue_from_last (run as root) [00:00] [PASS]
Test: .../cli_root/zpool_scrub/zpool_scrub_txg_continue_from_last (run as root) [00:03] [PASS]

zpool_scrub group Results Summary: PASS 20 (of 20), Running Time 00:09:08
zpool_events group Results Summary: PASS 10 (of 10)
```

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes the code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).