### PR TITLE
ddt: fix refcount bypass and gang member leak for dedup gang blocks

### DIFF
--- a/include/sys/ddt.h
+++ b/include/sys/ddt.h
@@ -129,9 +129,12 @@ typedef struct {
  * characteristics of the stored block, such as its location on disk (DVAs),
  * birth txg and ref count.
  *
- * The "traditional" entry has an array of four, one for each number of DVAs
- * (copies= property) and another for additional "ditto" copies. Users of the
- * traditional struct will specify the variant (index) of the one they want.
+ * The "traditional" entry has an array of four, one for each value of the
+ * copies= property the block was written with and another for additional
+ * "ditto" copies. (The stored block's BP may carry more DVAs than copies=,
+ * eg a gang header is stored in more copies than the data it gangs, so the
+ * slot is not the BP's DVA count.) Users of the traditional struct will
+ * specify the variant (index) of the one they want.
  *
  * The newer "flat" entry has only a single form that is specified using the
  * DDT_PHYS_FLAT variant.

--- a/module/zfs/ddt.c
+++ b/module/zfs/ddt.c
@@ -78,10 +78,13 @@
  *
  * Traditionally, each ddt_phys_t slot in the entry represents a separate dedup
  * block for the same content/checksum. The slot is selected based on the
- * zp_copies parameter the block is written with, that is, the number of DVAs
- * in the block. The "ditto" slot (DDT_PHYS_DITTO) used to be used for
- * now-removed "dedupditto" feature. These are no longer written, and will be
- * freed if encountered on old pools.
+ * zp_copies parameter the block is written with. Note that the block may
+ * carry more DVAs than zp_copies (a gang header is stored in more copies
+ * than the data it gangs), so the slot cannot be inferred from the BP's DVA
+ * count; a stored phys is matched to a BP by block identity (see
+ * ddt_phys_select()). The "ditto" slot (DDT_PHYS_DITTO) used to be used for
+ * the now-removed "dedupditto" feature. These are no longer written, and
+ * will be freed if encountered on old pools.
  *
  * If the "fast_dedup" feature is enabled, new dedup tables will be created
  * with the "flat phys" option. In this mode, there is only one ddt_phys_t
@@ -1187,44 +1190,31 @@ ddt_prefetch_all(spa_t *spa)
 static int ddt_configure(ddt_t *ddt, boolean_t new);
 
 /*
- * If the BP passed to ddt_lookup has valid DVAs, then we need to compare them
- * to the ones in the entry. If they're different, then the passed-in BP is
- * from a previous generation of this entry (ie was previously pruned) and we
+ * If the BP passed to ddt_lookup has valid DVAs, then we need to check that
+ * they match one of the phys in the entry. If not, then the passed-in BP is
+ * from a previous generation of this entry (eg was previously pruned) and we
  * have to act like the entry doesn't exist at all.
  *
- * This should only happen during a lookup to free the block (zio_ddt_free()).
+ * Callers that pass verify expect the entry they get back to hold a phys
+ * matching the BP in hand.
  *
- * XXX this is similar in spirit to ddt_phys_select(), maybe can combine
- *       -- robn, 2024-02-09
+ * The match is made on block identity (DVA[0] and physical birth) via
+ * ddt_phys_select(). The phys slot must not be inferred from the BP's DVA
+ * count: a gang header is stored in more copies than the data it gangs, so
+ * its BP carries more DVAs than the copies value the block was written with
+ * (eg a copies=1 dedup gang block has a two-DVA header BP but lives in the
+ * copies=1 slot). Slot-by-DVA-count would therefore check the wrong slot and
+ * misread a live entry as pruned, bypassing its refcount when the block is
+ * freed.
  */
 static boolean_t
 ddt_entry_lookup_is_valid(ddt_t *ddt, const blkptr_t *bp, ddt_entry_t *dde)
 {
 	/* If the BP has no DVAs, then this entry is good */
-	uint_t ndvas = BP_GET_NDVAS(bp);
-	if (ndvas == 0)
+	if (BP_GET_NDVAS(bp) == 0)
 		return (B_TRUE);
 
-	/*
-	 * Only checking the phys for the copies. For flat, there's only one;
-	 * for trad it'll be the one that has the matching set of DVAs.
-	 */
-	const dva_t *dvas = (ddt->ddt_flags & DDT_FLAG_FLAT) ?
-	    dde->dde_phys->ddp_flat.ddp_dva :
-	    dde->dde_phys->ddp_trad[ndvas].ddp_dva;
-
-	/*
-	 * Compare entry DVAs with the BP. They should all be there, but
-	 * there's not really anything we can do if its only partial anyway,
-	 * that's an error somewhere else, maybe long ago.
-	 */
-	uint_t d;
-	for (d = 0; d < ndvas; d++)
-		if (!DVA_EQUAL(&dvas[d], &bp->blk_dva[d]))
-			return (B_FALSE);
-	ASSERT3U(d, ==, ndvas);
-
-	return (B_TRUE);
+	return (ddt_phys_select(ddt, dde, bp) != DDT_PHYS_NONE);
 }
 
 ddt_entry_t *
@@ -2694,10 +2684,15 @@ ddt_addref(spa_t *spa, const blkptr_t *bp)
 		 * This entry was either synced to a store object (dde_type is
 		 * real) or was logged. It must be properly on disk at this
 		 * point, so we can just bump its refcount.
+		 *
+		 * The verified lookup above guarantees a matching phys
+		 * exists for any BP that carries DVAs, and clone BPs always
+		 * do; the VERIFY keeps DDT_PHYS_NONE from reaching
+		 * ddt_phys_addref(), which would index out of bounds on
+		 * release builds.
 		 */
-		int p = DDT_PHYS_FOR_COPIES(ddt, BP_GET_NDVAS(bp));
-		ddt_phys_variant_t v = DDT_PHYS_VARIANT(ddt, p);
-
+		ddt_phys_variant_t v = ddt_phys_select(ddt, dde, bp);
+		VERIFY3U(v, !=, DDT_PHYS_NONE);
 		ddt_phys_addref(dde->dde_phys, v);
 		result = B_TRUE;
 	} else {

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -2132,7 +2132,12 @@ zio_free_bp_init(zio_t *zio)
 
 	if (zio->io_child_type == ZIO_CHILD_LOGICAL) {
 		if (BP_GET_DEDUP(bp))
-			zio->io_pipeline = ZIO_DDT_FREE_PIPELINE;
+			/*
+			 * Keep the gang stages zio_create() added: if
+			 * zio_ddt_free() falls back to a plain free, they
+			 * free the gang members along with the header.
+			 */
+			zio->io_pipeline |= ZIO_DDT_FREE_PIPELINE;
 	}
 
 	ASSERT3P(zio->io_bp, ==, &zio->io_bp_copy);
@@ -4197,7 +4202,8 @@ zio_ddt_free(zio_t *zio)
 		 * table.  Clear the DEDUP bit so it is treated as a normal
 		 * block from here on.  BRT_FREE and DVA_FREE follow in the
 		 * pipeline and will handle any cloned references and the
-		 * actual block free respectively.
+		 * actual block free respectively, along with the gang stages
+		 * for a gang BP.
 		 *
 		 * Only flat (FDT) tables are ever pruned, so a miss against
 		 * a traditional table means the table and the BP disagree,

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -4174,13 +4174,12 @@ zio_ddt_free(zio_t *zio)
 			ddt_phys_decref(dde->dde_phys, v);
 		else
 			/*
-			 * If the entry was found but the phys was not, then
-			 * this block must have been pruned from the dedup
-			 * table, and the entry refers to a later version of
-			 * this data. Therefore, the caller is trying to delete
-			 * the only stored instance of this block, and so we
-			 * need to do a normal (not dedup) free. Clear dde so
-			 * we fall into the block below.
+			 * No phys matches this BP; ddt_lookup() returned a
+			 * fresh, empty entry because the key is not in the
+			 * table at all (eg the original entry was pruned).
+			 * There is no reference to release, so we need to do
+			 * a normal (not dedup) free. Clear dde so we fall
+			 * into the block below.
 			 */
 			dde = NULL;
 	}
@@ -4199,7 +4198,22 @@ zio_ddt_free(zio_t *zio)
 		 * block from here on.  BRT_FREE and DVA_FREE follow in the
 		 * pipeline and will handle any cloned references and the
 		 * actual block free respectively.
+		 *
+		 * Only flat (FDT) tables are ever pruned, so a miss against
+		 * a traditional table means the table and the BP disagree,
+		 * which should not be possible. The plain free below is
+		 * still the best we can do for this BP, but leave a trace.
 		 */
+		if (!(ddt->ddt_flags & DDT_FLAG_FLAT)) {
+			zfs_dbgmsg("%s: no matching traditional DDT phys for "
+			    "dedup BP DVA[0]=<%llu:%llx:%llx> phys_birth=%llu; "
+			    "freeing without a refcount decrement",
+			    spa_name(spa),
+			    (u_longlong_t)DVA_GET_VDEV(&bp->blk_dva[0]),
+			    (u_longlong_t)DVA_GET_OFFSET(&bp->blk_dva[0]),
+			    (u_longlong_t)DVA_GET_ASIZE(&bp->blk_dva[0]),
+			    (u_longlong_t)BP_GET_PHYSICAL_BIRTH(bp));
+		}
 		BP_SET_DEDUP(bp, 0);
 	}
 

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -94,6 +94,10 @@ tags = ['functional', 'cli_root', 'zpool_split']
 tests = ['compress_004_pos']
 tags = ['functional', 'compression']
 
+[tests/functional/dedup:Linux]
+tests = ['dedup_legacy_gang']
+tags = ['functional', 'dedup']
+
 [tests/functional/devices:Linux]
 tests = ['devices_001_pos', 'devices_002_neg', 'devices_003_pos']
 tags = ['functional', 'devices']

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1559,6 +1559,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/dedup/dedup_fdt_import.ksh \
 	functional/dedup/dedup_fdt_pacing.ksh \
 	functional/dedup/dedup_legacy_create.ksh \
+	functional/dedup/dedup_legacy_gang.ksh \
 	functional/dedup/dedup_legacy_import.ksh \
 	functional/dedup/dedup_legacy_fdt_upgrade.ksh \
 	functional/dedup/dedup_legacy_fdt_mixed.ksh \

--- a/tests/zfs-tests/tests/functional/dedup/dedup_legacy_gang.ksh
+++ b/tests/zfs-tests/tests/functional/dedup/dedup_legacy_gang.ksh
@@ -1,0 +1,177 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+# DESCRIPTION:
+#	Verify that deduplicated gang blocks in a traditional (legacy) DDT
+#	are refcounted correctly.  A gang header is stored in more copies
+#	than the data it gangs, so its BP carries more DVAs than the
+#	copies= value the block was written with, and the free-time and
+#	clone-time DDT phys selection must match by block identity, not by
+#	the BP's DVA count.  Getting this wrong bypassed the refcount:
+#	each reference delete physically freed the shared gang header (a
+#	committed double-free from the second delete on), leaked the gang
+#	members and left a stale DDT entry behind.
+#
+# STRATEGY:
+#	1. Create a pool with feature@fast_dedup disabled (traditional DDT)
+#	   and a dedup dataset.
+#	2. Force ganging and write a file of unique blocks; verify every
+#	   block is a two-DVA gang BP stored in the copies=1 phys slot.
+#	3. Create a second reference via dedup (copy) and a third via
+#	   block cloning; verify each bumps the refcount of that same
+#	   phys slot, and that the clone took no BRT reference.
+#	4. Delete the references one at a time; verify the refcount drops
+#	   by exactly one each time and a survivor is still readable
+#	   after a fresh import.
+#	5. After the last delete, verify the DDT is empty and zdb reports
+#	   no leaked space or double allocations.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/gang_blocks/gang_blocks.kshlib
+
+verify_runnable "global"
+
+log_assert "Deduplicated gang blocks in a legacy DDT are refcounted correctly"
+
+log_must save_tunable METASLAB_FORCE_GANGING
+log_must save_tunable METASLAB_FORCE_GANGING_PCT
+log_must save_tunable BCLONE_ENABLED
+
+function cleanup
+{
+	if poolexists $TESTPOOL ; then
+		destroy_pool $TESTPOOL
+	fi
+	log_must restore_tunable METASLAB_FORCE_GANGING
+	log_must restore_tunable METASLAB_FORCE_GANGING_PCT
+	log_must restore_tunable BCLONE_ENABLED
+}
+
+log_onexit cleanup
+
+# Count DDT entries whose copies=1 phys slot holds a two-DVA gang BP with
+# the given refcount - the shape whose refcounting this test verifies.
+# A zdb failure yields a non-numeric result, failing the caller's test.
+function count_gang_phys1
+{
+	typeset refcnt=$1
+	typeset out
+
+	out=$(zdb -DDDDD $TESTPOOL) || { echo "zdb failed"; return; }
+	echo "$out" | grep -c "refcnt $refcnt phys 1 .*gang.*double"
+}
+
+# We disable compression so our writes create predictable results on disk,
+# and use xattr=sa to prevent selinux xattrs influencing our accounting.
+# ashift=9 keeps gang headers small.
+log_must zpool create -f \
+    -o ashift=9 \
+    -o feature@fast_dedup=disabled \
+    -o feature@block_cloning=enabled \
+    -O dedup=on \
+    -O compression=off \
+    -O xattr=sa \
+    $TESTPOOL $DISKS
+
+log_must test "$(get_pool_prop feature@fast_dedup $TESTPOOL)" = "disabled"
+
+# redundant_metadata=all (the default) stores gang headers in copies+1
+# copies; pin it so the copies=1 blocks below always get a two-DVA gang
+# header BP.
+log_must zfs create -o recordsize=128k -o redundant_metadata=all \
+    $TESTPOOL/$TESTFS
+typeset mountpoint=$(get_prop mountpoint $TESTPOOL/$TESTFS)
+
+# Ensure block cloning is enabled (it is on by default) so the
+# FICLONE call below succeeds instead of failing with EOPNOTSUPP.
+log_must set_tunable32 BCLONE_ENABLED 1
+
+# Write unique data with ganging forced: 4 blocks, each a dedup gang block
+# whose gang header BP carries more DVAs than copies=1. The allocation (and
+# so the ganging decision) happens at sync, so keep the tunable set until
+# the pool has synced.
+log_must set_tunable64 METASLAB_FORCE_GANGING 20000
+log_must set_tunable32 METASLAB_FORCE_GANGING_PCT 100
+log_must dd if=/dev/urandom of=$mountpoint/file1 bs=128k count=4
+sync_pool $TESTPOOL
+log_must set_tunable32 METASLAB_FORCE_GANGING_PCT 0
+
+typeset dva=$(get_first_block_dva $TESTPOOL/$TESTFS file1)
+check_is_gang_dva $dva
+
+# All four entries must have the hazardous shape: a two-DVA gang BP in
+# the copies=1 slot.
+log_must eval "zdb -D $TESTPOOL | grep -q 'DDT-sha256-zap-unique:.*entries=4'"
+log_must test "$(count_gang_phys1 1)" -eq 4
+
+typeset sum=$(xxh128digest $mountpoint/file1)
+
+# Second reference via dedup: same phys slot, refcount 2.
+log_must dd if=$mountpoint/file1 of=$mountpoint/file2 bs=128k
+sync_pool $TESTPOOL
+log_must eval "zdb -D $TESTPOOL | grep -q 'DDT-sha256-zap-duplicate:.*entries=4'"
+log_must test "$(count_gang_phys1 2)" -eq 4
+
+# Third reference via block cloning: ddt_addref() must bump the same
+# phys slot to 3; nothing may land in the BRT.  Use FICLONE (-c):
+# unlike copy_file_range it cannot silently fall back to a byte copy,
+# which would dedup to the same refcount without exercising the clone
+# path.
+log_must clonefile -c $mountpoint/file1 $mountpoint/file3
+sync_pool $TESTPOOL
+log_must test "$(get_pool_prop bcloneused $TESTPOOL)" -eq 0
+log_must test "$(count_gang_phys1 3)" -eq 4
+
+# Delete the references one at a time. Each delete must drop the
+# refcount by exactly one; the shared gang blocks stay allocated until
+# the last one.
+log_must rm $mountpoint/file1
+sync_pool $TESTPOOL
+log_must test "$(count_gang_phys1 2)" -eq 4
+
+# A survivor must still be readable from disk after a fresh import.
+log_must zpool export $TESTPOOL
+log_must zpool import $TESTPOOL
+log_must test "$(xxh128digest $mountpoint/file2)" = "$sum"
+
+log_must rm $mountpoint/file3
+sync_pool $TESTPOOL
+log_must test "$(count_gang_phys1 1)" -eq 4
+log_must test "$(xxh128digest $mountpoint/file2)" = "$sum"
+
+log_must rm $mountpoint/file2
+sync_pool $TESTPOOL
+
+# The last delete must have released the entries and freed the gang
+# members: empty DDT, no leaked space, no double frees.
+log_must eval "zdb -D $TESTPOOL | grep -q 'All DDTs are empty'"
+
+zdb_out=$(zdb -bcc $TESTPOOL 2>&1)
+typeset rc=$?
+echo "$zdb_out"
+if (( rc != 0 )) || \
+    echo "$zdb_out" | grep -Eq "leaked space|DOUBLE ALLOC|DOUBLE FREE"; then
+	log_fail "legacy dedup gang free leaked or double-freed space"
+fi
+
+log_pass "Deduplicated gang blocks in a legacy DDT are refcounted correctly"

--- a/tests/zfs-tests/tests/functional/dedup/dedup_prune_leak.ksh
+++ b/tests/zfs-tests/tests/functional/dedup/dedup_prune_leak.ksh
@@ -35,6 +35,9 @@
 #	3. ddtprune all entries
 #	4. Remove the file
 #	5. Verify there's no space leak
+#	6. Repeat with ganging forced, so the pruned blocks are gang blocks:
+#	   freeing them must release the gang members too, not just the
+#	   headers
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -51,6 +54,8 @@ log_must save_tunable DEDUP_LOG_TXG_MAX
 log_must set_tunable32 DEDUP_LOG_TXG_MAX 1
 log_must save_tunable DEDUP_LOG_FLUSH_ENTRIES_MIN
 log_must set_tunable32 DEDUP_LOG_FLUSH_ENTRIES_MIN 100000
+log_must save_tunable METASLAB_FORCE_GANGING
+log_must save_tunable METASLAB_FORCE_GANGING_PCT
 function cleanup
 {
 	if poolexists $TESTPOOL ; then
@@ -58,6 +63,8 @@ function cleanup
 	fi
 	log_must restore_tunable DEDUP_LOG_TXG_MAX
 	log_must restore_tunable DEDUP_LOG_FLUSH_ENTRIES_MIN
+	log_must restore_tunable METASLAB_FORCE_GANGING
+	log_must restore_tunable METASLAB_FORCE_GANGING_PCT
 }
 
 log_onexit cleanup
@@ -77,10 +84,58 @@ log_must zpool ddtprune -p 100 $TESTPOOL
 log_must rm $mountpoint/f1
 sync_pool $TESTPOOL
 
-zdb_out=$(zdb -bcc $TESTPOOL)
+zdb_out=$(zdb -bcc $TESTPOOL 2>&1)
+rc=$?
 echo "$zdb_out"
-if echo "$zdb_out" | grep -q "leaked space"; then
+if (( rc != 0 )) || echo "$zdb_out" | grep -q "leaked space"; then
 	log_fail "DDT pruning causes space leak"
+fi
+
+# Repeat with ganging forced: freeing a pruned gang block must release
+# the gang members as well, not only the gang header. The allocation
+# (and so the ganging decision) happens at sync, so keep the tunable
+# set until the pool has synced. The extra syncs let the DDT log swap
+# and flush into the ZAP: the entry count includes log-resident entries,
+# but the prune walker only traverses the stored objects, so entries
+# stay unprunable until one flush after their append txg.
+log_must set_tunable64 METASLAB_FORCE_GANGING 20000
+log_must set_tunable32 METASLAB_FORCE_GANGING_PCT 100
+log_must dd if=/dev/urandom of=$mountpoint/f2 bs=1M count=16
+for i in $(seq 5); do
+	sync_pool $TESTPOOL
+done
+log_must set_tunable32 METASLAB_FORCE_GANGING_PCT 0
+
+# Verify the precondition: all 128 new entries are present in the DDT
+# and their blocks are ganged.
+log_must test "$(zdb -DDDDD $TESTPOOL | grep 'phys 0 ' | grep -c gang)" \
+    -eq 128
+typeset entries=$(zpool status -D $TESTPOOL | \
+    grep "dedup: DDT entries" | awk '{print $4+0}')
+log_must test "$entries" -eq 128
+
+# Sleep 1s so the DDT entries are at least 1 second old.  ddtprune uses
+# an age-based cutoff and will silently skip entries that are too fresh.
+sleep 1
+
+log_must zpool ddtprune -p 100 $TESTPOOL
+sync_pool $TESTPOOL
+
+# Confirm the prune actually removed the entries.
+entries=$(zpool status -D $TESTPOOL | \
+    grep "dedup: DDT entries" | awk '{print $4+0}')
+[[ -z "$entries" || "$entries" -eq 0 ]] || \
+    log_fail "DDT entries not pruned: $entries remain"
+
+log_must rm $mountpoint/f2
+sync_pool $TESTPOOL
+
+zdb_out=$(zdb -bcc $TESTPOOL 2>&1)
+rc=$?
+echo "$zdb_out"
+if (( rc != 0 )) || \
+    echo "$zdb_out" | grep -Eq "leaked space|DOUBLE ALLOC|DOUBLE FREE"; then
+	log_fail "DDT pruning causes space leak on gang blocks"
 fi
 
 log_pass "DDT pruning does not cause space leak"


### PR DESCRIPTION
### Motivation and Context

This PR fixes two related defects in how deduplicated gang blocks are
freed and referenced.

**Defect 1: traditional-DDT frees select the phys slot by BP DVA count,
bypassing refcounts.**

The write path stores a traditional DDT entry in the phys slot chosen by
the logical `zp_copies` value:

https://github.com/openzfs/zfs/blob/9bf75b4b13949afe322387fc5572c5820cce27c3/module/zfs/zio.c#L3843-L3844

but the free-path lookup validation selects the slot to compare by the
BP's physical DVA count:

https://github.com/openzfs/zfs/blob/9bf75b4b13949afe322387fc5572c5820cce27c3/module/zfs/ddt.c#L1200-L1228

and `ddt_addref()` makes the same assumption:

https://github.com/openzfs/zfs/blob/9bf75b4b13949afe322387fc5572c5820cce27c3/module/zfs/ddt.c#L2692-L2701

The two indexes diverge whenever a block's BP carries more DVAs than
its `copies` value — which is exactly what ganging does. A gang header
is stored in more copies than the data it gangs, so `copies=1` blocks
get a two-DVA gang header BP: unconditionally through 2.3.3, and under
the default `redundant_metadata=all` since a46ce73ca8 made gang copies
configurable in 2.3.4 and 9250403ba6 in 2.4.0. From 2.3.4 that same
default also gives unencrypted `copies=2` blocks a three-DVA header
BP:

https://github.com/openzfs/zfs/blob/9bf75b4b13949afe322387fc5572c5820ccL2556

Encrypted datasets diverge at the default `copies=1` as well —
encryption caps `gang_copies` at 2 but leaves `copies` at 1:

https://github.com/openzfs/zfs/blob/9bf75b4b13949afe322387fc5572c5820cce27c3/module/zfs/dmu.c#L2571-L2573

Through 2.3.3 only `copies=1` diverges; from 2.3.4 unencrypted
`copies=2` diverges as well, leaving just `copies=3` and encrypted
`copies>=2` lined up.

For such a block, free-time validation checks the wrong slot, concludes
the entry was previously pruned, and `zio_ddt_free()` falls back to a
plain physical free — the shared gang header extents are freed **once
per reference delete, with no refcount decrement**:

https://github.com/openzfs/zfs/blob/9bf75b4b13949afe322387fc5572c5820ccL4204

Consequences per triggering delete:

- Remaining references point at freed header sectors; reads fail with
  `cksum_algorithm=gang_header` checksum errors once the space is
  reused (all header copies are freed together, so mirror/raidz
  redundancy does not protect them).
- The second and later deletes commit overlapping FREE records to the
  spacemaps — surfacing as `zfs: rt=...: adding segment ... overlapping
  with existing one` panics at import or runtime — or free unrelated
  live allocations if the extents were reallocated in between,
  silently cross-linking whatever lands there next.
- The gang members are never traversed (see defect 2) and leak
  permanently once the last reference is deleted.
- The entry becomes immortal (its refcount never reaches zero), so
  future identical writes dedup against freed/reused storage and are
  lost as written. `dedup=verify` mitigates this vector.
- If a block was cloned while the bug was live, the failing verify
  lookup made `ddt_addref()` fall back to BRT
  ([module/zfs/brt.c#L1283](https://github.com/openzfs/zfs/blob/9bf75b427c3/module/zfs/brt.c#L1283)),
  leaving a DDT/BRT accounting hybrid that no later code can
  disambiguate from the BP alone.

The free-path regression was introduced by d4d79451cb ("Add DDT prune
command", #16277), first released in **2.3.0**; before that the free
path selected the phys by DVA identity and was correct. So the hazard
is retroactive: traditional-format dedup gang blocks written safely
under 2.1/2.2 (or later, on pools without `feature@fast_dedup`) become
corruption sources the first time they are deleted under >= 2.3.0.
Exposed pools are those with a traditional-format DDT — dedup first
used while `fast_dedup` was not enabled (legacy pools that upgraded,
or `compatibility=` profiles) — that ever wrote a dedup'd block under
enough allocation pressure to gang. Flat (FDT) tables are not affected
by the slot-indexing defect.

A possibly related field report: #17297 — the same overlapping-segment
panic class on 2.3.1 with dedup + zstd + encryption + low free space
and repeated `gang_header` checksum ereports; no root cause was
identified there, and its DDT format was not reported, so no direct
link is established. I also hit an `ms_defer` overlapping-segment
panic at import on a pool with legacy-dedup history, which is what
prompted this investigation.

**Defect 2: the DDT free pipeline discards gang stages.**

`zio_create()` adds the gang stages to the pipeline of a logical free
of a gang BP:

https://github.com/openzfs/zfs/blob/9bf75b4b13949afe322387fc5572c5820cce27c3/module/zfs/zio.c#L994-L995

but `zio_free_bp_init()` replaced the whole pipeline for dedup BPs,
discarding them:

https://github.com/openzfs/zfs/blob/9bf75b4b13949afe322387fc5572c5820ccL2141

On the *legitimate* pruned-entry fallback (`zpool ddtprune`), the plain
free that follows therefore releases only the gang header extents —
`metaslab_free_dva()` frees `vdev_gang_header_asize()` for a gang DVA
([module/zfs/metaslab.c#L5820-L5836](https://github.com/openzfs/zfs/blob/9bf75b4b13949afe322387fc5572c5820cce27c3/module/zfs/metaslab.c#L5820-L5836))
— and every gang member leaks permanently. #17983 and #18520 fixed
adjacent problems in this fallback without covering the gang case.

### Description

Two commits, independently backportable, each with its own regression
test:

1. **`ddt: select traditional phys by block identity, not BP DVA count`
   — `ddt_entry_lookup_is_valid()` now matches a phys by block identity
   (DVA[0] + physical birth) via `ddt_phys_select()`, the same
   predicate the decref path already uses (and what the existing
   `XXX ... maybe can combine` comment asked for). `ddt_addref()`
   selects the same way; both must change together because the addref
   mis-indexing is masked only by the broken lookup failing first, and
   the added `VERIFY` keeps `DDT_PHYS_NONE` from reaching
   `ddt_phys_addref()`, which would index out of bounds on release
   builds. A traditional-table miss on free — not expected on a
   consistent pool, since pruning only walks flat tables
   ([module/zfs/ddt.c#L2841](https://github.com/openzfs/zfs/blob/9bf75b4b13949afe322387fc5572c5820cce27c3/module/zfs/ddt.c#L2841))
   — now leaves a `zfs_dbgmsg` trace instead of silently bypassing the
   refcount. Incidentally this also repairs frees of legacy
   `DDT_PHYS_DITTO` blocks (the old code could never select slot 0).
   Stale comments describing the trad slot as "the number of DVAs"
   (the mental model that produced the bug) are corrected.
2. **`zio: don't strip gang stages from the DDT free pipeline`** —
   `zio_free_bp_init()` now ORs `ZIO_DDT_FREE_PIPELINE` into the
   pipeline instead of assigning it, keeping the gang stages (and any
   other stage `zio_create()` added for this BP). Today this only adds
   `ZIO_STAGE_DDT_FREE` — `zio_free_sync()` already builds dedup frees
   with every other bit of that pipeline — but ORing the whole
   declaration keeps the site correct if the pipeline definition ever
   grows. The gang stages still run only on the true fall-through: a
   live DDT entry or a surviving BRT reference truncates the pipeline
   before the gang stages execute (since the restructuring in #18520;
   stage order `DDT_FREE < BRT_FREE < GANG_ASSEMBLE/ISSUE <
   DVA_FREE`), and the refcount-to-zero path is unaffected
   (`ddt_phys_free()` rebuilds a dedup-cleared BP whose free zio gets
   its own gang stages).

**What this fix does not do.** It is prevention only. Damage already
committed by the bug persists on disk and cannot be repaired in place:
leaked members (capacity only), committed spacemap double-frees (the
serious one — the allocator can hand doubly-freed regions to two
owners, and `zfs_recover=1` merely warns and skips the overlapping
segment,
[module/zfs/range_tree.c#L355-L366](https://github.com/openzfs/zfs/blob/9bf75b4b13949afe322387fc5572c5820cce27c3/module/zfs/range_tree.c#L355-L366)),
immortal stale entries (which keep matching future identical writes
even on fixed code — write-path lookups don't validate), and the
DDT/BRT clone hybrids. Pools with committed double-frees need
backup-and-rebuild; suggestions welcome on whether remediation guidance
belongs somewhere more durable than this PR text.

**Auditing a pool:**

- Table format: `zdb -D <pool>` prints `version=0 [LEGACY]` vs
  `version=1 [FDT]` per table (object names `DDT-<cksum>-zap-*` do not
  discriminate — FDT uses them too).
- Hard evidence, latent or triggered: `zdb -DDDDD <pool>` (five D's —
  at `-DDDD` the unique/refcnt-1 class is skipped, which is where
  never-deleted hazards live). Look for LEGACY-table entries whose
  `phys` slot contradicts the printed BP, e.g.
  `refcnt 1 phys 1 ... gang ... double`. Can be expensive on large
  DDTs.
- Corroborating: leaked space in `zdb -bcc` after last-reference
  deletes; `gang_header` checksum ereports; overlapping-segment panics.

**Backports:** the defective validation function is byte-identical in
every 2.3.x/2.4.x release; surrounding code differs slightly per
branch (2.3.0 and 2.3.1 have no `verify` lookup parameter — it arrives
in 2.3.2; the current 2.3-release tip predates master's phys-miss
fall-through), so backports need minor adaptation. The `ddt_addref()`
half predates 2.3.0 and exists in 2.2.x via block cloning, with no
verify-lookup masking it there; that branch deserves a separate audit.

### How Has This Been Tested?

- **Deterministic reproducer** (forced ganging via the existing
  `metaslab_force_ganging` tunables on a `feature@fast_dedup=disabled`
  pool, userland libzpool): unpatched master leaks exactly 3,342,336
  bytes per run in `zdb -bcc` and retains stale DDT entries after all
  references are deleted; with this change the identical workload
  decrements refcounts correctly and repeated runs report no leak. The
  prune/gang case (defect 2) leaks 1,198,080 bytes unpatched and is
  clean with the fix.
- **Randomized ztest**: 15 runs with `-o metaslab_force_ganging_pct=100
  on the patched tree (ztest randomly enables dedup and creates
  legacy/FDT pools 50/50; four runs exercised traditional DDTs), all
  clean through ztest's built-in `zdb -bccsv` verification.
- **New ZTS coverage**: `dedup_legacy_gang` (traditional DDT + forced
  ganging; three references — write, dedup copy, block clone; asserts
  the refcount of the copies=1 phys after every step, that the clone
  took a DDT reference and not BRT via `bcloneused`, survivor
  readability across an export/import, and a final empty-DDT +
  `zdb -bcc` gate) and a forced-ganging second phase in
  `dedup_prune_leak` (asserts the entries are ganged and actually
  pruned, then verifies the members are freed). `dedup_legacy_gang`
  takes its clone reference with `FICLONE`, so it is registered
  Linux-only alongside the other FICLONE tests. Both follow existing
  sibling-test idioms; I have not yet run the full suite against a
  live kernel with this change, so CI is the first executor — flagging
  that honestly.
- Userland build clean (`-Werror`, debug), `make checkstyle` clean
  (cstyle, shellcheck, commitcheck), `git diff --check` clean.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

