### PR TITLE
man: conditionally install pam_zfs_key.8

### DIFF
--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -116,9 +116,13 @@ endif
 
 if BUILD_LINUX
 dist_man_MANS += \
-	%D%/man8/pam_zfs_key.8 \
 	%D%/man8/zfs-unzone.8 \
 	%D%/man8/zfs-zone.8
+endif
+
+if PAM_ZFS_ENABLED
+dist_man_MANS += \
+	%D%/man8/pam_zfs_key.8
 endif
 
 nodist_man_MANS = \


### PR DESCRIPTION
### Motivation and Context

#18815 - gate all of the components of pam_zfs_key behind --enable-pam/--disable-pam

### Description

When built with --enable-pam include the pam_zfs_key.8 man page, otherwise omit it.  This aligns man/Makefile.am with the build logic in contrib/Makefile.am.

### How Has This Been Tested?

Locally compiled.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)
