### PR TITLE
ABD: Validate borrowed buffer length

### DIFF
--- a/lib/libzpool/abd_os.c
+++ b/lib/libzpool/abd_os.c
@@ -376,7 +376,7 @@ abd_borrow_buf(abd_t *abd, size_t n)
 {
 	void *buf;
 	abd_verify(abd);
-	ASSERT3U(abd->abd_size, >=, 0);
+	ASSERT3U(abd->abd_size, >=, n);
 	if (abd_is_linear(abd)) {
 		buf = abd_to_buf(abd);
 	} else {

--- a/module/os/freebsd/zfs/abd_os.c
+++ b/module/os/freebsd/zfs/abd_os.c
@@ -597,7 +597,7 @@ abd_borrow_buf(abd_t *abd, size_t n)
 {
 	void *buf;
 	abd_verify(abd);
-	ASSERT3U(abd->abd_size, >=, 0);
+	ASSERT3U(abd->abd_size, >=, n);
 	if (abd_is_linear(abd)) {
 		buf = abd_to_buf(abd);
 	} else {

--- a/module/os/linux/zfs/abd_os.c
+++ b/module/os/linux/zfs/abd_os.c
@@ -981,7 +981,7 @@ abd_borrow_buf(abd_t *abd, size_t n)
 {
 	void *buf;
 	abd_verify(abd);
-	ASSERT3U(abd->abd_size, >=, 0);
+	ASSERT3U(abd->abd_size, >=, n);
 	/*
 	 * In the event the ABD is composed of a single user page from Direct
 	 * I/O we can not direclty return the raw buffer. This is a consequence


### PR DESCRIPTION
This PR was made with the help of GPT-5.6-sol ultra. This was discovered while auditing ABD ownership and buffer lifetimes for the DMU late-arrival fix, but [it is an independent issue](https://github.com/openzfs/zfs/pull/18810). I don't have prior development experience with ZFS—only user-side experience.

### Motivation and Context

abd_borrow_buf() currently asserts that an unsigned size is at least zero.  This is tautological and allows a caller to borrow more bytes than the ABD represents.

Assert that the ABD covers the requested length in the Linux, FreeBSD, and libzpool implementations.  Add userspace unit coverage for an exact-size borrow and rejection of an oversized borrow.

### Description

Replace the ineffective assertion with a check that the ABD contains at
least the requested number of bytes.

Apply the same invariant consistently to:

- Linux kernel ABD;
- FreeBSD kernel ABD; and
- libzpool userspace ABD.

Add userspace unit coverage for both an exact-size borrow and rejection of
an oversized borrow.

### How Has This Been Tested?

Tested using an x86_64 OpenZFS debug userspace build.

The following completed successfully:

- full `make -j32`;
- targeted `make unit T=abd`;
- full `make unit`;
- `make checkstyle`; and
- OpenZFS commit checks.

### Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
