### PR TITLE
Remove libuutil from the pull request template and fix headings.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,7 @@
 <!--- If your change is a performance enhancement, please provide benchmarks here. -->
 <!--- Please think about using the draft PR feature if appropriate -->
 
-### Types of changes
+### Types of Changes
 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
@@ -24,10 +24,10 @@
 - [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
 - [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
-- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
+- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
 - [ ] Documentation (a change to man pages or other documentation)
 
-### Checklist:
+### Checklist
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 - [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).


### PR DESCRIPTION
- libuutil was removed in adb316f41.
- Normalize section headers to title case.
- Drop the trailing colon on "Checklist".

---

### Motivation and Context
`libuutil` was removed from the tree in adb316f41, but the pull request template still lists it under the "Library ABI change" checkbox. While looking at the file, the section headers are also slightly inconsistent — "Types of changes" is sentence case where the others are title case, and "Checklist" has a stray trailing colon.

### Description
- Drop `libuutil` from the Library ABI change checkbox.
- Rename "Types of changes" to "Types of Changes" for consistency with the surrounding headers.
- Drop the trailing colon on "Checklist".

### How Has This Been Tested?
Documentation-only change to `.github/PULL_REQUEST_TEMPLATE.md`; no code paths are affected. Rendered locally to confirm the Markdown still looks right.

### Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs_core, libnvpair and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist
- [x] My code follows the OpenZFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the contributing document.
- [ ] I have added tests to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
