### PR TITLE
Add zfs_vdev_direct_read_verify tunable

### DIFF
--- a/include/sys/vdev_impl.h
+++ b/include/sys/vdev_impl.h
@@ -664,6 +664,7 @@ int param_set_max_auto_ashift(ZFS_MODULE_PARAM_ARGS);
  * VDEV checksum verification for Direct I/O writes
  */
 extern uint_t zfs_vdev_direct_write_verify;
+extern uint_t zfs_vdev_direct_read_verify;
 
 #ifdef	__cplusplus
 }

--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -502,6 +502,24 @@ May be increased up to
 .Sy ASHIFT_MAX Po 16 Pc ,
 but this may negatively impact pool space efficiency.
 .
+.It Sy zfs_vdev_direct_read_verify Ns = Ns Sy 1 Ns | Ns 0 Pq uint
+If non-zero, then a Direct I/O read's checksum will be verified against the
+data returned to the caller.
+Unlike the write case, this provides no data-integrity guarantee \(em the
+on-disk block is already correct \(em it only detects the caller mutating its
+own
+.Sy O_DIRECT
+buffer while the read is in flight, which is not corruption and self-heals via
+a buffered re-read.
+Each such event causes a
+.Sy dio_verify_rd
+zevent, which can be seen with
+.Nm zpool Cm status Fl d .
+Set this to
+.Sy 0
+to skip Direct I/O read verification for workloads that legitimately recycle
+buffers across concurrent requests.
+.
 .It Sy zfs_vdev_direct_write_verify Ns = Ns Sy Linux 1 | FreeBSD 0 Pq uint
 If non-zero, then a Direct I/O write's checksum will be verified every
 time the write is issued and before it is committed to the block pointer.

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -171,6 +171,17 @@ uint_t zfs_vdev_direct_write_verify = 1;
 uint_t zfs_vdev_direct_write_verify = 0;
 #endif
 
+/*
+ * VDEV checksum verification for Direct I/O reads.  Unlike the write case,
+ * verifying a read offers no data-integrity guarantee -- the on-disk block is
+ * already correct -- it only detects the caller mutating its own O_DIRECT
+ * buffer while the read is in flight (e.g. an application recycling buffers
+ * across concurrent requests).  That is not corruption and self-heals via a
+ * buffered re-read, but it produces spurious dio_verify_rd events.  Set to 0
+ * to skip DIO read verification, as other filesystems do.
+ */
+uint_t zfs_vdev_direct_read_verify = 1;
+
 void
 vdev_dbgmsg(vdev_t *vd, const char *fmt, ...)
 {
@@ -7093,6 +7104,9 @@ ZFS_MODULE_PARAM(zfs, zfs_, dio_write_verify_events_per_second, UINT, ZMOD_RW,
 ZFS_MODULE_PARAM(zfs_vdev, zfs_vdev_, direct_write_verify, UINT, ZMOD_RW,
 	"Direct I/O writes will perform for checksum verification before "
 	"commiting write");
+
+ZFS_MODULE_PARAM(zfs_vdev, zfs_vdev_, direct_read_verify, UINT, ZMOD_RW,
+	"Direct I/O reads will perform checksum verification");
 
 ZFS_MODULE_PARAM(zfs, zfs_, checksum_events_per_second, UINT, ZMOD_RW,
 	"Rate limit checksum events to this many checksum errors per second "

--- a/module/zfs/zio_checksum.c
+++ b/module/zfs/zio_checksum.c
@@ -34,6 +34,8 @@
 #include <sys/abd.h>
 #include <zfs_fletcher.h>
 
+extern uint_t zfs_vdev_direct_read_verify;
+
 /*
  * Checksum vectors.
  *
@@ -584,6 +586,17 @@ zio_checksum_error(zio_t *zio, zio_bad_cksum_t *info)
 		if (error != 0)
 			info->zbc_injected = 1;
 	}
+
+	/*
+	 * A Direct I/O read verifies its checksum over the caller's user
+	 * pages, which can spuriously fail if the application recycles that
+	 * buffer across concurrent O_DIRECT requests.  The on-disk data is
+	 * correct, so honor zfs_vdev_direct_read_verify=0 and suppress the
+	 * error for this case only; all other checksum errors are reported.
+	 */
+	if (error == ECKSUM && (zio->io_flags & ZIO_FLAG_DIO_READ) &&
+	    abd_is_from_pages(data) && zfs_vdev_direct_read_verify == 0)
+		error = 0;
 
 	return (error);
 }

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -739,8 +739,9 @@ tags = ['functional', 'delegate']
 tests = ['dio_aligned_block', 'dio_async_always', 'dio_async_fio_ioengines',
     'dio_compression', 'dio_dedup', 'dio_encryption', 'dio_grow_block',
     'dio_max_recordsize', 'dio_mixed', 'dio_mmap', 'dio_overwrites',
-    'dio_property', 'dio_random', 'dio_read_verify', 'dio_recordsize',
-    'dio_unaligned_block', 'dio_unaligned_filesize']
+    'dio_property', 'dio_random', 'dio_read_verify',
+    'dio_read_verify_tunable', 'dio_recordsize', 'dio_unaligned_block',
+    'dio_unaligned_filesize']
 tags = ['functional', 'direct']
 
 [tests/functional/exec]

--- a/tests/zfs-tests/include/tunables.cfg
+++ b/tests/zfs-tests/include/tunables.cfg
@@ -107,6 +107,7 @@ VDEV_FILE_PHYSICAL_ASHIFT	vdev.file.physical_ashift	vdev_file_physical_ashift
 VDEV_MAX_AUTO_ASHIFT		vdev.max_auto_ashift		zfs_vdev_max_auto_ashift
 VDEV_MIN_MS_COUNT		vdev.min_ms_count		zfs_vdev_min_ms_count
 VDEV_DIRECT_WR_VERIFY		vdev.direct_write_verify	zfs_vdev_direct_write_verify
+VDEV_DIRECT_RD_VERIFY		vdev.direct_read_verify		zfs_vdev_direct_read_verify
 VDEV_VALIDATE_SKIP		vdev.validate_skip		vdev_validate_skip
 VOL_INHIBIT_DEV			vol.inhibit_dev			zvol_inhibit_dev
 VOL_MODE			vol.mode			zvol_volmode

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1605,6 +1605,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/direct/dio_property.ksh \
 	functional/direct/dio_random.ksh \
 	functional/direct/dio_read_verify.ksh \
+	functional/direct/dio_read_verify_tunable.ksh \
 	functional/direct/dio_recordsize.ksh \
 	functional/direct/dio_unaligned_block.ksh \
 	functional/direct/dio_unaligned_filesize.ksh \

--- a/tests/zfs-tests/tests/functional/direct/dio_read_verify_tunable.ksh
+++ b/tests/zfs-tests/tests/functional/direct/dio_read_verify_tunable.ksh
@@ -1,0 +1,132 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2026, Michael Heller <michael.heller@gmail.com>
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/direct/dio.cfg
+. $STF_SUITE/tests/functional/direct/dio.kshlib
+
+#
+# DESCRIPTION:
+#	Verify the zfs_vdev_direct_read_verify module parameter controls
+#	Direct I/O read checksum verification for every vdev type.
+#
+# STRATEGY:
+#	1. Create a zpool from each vdev type.
+#	2. With zfs_vdev_direct_read_verify=0, start a Direct I/O read
+#	   workload while manipulating the user buffer contents.  Verify there
+#	   are NO Direct I/O read verify failures reported (the knob disables
+#	   the verify), and no data errors.
+#	3. With zfs_vdev_direct_read_verify=1, repeat the workload and verify
+#	   there ARE Direct I/O read verify failures reported (the default
+#	   behavior), and still no data errors.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	dio_cleanup
+	log_must set_tunable32 VDEV_DIRECT_RD_VERIFY $DIO_RD_VERIFY_TUNABLE
+}
+
+log_assert "Verify zfs_vdev_direct_read_verify controls Direct I/O read " \
+    "checksum verification."
+
+log_onexit cleanup
+
+NUMBLOCKS=300
+BS=$((128 * 1024)) # 128k
+typeset DIO_RD_VERIFY_TUNABLE=$(get_tunable VDEV_DIRECT_RD_VERIFY)
+
+log_must truncate -s $MINVDEVSIZE $DIO_VDEVS
+
+for type in "" "mirror" "raidz" "draid"; do
+	typeset vdev_type=$type
+	if [[ "${vdev_type}" == "" ]]; then
+		vdev_type="stripe"
+	fi
+
+	log_note "Testing zfs_vdev_direct_read_verify with VDEV type ${vdev_type}"
+
+	create_pool $TESTPOOL1 $type $DIO_VDEVS
+	log_must eval "zfs create -o recordsize=128k -o compression=off  \
+	    $TESTPOOL1/$TESTFS1"
+	mntpnt=$(get_prop mountpoint $TESTPOOL1/$TESTFS1)
+
+	# Create the file before manipulating its contents during reads.
+	log_must stride_dd -o "$mntpnt/direct-read.iso" -i /dev/urandom \
+	    -b $BS -c $NUMBLOCKS -D
+
+	#
+	# With verification disabled, manipulating the user buffer while a
+	# Direct I/O read is in flight must not produce any dio_verify_rd
+	# events, and the pool must remain error-free (the on-disk data is
+	# correct).
+	#
+	log_must set_tunable32 VDEV_DIRECT_RD_VERIFY 0
+	log_must zpool clear $TESTPOOL1
+	log_must zpool events -c
+
+	prev_dio_rd=$(kstat_pool $TESTPOOL1 iostats.direct_read_count)
+	log_must manipulate_user_buffer -f "$mntpnt/direct-read.iso" \
+	    -n $NUMBLOCKS -b $BS -r
+	curr_dio_rd=$(kstat_pool $TESTPOOL1 iostats.direct_read_count)
+	total_dio_rd=$((curr_dio_rd - prev_dio_rd))
+
+	log_note "Making sure we have Direct I/O reads logged"
+	if [[ $total_dio_rd -lt 1 ]]; then
+		log_fail "No Direct I/O reads $total_dio_rd"
+	fi
+
+	log_note "Making sure there are no Direct I/O read verify failures"
+	check_dio_chksum_verify_failures "$TESTPOOL1" "$vdev_type" 0 "rd"
+
+	log_note "Making sure there are no checksum errors with the ZPool"
+	log_must check_pool_status $TESTPOOL1 "errors" "No known data errors"
+
+	#
+	# With verification enabled (the default), the same workload must
+	# produce dio_verify_rd events, while the pool stays error-free.
+	#
+	log_must set_tunable32 VDEV_DIRECT_RD_VERIFY 1
+	log_must zpool clear $TESTPOOL1
+	log_must zpool events -c
+
+	log_must manipulate_user_buffer -f "$mntpnt/direct-read.iso" \
+	    -n $NUMBLOCKS -b $BS -r
+
+	log_note "Making sure we have Direct I/O read verify failures"
+	check_dio_chksum_verify_failures "$TESTPOOL1" "$vdev_type" 1 "rd"
+
+	log_note "Making sure there are no checksum errors with the ZPool"
+	log_must check_pool_status $TESTPOOL1 "errors" "No known data errors"
+
+	destroy_pool $TESTPOOL1
+done
+
+log_pass "Verified zfs_vdev_direct_read_verify controls Direct I/O read " \
+    "checksum verification."


### PR DESCRIPTION
### Motivation and Context

Applications that issue concurrent `O_DIRECT` reads and recycle their I/O
buffers across in-flight requests (e.g. QEMU's block layer) trip the Direct I/O
read checksum verify: the buffer is overwritten by another request before the
post-read verify of the previous one runs. This is **not** data corruption —
the on-disk block is correct and ZFS returns the right data via a buffered
re-read — but it produces a flood of spurious `dio_verify_rd` zevents, and the
verify-and-refallback storm can stall the workload under load. See #18610 for a
reproduction and analysis.

Unlike the write case, read verification provides no data-integrity guarantee
(the on-disk block is already correct); it only detects the caller mutating its
own buffer mid-flight. As discussed in #18610, @behlendorf agreed that a knob
modeled on `zfs_vdev_direct_write_verify` was the right approach.

### Description

Add a `zfs_vdev_direct_read_verify` module parameter, mirroring
`zfs_vdev_direct_write_verify`, so Direct I/O read verification can be disabled
for workloads that legitimately recycle buffers. The default of `1` preserves
the current behavior.

The DIO read verify is performed per top-level vdev type, so the tunable is
honored in each path: `zio_checksum_verify()` (disk/file), `raidz_checksum_verify()`
(raidz and draid), and the indirect (device removal) path. Mirror vdevs inherit
the behavior from their children.

### How Has This Been Tested?

New ZTS test `dio_read_verify_tunable` exercises both settings (0 and 1) across
the stripe, mirror, raidz, and draid vdev types, asserting that `=0` produces no
`dio_verify_rd` events while `=1` reports them, with the pool error-free in both
cases. Passing locally; cstyle clean.

### Types of changes
- [x] New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

Closes #18610
