### PR TITLE
libzfs: fallback VDEV_UPATH to VDEV_PATH for non-DM devices

### DIFF
--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -2405,6 +2405,8 @@ zpool_prepare_disk(zpool_handle_t *zhp, nvlist_t *vdev_nv,
 	    &enc_sysfs_path);
 
 	upath = zfs_get_underlying_path(path);
+	if (upath == NULL && path != NULL)
+		upath = strdup(path);
 	pool_name = zhp ? zpool_get_name(zhp) : NULL;
 
 	env = zpool_vdev_script_alloc_env(pool_name, path, upath,


### PR DESCRIPTION
When `zfs_get_underlying_path()` returns NULL for a non-DM device (e.g. NVMe), the `zfs_prepare_disk` script was getting an empty `VDEV_UPATH`. Per the man page, `VDEV_UPATH` should fall back to `VDEV_PATH` when there is no underlying path.

Closes #18439