### PR TITLE
zdb: output refcounts from verify_spacemap_refcounts()

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -1552,23 +1552,36 @@ static int
 verify_spacemap_refcounts(spa_t *spa)
 {
 	uint64_t expected_refcount = 0;
-	uint64_t actual_refcount;
+	uint64_t actual_refcount = 0;
+	int dtl_refcount, metaslab_refcount, obsolete_refcount,
+	    prev_obsolete_refcount, checkpoint_refcount, log_spacemap_refcount;
 
 	(void) feature_get_refcount(spa,
 	    &spa_feature_table[SPA_FEATURE_SPACEMAP_HISTOGRAM],
 	    &expected_refcount);
-	actual_refcount = get_dtl_refcount(spa->spa_root_vdev);
-	actual_refcount += get_metaslab_refcount(spa->spa_root_vdev);
-	actual_refcount += get_obsolete_refcount(spa->spa_root_vdev);
-	actual_refcount += get_prev_obsolete_spacemap_refcount(spa);
-	actual_refcount += get_checkpoint_refcount(spa->spa_root_vdev);
-	actual_refcount += get_log_spacemap_refcount(spa);
+	dtl_refcount = get_dtl_refcount(spa->spa_root_vdev);
+	metaslab_refcount = get_metaslab_refcount(spa->spa_root_vdev);
+	obsolete_refcount = get_obsolete_refcount(spa->spa_root_vdev);
+	prev_obsolete_refcount = get_prev_obsolete_spacemap_refcount(spa);
+	checkpoint_refcount = get_checkpoint_refcount(spa->spa_root_vdev);
+	log_spacemap_refcount = get_log_spacemap_refcount(spa);
+	actual_refcount += dtl_refcount;
+	actual_refcount += metaslab_refcount;
+	actual_refcount += obsolete_refcount;
+	actual_refcount += prev_obsolete_refcount;
+	actual_refcount += checkpoint_refcount;
+	actual_refcount += log_spacemap_refcount;
 
 	if (expected_refcount != actual_refcount) {
 		(void) printf("space map refcount mismatch: expected %lld != "
 		    "actual %lld\n",
 		    (longlong_t)expected_refcount,
 		    (longlong_t)actual_refcount);
+		(void) printf("\tDTL: %d, metaslab: %d, obsolete: %d, "
+		    "prev obsolete: %d, checkpoint: %d, log spacemap: %d\n",
+		    dtl_refcount, metaslab_refcount, obsolete_refcount,
+		    prev_obsolete_refcount, checkpoint_refcount,
+		    log_spacemap_refcount);
 		return (2);
 	}
 	return (0);

--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -37,6 +37,7 @@
  * Copyright (c) 2023, 2024, Klara Inc.
  * Copyright (c) 2023, Rob Norris <robn@despairlabs.com>
  * Copyright (c) 2026, TrueNAS.
+ * Copyright 2026 Edgecast Cloud LLC.
  */
 
 #include <stdio.h>
@@ -1447,10 +1448,10 @@ dump_zpldir(objset_t *os, uint64_t object, void *data, size_t size)
 	zap_attribute_free(attrp);
 }
 
-static int
+static uint64_t
 get_dtl_refcount(vdev_t *vd)
 {
-	int refcount = 0;
+	uint64_t refcount = 0;
 
 	if (vd->vdev_ops->vdev_op_leaf) {
 		space_map_t *sm = vd->vdev_dtl_sm;
@@ -1466,10 +1467,10 @@ get_dtl_refcount(vdev_t *vd)
 	return (refcount);
 }
 
-static int
+static uint64_t
 get_metaslab_refcount(vdev_t *vd)
 {
-	int refcount = 0;
+	uint64_t refcount = 0;
 
 	if (vd->vdev_top == vd) {
 		for (uint64_t m = 0; m < vd->vdev_ms_count; m++) {
@@ -1486,11 +1487,11 @@ get_metaslab_refcount(vdev_t *vd)
 	return (refcount);
 }
 
-static int
+static uint64_t
 get_obsolete_refcount(vdev_t *vd)
 {
 	uint64_t obsolete_sm_object;
-	int refcount = 0;
+	uint64_t refcount = 0;
 
 	VERIFY0(vdev_obsolete_sm_object(vd, &obsolete_sm_object));
 	if (vd->vdev_top == vd && obsolete_sm_object != 0) {
@@ -1511,7 +1512,7 @@ get_obsolete_refcount(vdev_t *vd)
 	return (refcount);
 }
 
-static int
+static uint64_t
 get_prev_obsolete_spacemap_refcount(spa_t *spa)
 {
 	uint64_t prev_obj =
@@ -1526,10 +1527,10 @@ get_prev_obsolete_spacemap_refcount(spa_t *spa)
 	return (0);
 }
 
-static int
+static uint64_t
 get_checkpoint_refcount(vdev_t *vd)
 {
-	int refcount = 0;
+	uint64_t refcount = 0;
 
 	if (vd->vdev_top == vd && vd->vdev_top_zap != 0 &&
 	    zap_contains(spa_meta_objset(vd->vdev_spa),
@@ -1542,7 +1543,7 @@ get_checkpoint_refcount(vdev_t *vd)
 	return (refcount);
 }
 
-static int
+static uint64_t
 get_log_spacemap_refcount(spa_t *spa)
 {
 	return (avl_numnodes(&spa->spa_sm_logs_by_txg));
@@ -1553,7 +1554,7 @@ verify_spacemap_refcounts(spa_t *spa)
 {
 	uint64_t expected_refcount = 0;
 	uint64_t actual_refcount = 0;
-	int dtl_refcount, metaslab_refcount, obsolete_refcount,
+	uint64_t dtl_refcount, metaslab_refcount, obsolete_refcount,
 	    prev_obsolete_refcount, checkpoint_refcount, log_spacemap_refcount;
 
 	(void) feature_get_refcount(spa,
@@ -1565,23 +1566,24 @@ verify_spacemap_refcounts(spa_t *spa)
 	prev_obsolete_refcount = get_prev_obsolete_spacemap_refcount(spa);
 	checkpoint_refcount = get_checkpoint_refcount(spa->spa_root_vdev);
 	log_spacemap_refcount = get_log_spacemap_refcount(spa);
-	actual_refcount += dtl_refcount;
-	actual_refcount += metaslab_refcount;
-	actual_refcount += obsolete_refcount;
-	actual_refcount += prev_obsolete_refcount;
-	actual_refcount += checkpoint_refcount;
-	actual_refcount += log_spacemap_refcount;
+	actual_refcount = dtl_refcount + metaslab_refcount +
+	    obsolete_refcount + prev_obsolete_refcount +
+	    checkpoint_refcount + log_spacemap_refcount;
 
 	if (expected_refcount != actual_refcount) {
-		(void) printf("space map refcount mismatch: expected %lld != "
-		    "actual %lld\n",
-		    (longlong_t)expected_refcount,
-		    (longlong_t)actual_refcount);
-		(void) printf("\tDTL: %d, metaslab: %d, obsolete: %d, "
-		    "prev obsolete: %d, checkpoint: %d, log spacemap: %d\n",
-		    dtl_refcount, metaslab_refcount, obsolete_refcount,
-		    prev_obsolete_refcount, checkpoint_refcount,
-		    log_spacemap_refcount);
+		(void) printf("space map refcount mismatch: expected %llu != "
+		    "actual %llu\n",
+		    (u_longlong_t)expected_refcount,
+		    (u_longlong_t)actual_refcount);
+		(void) printf("\tDTL: %llu, metaslab: %llu, obsolete: %llu, "
+		    "prev obsolete: %llu, checkpoint: %llu, "
+		    "log spacemap: %llu\n",
+		    (u_longlong_t)dtl_refcount,
+		    (u_longlong_t)metaslab_refcount,
+		    (u_longlong_t)obsolete_refcount,
+		    (u_longlong_t)prev_obsolete_refcount,
+		    (u_longlong_t)checkpoint_refcount,
+		    (u_longlong_t)log_spacemap_refcount);
 		return (2);
 	}
 	return (0);


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
Output information about refcounts when there is refcount mismatch.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

When verify_spacemap_refcounts() does discover refcount mismatch, we do get generic message, but no
information about details - we have six counters for refcounts and it would be helpful to see
their values.

<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->
The idea is simple - collect individual values and print them out when there is an mismatch with expected value.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
