### PR TITLE
Fix dmu_zfetch_prime() assuming a stream was created

### DIFF
--- a/module/zfs/dmu_zfetch.c
+++ b/module/zfs/dmu_zfetch.c
@@ -244,7 +244,7 @@ dmu_zfetch_fini(zfetch_t *zf)
  * If needed, reuse oldest stream without hits for zfetch_min_sec_reap or ever.
  * The "blkid" argument is the next block that we expect this stream to access.
  */
-static void
+static zstream_t *
 dmu_zfetch_stream_create(zfetch_t *zf, uint64_t blkid)
 {
 	zstream_t *zs, *zs_next, *zs_old = NULL;
@@ -302,7 +302,7 @@ dmu_zfetch_stream_create(zfetch_t *zf, uint64_t blkid)
 			goto reuse;
 		}
 		ZFETCHSTAT_BUMP(zfetchstat_max_streams);
-		return;
+		return (NULL);
 	}
 
 	zs = kmem_zalloc(sizeof (*zs), KM_SLEEP);
@@ -326,6 +326,7 @@ reuse:
 	zs->zs_ipf_end = blkid;
 	zs->zs_missed = B_FALSE;
 	zs->zs_more = B_FALSE;
+	return (zs);
 }
 
 static void
@@ -495,9 +496,12 @@ dmu_zfetch_prime(zfetch_t *zf, uint64_t blkid, uint64_t end_blkid)
 		}
 	}
 
-	dmu_zfetch_stream_create(zf, blkid);
-	zs = list_head(&zf->zf_stream);
-	ASSERT(zs != NULL);
+	/* Skip if at stream limit and none are reclaimable. */
+	zs = dmu_zfetch_stream_create(zf, blkid);
+	if (zs == NULL) {
+		mutex_exit(&zf->zf_lock);
+		return (B_FALSE);
+	}
 	ASSERT3U(zs->zs_blkid, ==, blkid);
 
 	/* dmu_zfetch_prepare() will double the distances, so take a half. */
@@ -631,7 +635,7 @@ dmu_zfetch_prepare(zfetch_t *zf, uint64_t blkid, uint64_t nblks,
 	 */
 	ASSERT0P(zs);
 	if (end_blkid < maxblkid)
-		dmu_zfetch_stream_create(zf, end_blkid);
+		(void) dmu_zfetch_stream_create(zf, end_blkid);
 	mutex_exit(&zf->zf_lock);
 	ZFETCHSTAT_BUMP(zfetchstat_misses);
 	ipf_start = 0;


### PR DESCRIPTION
### Motivation and Context

Fixes #18800. `dmu_zfetch_prime()` trips `VERIFY3U(zs->zs_blkid, ==, blkid)` (debug builds panic; a non-debug build primes the wrong stream) when a `dmu_prefetch_stream()` caller drives more than `zfetch_max_streams` (default 8) concurrent streams on a dnode. See #18800 for the full root cause and reproducer.

### Description

`dmu_zfetch_prime()` assumed the stream produced by `dmu_zfetch_stream_create()` was at `list_head`. But `dmu_zfetch_stream_create()` only inserts a new head stream in its normal path; at the stream cap with nothing reclaimable it returns without creating one, leaving an unrelated stream at the head, so the `VERIFY` trips.

This makes `dmu_zfetch_stream_create()` return the created/reused stream (or `NULL` when it declines), and has `dmu_zfetch_prime()` stop priming on `NULL` instead of trusting `list_head`. `dmu_zfetch_prepare()`, the only other caller, does not use the returned stream.

### How Has This Been Tested?

Debug build, QEMU, raidz pool. Before: an advancing-offset `posix_fadvise(WILLNEED)` storm panics with `VERIFY3U(...) failed (952 == 1088)`. After: the same run issues 36.2M `WILLNEED` calls, exercises the decline path ~33.6M times (`zfetchstats:max_streams` 0 → 33.6M), and completes with 0 VERIFY/BUG/panic. The `fadvise` ZTS group passes.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the OpenZFS code style requirements.
- [x] I have run the ZFS Test Suite affected area (`fadvise`) with my changes.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
