### PR TITLE
zpool_influxdb: export per-vdev slow_ios counter

### DIFF
--- a/cmd/zpool_influxdb/zpool_influxdb.c
+++ b/cmd/zpool_influxdb/zpool_influxdb.c
@@ -361,6 +361,7 @@ print_summary_stats(nvlist_t *nvroot, const char *pool_name,
 	print_kv(",write_ops", vs->vs_ops[ZIO_TYPE_WRITE]);
 	print_kv(",checksum_errors", vs->vs_checksum_errors);
 	print_kv(",fragmentation", vs->vs_fragmentation);
+	print_kv(",slow_ios", vs->vs_slow_ios);
 	printf(" %llu\n", (u_longlong_t)timestamp);
 	return (0);
 }


### PR DESCRIPTION
OpenZFS 2.4 added slow vdev sit-out detection, visible in `zpool status -s` as the SLOW column. Export the same `vs_slow_ios` counter in `zpool_influxdb` output so monitoring stacks can alert on slow vdevs.

Closes #18555