### PR TITLE
zpool: fix spare/cache indentation in `list -v` output

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -6787,7 +6787,7 @@ typedef struct list_cbdata {
  * If `vdev_name` is NULL, we print a line of the headers.
  */
 static void
-print_line(list_cbdata_t *cb, const char *vdev_name)
+print_line(list_cbdata_t *cb, const char *vdev_name, int depth)
 {
 	zprop_list_t *pl = cb->cb_proplist;
 	char headerbuf[ZPOOL_MAXPROPLEN];
@@ -6798,14 +6798,25 @@ print_line(list_cbdata_t *cb, const char *vdev_name)
 
 	boolean_t print_header = (vdev_name == NULL);
 
+	if (!print_header && !cb->cb_json && depth > 0) {
+		if (cb->cb_scripted)
+			(void) printf("\t");
+		else
+			(void) printf("%*s", depth, "");
+	} else {
+		/* Zap it, no more need. */
+		depth = 0;
+	}
+
 	for (; pl != NULL; pl = pl->pl_next) {
 		width = pl->pl_width;
 		if (first && cb->cb_verbose) {
 			/*
-			 * Reset the width to accommodate the verbose listing
-			 * of devices.
+			 * Reset the width to accommodate the verbose listing of
+			 * devices.  depth is accounted for to avoid offseting
+			 * our line of dashes.
 			 */
-			width = cb->cb_namewidth;
+			width = cb->cb_namewidth - depth;
 		}
 
 		if (!first)
@@ -7289,7 +7300,7 @@ collect_list_stats(zpool_handle_t *zhp, const char *name, nvlist_t *nv,
 				continue;
 
 			if (!printed && !cb->cb_json) {
-				print_line(cb, class_name[n]);
+				print_line(cb, class_name[n], 0);
 				printed = B_TRUE;
 			}
 			vname = zpool_vdev_name(g_zfs, zhp, child[c],
@@ -7310,12 +7321,12 @@ collect_list_stats(zpool_handle_t *zhp, const char *name, nvlist_t *nv,
 		if (cb->cb_json) {
 			l2c = fnvlist_alloc();
 		} else {
-			print_line(cb, "cache");
+			print_line(cb, "cache", depth + 2);
 		}
 		for (c = 0; c < children; c++) {
 			vname = zpool_vdev_name(g_zfs, zhp, child[c],
 			    cb->cb_name_flags);
-			collect_list_stats(zhp, vname, child[c], cb, depth + 2,
+			collect_list_stats(zhp, vname, child[c], cb, depth + 4,
 			    B_FALSE, l2c);
 			free(vname);
 		}
@@ -7331,12 +7342,12 @@ collect_list_stats(zpool_handle_t *zhp, const char *name, nvlist_t *nv,
 		if (cb->cb_json) {
 			sp = fnvlist_alloc();
 		} else {
-			print_line(cb, "spare");
+			print_line(cb, "spare", depth + 2);
 		}
 		for (c = 0; c < children; c++) {
 			vname = zpool_vdev_name(g_zfs, zhp, child[c],
 			    cb->cb_name_flags);
-			collect_list_stats(zhp, vname, child[c], cb, depth + 2,
+			collect_list_stats(zhp, vname, child[c], cb, depth + 4,
 			    B_TRUE, sp);
 			free(vname);
 		}
@@ -7574,7 +7585,7 @@ zpool_do_list(int argc, char **argv)
 
 		if (!cb.cb_scripted && (first || cb.cb_verbose) &&
 		    !cb.cb_json) {
-			print_line(&cb, NULL);
+			print_line(&cb, NULL, 0);
 			first = B_FALSE;
 		}
 		ret = pool_list_iter(list, B_TRUE, list_callback, &cb);


### PR DESCRIPTION
### Motivation and Context
Normal vdevs come out right because of recursion into `collect_list_stats` with a greater depth, but spare/cache details are emitted at the top-level and need a bit more of a nudge in indentation to avoid blending in with another zpool.

Some details omitted for brevity.  Before:
```
$ zpool list -v -o name,size,alloc,free,health
NAME             SIZE  ALLOC   FREE    HEALTH
storage         43.7T  2.66M  43.7T    ONLINE
  raidz2-0      21.8T  1.30M  21.8T    ONLINE
    [...]
  raidz2-1      21.8T  1.36M  21.8T    ONLINE
    [...]
spare               -      -      -         -
  gpt/disk6     3.64T      -      -     AVAIL
  gpt/disk7     3.64T      -      -     AVAIL
  gpt/disk14    3.64T      -      -     AVAIL
zroot            216G  1.40G   215G    ONLINE
  mirror-0       216G  1.40G   215G    ONLINE
    ada0p3       217G      -      -    ONLINE
    ada1p3       217G      -      -    ONLINE
```

After:
```
$ zpool list -v -o name,size,alloc,free,health
NAME             SIZE  ALLOC   FREE    HEALTH
storage         43.7T  2.66M  43.7T    ONLINE
  raidz2-0      21.8T  1.30M  21.8T    ONLINE
    [...]
  raidz2-1      21.8T  1.36M  21.8T    ONLINE
    [...]
  spare             -      -      -         -
    gpt/disk6   3.64T      -      -     AVAIL
    gpt/disk7   3.64T      -      -     AVAIL
    gpt/disk14  3.64T      -      -     AVAIL
zroot            216G  1.40G   215G    ONLINE
  mirror-0       216G  1.40G   215G    ONLINE
    ada0p3       217G      -      -    ONLINE
    ada1p3       217G      -      -    ONLINE
```

### Description
Give print_line() the ability to print indentation and take it into account for the name and use the appropriate depth for both, accounting for the fact that we're missing a level of depth being at the top-level.

### How Has This Been Tested?
Ran on FreeBSD 15.1 with spares configured, doesn't really affect non-spare setupss.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
