### PR TITLE
are_write_done should check refcount explicitly

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -7042,13 +7042,46 @@ arc_write_done(zio_t *zio)
 				if (!BP_EQUAL(&zio->io_bp_orig, zio->io_bp))
 					panic("bad overwrite, hdr=%p exists=%p",
 					    (void *)hdr, (void *)exists);
-				ASSERT(zfs_refcount_is_zero(
-				    &exists->b_l1hdr.b_refcnt));
-				arc_change_state(arc_anon, exists);
-				arc_hdr_destroy(exists);
-				mutex_exit(hash_lock);
-				exists = buf_hash_insert(hdr, &hash_lock);
-				ASSERT0P(exists);
+
+				/*
+				 * This is a sync-to-convergence overwrite:
+				 * the new block has the same DVA+birth as a
+				 * block written in an earlier sync pass, so
+				 * buf_hash_insert() found the old header.
+				 *
+				 * The old header may still be in use by a
+				 * concurrent ghost-hit read: a block evicted
+				 * to a ghost state and then re-requested
+				 * between sync passes.  In that case the
+				 * header has IO_IN_PROGRESS set and a
+				 * non-zero refcount from arc_read().  The
+				 * hash lock was released before the read
+				 * I/O was submitted, so arc_write_done()
+				 * can acquire it here and collide.
+				 *
+				 * If we destroy a header that still has an
+				 * I/O in flight, arc_read_done() will
+				 * access freed memory via zio->io_private,
+				 * corrupting whatever reuses it and
+				 * eventually panicking in buf_hash_remove().
+				 *
+				 * Only destroy the old header when it is
+				 * truly idle: no I/O in progress and no
+				 * outstanding references.  Otherwise leave
+				 * it in the hash table — the write data is
+				 * already on disk, so the worst case is a
+				 * cache miss on the next read.
+				 */
+				if (!HDR_IO_IN_PROGRESS(exists) &&
+				    zfs_refcount_is_zero(
+				    &exists->b_l1hdr.b_refcnt)) {
+					arc_change_state(arc_anon, exists);
+					arc_hdr_destroy(exists);
+					mutex_exit(hash_lock);
+					exists = buf_hash_insert(hdr,
+					    &hash_lock);
+					ASSERT0P(exists);
+				}
 			} else if (zio->io_flags & ZIO_FLAG_NOPWRITE) {
 				/* nopwrite */
 				ASSERT(zio->io_prop.zp_nopwrite);


### PR DESCRIPTION
### Motivation and Context
This PR is for #18782 . It is a tricky data corruption issue which should never happens.

### Description
By digging into the code, looks the only possible reason should be a lock issue. arc_read release hash_lock before starting IO. There is a chance other thread could operate on the hdr. And arc_write_done has the chance to destroy it.

### How Has This Been Tested?
Not really, but CI shows no regression.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [X] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
