### PR TITLE
ZTS/block_cloning: test `COPY_FILE_RANGE_CLONE` on FreeBSD 15+

### DIFF
--- a/tests/runfiles/freebsd.run
+++ b/tests/runfiles/freebsd.run
@@ -22,6 +22,12 @@ failsafe_user = root
 failsafe = callbacks/zfs_failsafe
 tags = ['functional']
 
+[tests/functional/block_cloning:FreeBSD]
+tests = ['block_cloning_copyfilerange_clone',
+    'block_cloning_copyfilerange_clone_partial',
+    'block_cloning_disabled_copyfilerange_clone']
+
+tags = ['functional', 'block_cloning']
 [tests/functional/cli_root/zfs_jail:FreeBSD]
 tests = ['zfs_jail_001_pos']
 tags = ['functional', 'cli_root', 'zfs_jail']

--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -291,6 +291,12 @@ if sys.platform.startswith('freebsd'):
             ['SKIP', cfr_cross_reason],
         'block_cloning/block_cloning_copyfilerange_cross_dataset':
             ['SKIP', cfr_cross_reason],
+        'block_cloning/block_cloning_copyfilerange_clone':
+            ['SKIP', cfr_reason],
+        'block_cloning/block_cloning_copyfilerange_clone_partial':
+            ['SKIP', cfr_reason],
+        'block_cloning/block_cloning_disabled_copyfilerange_clone':
+            ['SKIP', cfr_reason],
         'stat/statx_dioalign': ['SKIP', 'na_reason'],
     })
 elif sys.platform.startswith('linux'):

--- a/tests/zfs-tests/cmd/clonefile.c
+++ b/tests/zfs-tests/cmd/clonefile.c
@@ -2,6 +2,7 @@
  * SPDX-License-Identifier: MIT
  *
  * Copyright (c) 2023, Rob Norris <robn@despairlabs.com>
+ * Copyright (c) 2026, TrueNAS.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to
@@ -23,9 +24,9 @@
  */
 
 /*
- * This program is to test the availability and behaviour of copy_file_range,
- * FICLONE, FICLONERANGE and FIDEDUPERANGE in the Linux kernel. It should
- * compile and run even if these features aren't exposed through the libc.
+ * This program is to test the availability and behaviour of various data
+ * cloning system calls. It should compile and run even if these features
+ * aren't exposed through the libc.
  */
 
 #include <sys/ioctl.h>
@@ -40,6 +41,12 @@
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
+
+#if defined(__linux__)
+/*
+ * Not all Linux libc implementations define or expose copy_file_range(),
+ * for these we fall back to the syscall directly.
+ */
 
 #ifndef __NR_copy_file_range
 #if defined(__x86_64__)
@@ -59,7 +66,7 @@
 #endif
 #endif /* __NR_copy_file_range */
 
-#if defined(_GNU_SOURCE) && defined(__linux__)
+#if defined(_GNU_SOURCE)
 _Static_assert(sizeof (loff_t) == sizeof (off_t),
 	"loff_t and off_t must be the same size");
 #endif
@@ -77,6 +84,21 @@ cf_copy_file_range(int sfd, off_t *soff, int dfd, off_t *doff,
 	return (
 	    syscall(__NR_copy_file_range, sfd, soff, dfd, doff, len, flags));
 }
+
+#else
+/* Other platforms, let the linker sort it out. */
+static inline ssize_t
+cf_copy_file_range(int sfd, off_t *soff, int dfd, off_t *doff,
+    size_t len, unsigned int flags)
+{
+	return (copy_file_range(sfd, soff, dfd, doff, len, flags));
+}
+#endif
+
+/*
+ * Like above, not all libcs define the types we need for the ioctl-based
+ * clone calls, so define any that are missing directly.
+ */
 
 /* Define missing FICLONE */
 #ifdef FICLONE
@@ -125,6 +147,14 @@ typedef struct {
 #define	CF_FIDEDUPERANGE		_IOWR(0x94, 54, cf_file_dedupe_range_t)
 #define	CF_FILE_DEDUPE_RANGE_SAME	(0)
 #define	CF_FILE_DEDUPE_RANGE_DIFFERS	(1)
+
+/* Define missing COPY_FILE_RANGE_CLONE flag. */
+#ifdef	COPY_FILE_RANGE_CLONE
+#define	CF_COPY_FILE_RANGE_CLONE	COPY_FILE_RANGE_CLONE
+#else
+#define	CF_COPY_FILE_RANGE_CLONE	(0x00800000)
+#endif
+
 #endif
 
 typedef enum {
@@ -132,6 +162,7 @@ typedef enum {
 	CF_MODE_CLONE,
 	CF_MODE_CLONERANGE,
 	CF_MODE_COPYFILERANGE,
+	CF_MODE_COPYFILERANGE_CLONE,
 	CF_MODE_DEDUPERANGE,
 } cf_mode_t;
 
@@ -146,6 +177,8 @@ usage(void)
 	    "    clonefile -r <src> <dst> <soff> <doff> <len>\n"
 	    "  copy_file_range:\n"
 	    "    clonefile -f <src> <dst> [<soff> <doff> <len | \"all\">]\n"
+	    "  copy_file_range(CLONE):\n"
+	    "    clonefile -F <src> <dst> [<soff> <doff> <len | \"all\">]\n"
 	    "  FIDEDUPERANGE:\n"
 	    "    clonefile -d <src> <dst> <soff> <doff> <len>\n");
 	return (1);
@@ -154,6 +187,8 @@ usage(void)
 int do_clone(int sfd, int dfd);
 int do_clonerange(int sfd, int dfd, off_t soff, off_t doff, size_t len);
 int do_copyfilerange(int sfd, int dfd, off_t soff, off_t doff, size_t len);
+int do_copyfilerange_clone(int sfd, int dfd, off_t soff, off_t doff,
+    size_t len);
 int do_deduperange(int sfd, int dfd, off_t soff, off_t doff, size_t len);
 
 int quiet = 0;
@@ -164,7 +199,7 @@ main(int argc, char **argv)
 	cf_mode_t mode = CF_MODE_NONE;
 
 	int c;
-	while ((c = getopt(argc, argv, "crfdq")) != -1) {
+	while ((c = getopt(argc, argv, "crfFdq")) != -1) {
 		switch (c) {
 			case 'c':
 				mode = CF_MODE_CLONE;
@@ -174,6 +209,9 @@ main(int argc, char **argv)
 				break;
 			case 'f':
 				mode = CF_MODE_COPYFILERANGE;
+				break;
+			case 'F':
+				mode = CF_MODE_COPYFILERANGE_CLONE;
 				break;
 			case 'd':
 				mode = CF_MODE_DEDUPERANGE;
@@ -197,6 +235,7 @@ main(int argc, char **argv)
 				return (usage());
 			break;
 		case CF_MODE_COPYFILERANGE:
+		case CF_MODE_COPYFILERANGE_CLONE:
 			if ((argc-optind) != 2 && (argc-optind) != 5)
 				return (usage());
 			break;
@@ -259,6 +298,9 @@ main(int argc, char **argv)
 		case CF_MODE_COPYFILERANGE:
 			err = do_copyfilerange(sfd, dfd, soff, doff, len);
 			break;
+		case CF_MODE_COPYFILERANGE_CLONE:
+			err = do_copyfilerange_clone(sfd, dfd, soff, doff, len);
+			break;
 		case CF_MODE_DEDUPERANGE:
 			err = do_deduperange(sfd, dfd, soff, doff, len);
 			break;
@@ -314,14 +356,15 @@ do_clonerange(int sfd, int dfd, off_t soff, off_t doff, size_t len)
 	return (0);
 }
 
-int
-do_copyfilerange(int sfd, int dfd, off_t soff, off_t doff, size_t len)
+static int
+_do_copyfilerange_impl(int sfd, int dfd, off_t soff, off_t doff, size_t len,
+    unsigned int flags, const char *name)
 {
 	if (!quiet)
-		fprintf(stderr, "using copy_file_range\n");
-	ssize_t copied = cf_copy_file_range(sfd, &soff, dfd, &doff, len, 0);
+		fprintf(stderr, "using %s\n", name);
+	ssize_t copied = cf_copy_file_range(sfd, &soff, dfd, &doff, len, flags);
 	if (copied < 0) {
-		fprintf(stderr, "copy_file_range: %s\n", strerror(errno));
+		fprintf(stderr, "%s: %s\n", name, strerror(errno));
 		return (1);
 	}
 	if (len == SSIZE_MAX) {
@@ -334,11 +377,25 @@ do_copyfilerange(int sfd, int dfd, off_t soff, off_t doff, size_t len)
 		len = sb.st_size;
 	}
 	if (copied != len) {
-		fprintf(stderr, "copy_file_range: copied less than requested: "
-		    "requested=%zu; copied=%zd\n", len, copied);
+		fprintf(stderr, "%s: copied less than requested: "
+		    "requested=%zu; copied=%zd\n", name, len, copied);
 		return (1);
 	}
 	return (0);
+}
+
+int
+do_copyfilerange(int sfd, int dfd, off_t soff, off_t doff, size_t len)
+{
+	return (_do_copyfilerange_impl(sfd, dfd, soff, doff, len, 0,
+	    "copy_file_range"));
+}
+
+int
+do_copyfilerange_clone(int sfd, int dfd, off_t soff, off_t doff, size_t len)
+{
+	return (_do_copyfilerange_impl(sfd, dfd, soff, doff, len,
+	    CF_COPY_FILE_RANGE_CLONE, "copy_file_range(CLONE)"));
 }
 
 int

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -525,7 +525,10 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/block_cloning/block_cloning_copyfilerange_fallback_same_txg.ksh \
 	functional/block_cloning/block_cloning_copyfilerange.ksh \
 	functional/block_cloning/block_cloning_copyfilerange_partial.ksh \
+	functional/block_cloning/block_cloning_copyfilerange_clone.ksh \
+	functional/block_cloning/block_cloning_copyfilerange_clone_partial.ksh \
 	functional/block_cloning/block_cloning_disabled_copyfilerange.ksh \
+	functional/block_cloning/block_cloning_disabled_copyfilerange_clone.ksh \
 	functional/block_cloning/block_cloning_disabled_ficlone.ksh \
 	functional/block_cloning/block_cloning_disabled_ficlonerange.ksh \
 	functional/block_cloning/block_cloning_ficlone.ksh \

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_copyfilerange_clone.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_copyfilerange_clone.ksh
@@ -1,0 +1,62 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2023, Klara Inc.
+# Copyright (c) 2026, TrueNAS.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/block_cloning/block_cloning.kshlib
+
+verify_runnable "global"
+
+if is_freebsd && [[ $(freebsd_version) -lt $(freebsd_version "15.0") ]]; then
+	log_unsupported "COPY_FILE_RANGE_CLONE not available before FreeBSD 15"
+fi
+
+claim="The copy_file_range(CLONE) syscall can clone whole files."
+
+log_assert $claim
+
+function cleanup
+{
+	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+}
+
+log_onexit cleanup
+
+log_must zpool create -o feature@block_cloning=enabled $TESTPOOL $DISKS
+
+log_must dd if=/dev/urandom of=/$TESTPOOL/file1 bs=128K count=4
+log_must sync_pool $TESTPOOL
+
+log_must clonefile -F /$TESTPOOL/file1 /$TESTPOOL/file2 0 0 524288
+log_must sync_pool $TESTPOOL
+
+log_must have_same_content /$TESTPOOL/file1 /$TESTPOOL/file2
+
+typeset blocks=$(get_same_blocks $TESTPOOL file1 $TESTPOOL file2)
+log_must [ "$blocks" = "0 1 2 3" ]
+
+log_pass $claim

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_copyfilerange_clone_partial.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_copyfilerange_clone_partial.ksh
@@ -1,0 +1,70 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2023, Klara Inc.
+# Copyright (c) 2026, TrueNAS.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/block_cloning/block_cloning.kshlib
+
+verify_runnable "global"
+
+if is_freebsd && [[ $(freebsd_version) -lt $(freebsd_version "15.0") ]]; then
+	log_unsupported "COPY_FILE_RANGE_CLONE not available before FreeBSD 15"
+fi
+
+claim="The copy_file_range(CLONE) syscall can clone parts of a file."
+
+log_assert $claim
+
+function cleanup
+{
+	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+}
+
+log_onexit cleanup
+
+log_must zpool create -o feature@block_cloning=enabled $TESTPOOL $DISKS
+
+log_must dd if=/dev/urandom of=/$TESTPOOL/file1 bs=128K count=4
+log_must sync_pool $TESTPOOL
+
+log_must dd if=/$TESTPOOL/file1 of=/$TESTPOOL/file2 bs=128K count=4
+log_must sync_pool $TESTPOOL
+
+log_must have_same_content /$TESTPOOL/file1 /$TESTPOOL/file2
+
+typeset blocks=$(get_same_blocks $TESTPOOL file1 $TESTPOOL file2)
+log_must [ "$blocks" = "" ]
+
+log_must clonefile -F /$TESTPOOL/file1 /$TESTPOOL/file2 131072 131072 262144
+log_must sync_pool $TESTPOOL
+
+log_must have_same_content /$TESTPOOL/file1 /$TESTPOOL/file2
+
+typeset blocks=$(get_same_blocks $TESTPOOL file1 $TESTPOOL file2)
+log_must [ "$blocks" = "1 2" ]
+
+log_pass $claim

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_disabled_copyfilerange_clone.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_disabled_copyfilerange_clone.ksh
@@ -1,0 +1,56 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2023, Klara Inc.
+# Copyright (c) 2026, TrueNAS.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/block_cloning/block_cloning.kshlib
+
+verify_runnable "global"
+
+if is_freebsd && [[ $(freebsd_version) -lt $(freebsd_version "15.0") ]]; then
+	log_unsupported "COPY_FILE_RANGE_CLONE not available before FreeBSD 15"
+fi
+
+claim="The copy_file_range(CLONE) syscall fails when block cloning is disabled."
+
+log_assert $claim
+
+function cleanup
+{
+	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+}
+
+log_onexit cleanup
+
+log_must zpool create -o feature@block_cloning=disabled $TESTPOOL $DISKS
+
+log_must dd if=/dev/urandom of=/$TESTPOOL/file1 bs=128K count=4
+log_must sync_pool $TESTPOOL
+
+log_mustnot clonefile -F /$TESTPOOL/file1 /$TESTPOOL/file2 0 0 524288
+
+log_pass $claim


### PR DESCRIPTION
### Motivation and Context

Turns out FreeBSD 15 gained a "force copy, no fallback" flag. It "just works" out of the box so we already support it, this just adds test support for it.

It's like `FICLONERANGE` in that if the clone fails, there's no fallback to copy, it just fails. However, it's a `copy_file_range()` variant, requested via the `COPY_FILE_RANGE_CLONE` flag, so it supports the other `copy_file_range()` semantics like implied offsets and lengths.

Because it's implemented by the `vn_generic_copy_file_range()` fallback, we already got support for free. This PR just adds tests for it to the test suite.

### Description

Extends `clonefile` with a new mode to add the flag.

Then, copy the `ficlonerange` and `copyfilerange` tests as appropriate to make new `copyfilerange_clone` tests that only run on FreeBSD.

Since its a 15+ feature, the tests are skipped before that.

### How Has This Been Tested?

Manual fiddling to get `clonefile` right, and now the `block_cloning` tag with the new tests pass on 15.1-RELEASE.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).