### PR TITLE
zio: include ZIO_TYPE_WRITE in ENXIO suspend condition

### DIFF
--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -734,6 +734,21 @@ txg_wait_synced_flags(dsl_pool_t *dp, uint64_t txg, txg_wait_flag_t flags)
 			break;
 		}
 
+		/*
+		 * If the pool is suspended, wait for it to be resumed
+		 * before continuing to wait for the txg to sync.
+		 */
+		if (spa_suspended(dp->dp_spa)) {
+			mutex_exit(&tx->tx_sync_lock);
+			mutex_enter(&dp->dp_spa->spa_suspend_lock);
+			while (spa_suspended(dp->dp_spa))
+				cv_wait(&dp->dp_spa->spa_suspend_cv,
+				    &dp->dp_spa->spa_suspend_lock);
+			mutex_exit(&dp->dp_spa->spa_suspend_lock);
+			mutex_enter(&tx->tx_sync_lock);
+			continue;
+		}
+
 		dprintf("broadcasting sync more "
 		    "tx_synced=%llu waiting=%llu dp=%px\n",
 		    (u_longlong_t)tx->tx_synced_txg,

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -5749,7 +5749,8 @@ zio_done(zio_t *zio)
 		}
 
 		if ((zio->io_type == ZIO_TYPE_READ ||
-		    zio->io_type == ZIO_TYPE_FREE) &&
+		    zio->io_type == ZIO_TYPE_FREE ||
+		    zio->io_type == ZIO_TYPE_WRITE) &&
 		    !(zio->io_flags & ZIO_FLAG_SCAN_THREAD) &&
 		    zio->io_error == ENXIO &&
 		    spa_load_state(zio->io_spa) == SPA_LOAD_NONE &&

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1679,6 +1679,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/fault/decrypt_fault.ksh \
 	functional/fault/fault_limits.ksh \
 	functional/fault/scrub_after_resilver.ksh \
+	functional/fault/suspend_on_device_removal.ksh \
 	functional/fault/suspend_on_probe_errors.ksh \
 	functional/fault/suspend_resume_single.ksh \
 	functional/fault/suspend_draid_fgroups.ksh \

--- a/tests/zfs-tests/tests/functional/fault/suspend_on_device_removal.ksh
+++ b/tests/zfs-tests/tests/functional/fault/suspend_on_device_removal.ksh
@@ -1,0 +1,130 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2026, Gluesys. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/fault/fault.cfg
+
+#
+# DESCRIPTION:
+#	Verify that a single-disk pool correctly suspends when its device is
+#	permanently removed (SCSI delete), rather than hanging in an infinite
+#	zio reexecute loop.  Before the fix, WRITE zios that received ENXIO
+#	at the root logical zio level were not covered by the suspend
+#	condition in zio_done(), causing them to be infinitely reexecuted
+#	instead of suspending the pool.  This resulted in sync and other
+#	operations hanging permanently in D-state.
+#
+# STRATEGY:
+#	1. Create a single-disk pool on a scsi_debug device
+#	2. Write data to the pool (dirty data in ARC)
+#	3. Permanently remove the device (echo 1 > device/delete)
+#	4. Verify the pool transitions to SUSPENDED state
+#	5. Bring the device back via SCSI rescan
+#	6. zpool clear to resume the pool
+#	7. Verify data integrity
+#
+
+DATAFILE=$(mktemp)
+
+function cleanup
+{
+	if poolexists $TESTPOOL; then
+		zpool clear $TESTPOOL 2>/dev/null
+		destroy_pool $TESTPOOL 2>/dev/null
+	fi
+	unload_scsi_debug
+	rm -f $DATAFILE
+}
+
+log_onexit cleanup
+
+log_assert "single-disk pool suspends on permanent device removal (SCSI delete)"
+
+# create test data
+log_must dd if=/dev/urandom of=$DATAFILE bs=128K count=4
+typeset sum1=$(xxh128digest $DATAFILE)
+
+# create a scsi_debug device
+load_scsi_debug 100 1 1 1 '512b'
+sd=$(get_debug_device)
+log_note "scsi_debug device: $sd"
+
+# create a single-device pool and write some data
+log_must zpool create $TESTPOOL $sd
+log_must zpool sync
+
+# copy data onto the pool (will be in ARC, not yet on disk)
+log_must cp $DATAFILE /$TESTPOOL/file
+
+# permanently remove the device via SCSI delete.  this causes all
+# subsequent I/O to the device to fail.  the error reaches the root
+# logical zio as ENXIO, which (with the fix) triggers pool suspension.
+log_note "removing device $sd via SCSI delete"
+log_must eval "echo 1 > /sys/block/$sd/device/delete"
+
+# with the fix, the pool should suspend within a few seconds as
+# pending writes fail and zio_done() triggers zio_suspend().  without
+# the fix, WRITE ENXIO causes infinite zio reexecute and the pool
+# stays ONLINE forever, with sync hung in D-state.
+log_note "waiting for pool to suspend"
+typeset -i tries=30
+while [[ $(kstat_pool $TESTPOOL state) != "SUSPENDED" ]] ; do
+	if ((tries-- == 0)); then
+		log_fail "pool did not suspend after device removal"
+	fi
+	sleep 1
+done
+log_note "pool suspended successfully after device removal"
+
+# bring the device back by rescanning all SCSI hosts.  the scsi_debug
+# module is still loaded, so the virtual target will respond and the
+# device will be recreated (possibly under a different name).
+for h in /sys/class/scsi_host/host*; do
+	echo "- - -" > $h/scan 2>/dev/null
+done
+block_device_wait
+
+# clear the error state, which should reopen the vdev, resume the pool,
+# and replay the failed I/O
+log_must zpool clear $TESTPOOL
+
+# wait for the pool to settle and complete the txg sync
+log_note "waiting for pool to settle"
+sleep 7
+
+# verify the pool is back online
+if [[ $(kstat_pool $TESTPOOL state) == "SUSPENDED" ]] ; then
+	log_fail "pool still suspended after clear and device restore"
+fi
+
+# verify data integrity — the file written before the device was
+# removed should be fully intact after the pool resumes and syncs
+typeset sum2=$(xxh128digest /$TESTPOOL/file)
+if [[ "$sum1" != "$sum2" ]] ; then
+	log_fail "checksum mismatch: expected $sum1, got $sum2"
+fi
+
+log_pass "single-disk pool suspends on device removal and resumes cleanly"


### PR DESCRIPTION
## Motivation and Context

When a WRITE zio receives ENXIO (e.g. device removal,
`vdev_remove_wanted`), the pool does not suspend. Instead, the zio is
infinitely reexecuted via `ZIO_POST_REEXECUTE`, causing `sync`, `umount`,
and other operations to hang permanently in D-state. The pool remains
ONLINE with no warning in system logs.

The root cause is that the ENXIO suspend condition in `zio_done()` only
checks `ZIO_TYPE_READ` and `ZIO_TYPE_FREE`, omitting `ZIO_TYPE_WRITE`.

Reported in #14859 and #12949.

## Description

1. **zio.c**: Add `ZIO_TYPE_WRITE` to the ENXIO suspend condition in
   `zio_done()`. WRITE zios with ENXIO will now suspend the pool via
   `ZIO_POST_SUSPEND` instead of being infinitely reexecuted.

2. **txg.c**: Add an unconditional `spa_suspended()` check in
   `txg_wait_synced_flags()`. Callers using `TXG_WAIT_NONE` (the default)
   currently block indefinitely on `tx_sync_done_cv` when the pool is
   suspended. The new check waits on `spa_suspend_cv`, which is signaled
   by `zio_resume()` during pool recovery.

## How Has This Been Tested?

New test: `functional/fault/suspend_on_device_removal.ksh`

Tested on Rocky Linux 8.10 (kernel 4.18.0-553.111.1.el8_10), OpenZFS 2.2.9:
- SCSI device delete on single-device pool
- Without patch: pool stays ONLINE, sync hangs indefinitely
- With patch: pool suspends within 6 seconds

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the OpenZFS code style requirements.
- [x] I have read the contributing document.
- [x] I have added tests to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.