### PR TITLE
man: thorough scrub documentation update

### DIFF
--- a/man/man8/zpool-scrub.8
+++ b/man/man8/zpool-scrub.8
@@ -193,18 +193,6 @@ May be combined with
 or
 start/end date options
 .Pq Fl S / Fl E .
-.Pp
-If a thorough scrub is paused, resuming with
-.Nm zpool Cm scrub
-.Pq with or without
-.Fl t
-continues as a thorough scrub.
-Resuming a paused normal scrub with
-.Fl t
-will fail; use
-.Nm zpool Cm scrub
-without
-.Fl t .
 .It Fl S Ar date , Fl E Ar date
 Allows specifying the date range for blocks created between these dates.
 .Bl -bullet -compact -offset indent


### PR DESCRIPTION
### Motivation and Context

Documentation update based on follow up discussion in the original PR.

https://github.com/openzfs/zfs/pull/18474#issuecomment-4948900321

### Description

Drop the paragraph in the -t option description which details the resume behavior.  This is already covered under the -p option and there's no need to belabor the point.

### How Has This Been Tested?

`man man/man8/zpool-scrub.8`

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
