### PR TITLE
zdb: account pending DDT-log frees in leak detection

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -6608,24 +6608,54 @@ ddt_done:
 		uint64_t offset = DVA_GET_OFFSET(&bp->blk_dva[0]);
 		vdev_t *vd = vdev_lookup_top(zcb->zcb_spa, vdev);
 		ASSERT(vd != NULL);
-		metaslab_t *ms = vd->vdev_ms[offset >> vd->vdev_ms_shift];
-		ASSERT(ms != NULL);
-		metaslab_group_t *mg = ms->ms_group;
-		ASSERT(mg != NULL);
-		metaslab_class_t *mc = mg->mg_class;
-		ASSERT(mc != NULL);
-
-		spa_config_exit(zcb->zcb_spa, SCL_CONFIG, FTAG);
 
 		int class;
-		if (mc == spa_normal_class(zcb->zcb_spa)) {
-			class = CLASS_NORMAL;
-		} else if (mc == spa_special_class(zcb->zcb_spa)) {
-			class = CLASS_SPECIAL;
-		} else if (mc == spa_dedup_class(zcb->zcb_spa)) {
-			class = CLASS_DEDUP;
+		if (vd->vdev_ops == &vdev_indirect_ops) {
+			/*
+			 * A removed vdev has no metaslabs of its own. Without
+			 * -L we synthesize them (see
+			 * zdb_leak_init_prepare_indirect_vdevs()), but under
+			 * -L there is no metaslab array to index. Classify
+			 * from the allocation bias, which determines the
+			 * vdev's primary metaslab group, and does not depend
+			 * on whether those synthetic metaslabs happen to
+			 * exist.
+			 */
+			switch (vd->vdev_alloc_bias) {
+			case VDEV_BIAS_SPECIAL:
+				class = CLASS_SPECIAL;
+				break;
+			case VDEV_BIAS_DEDUP:
+				class = CLASS_DEDUP;
+				break;
+			case VDEV_BIAS_LOG:
+				class = CLASS_OTHER;
+				break;
+			default:
+				class = CLASS_NORMAL;
+				break;
+			}
+			spa_config_exit(zcb->zcb_spa, SCL_CONFIG, FTAG);
 		} else {
-			class = CLASS_OTHER;
+			metaslab_t *ms =
+			    vd->vdev_ms[offset >> vd->vdev_ms_shift];
+			ASSERT(ms != NULL);
+			metaslab_group_t *mg = ms->ms_group;
+			ASSERT(mg != NULL);
+			metaslab_class_t *mc = mg->mg_class;
+			ASSERT(mc != NULL);
+
+			spa_config_exit(zcb->zcb_spa, SCL_CONFIG, FTAG);
+
+			if (mc == spa_normal_class(zcb->zcb_spa)) {
+				class = CLASS_NORMAL;
+			} else if (mc == spa_special_class(zcb->zcb_spa)) {
+				class = CLASS_SPECIAL;
+			} else if (mc == spa_dedup_class(zcb->zcb_spa)) {
+				class = CLASS_DEDUP;
+			} else {
+				class = CLASS_OTHER;
+			}
 		}
 
 		if (!(block_classes & class)) {

--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -6092,16 +6092,19 @@ typedef struct zdb_blkstats {
 } zdb_blkstats_t;
 
 /*
- * Extended object types to report deferred frees and dedup auto-ditto blocks.
+ * Extended object types to report deferred frees, dedup auto-ditto blocks
+ * and pending DDT-log frees.
  */
 #define	ZDB_OT_DEFERRED	(DMU_OT_NUMTYPES + 0)
 #define	ZDB_OT_DITTO	(DMU_OT_NUMTYPES + 1)
-#define	ZDB_OT_OTHER	(DMU_OT_NUMTYPES + 2)
-#define	ZDB_OT_TOTAL	(DMU_OT_NUMTYPES + 3)
+#define	ZDB_OT_DDT_PENDING	(DMU_OT_NUMTYPES + 2)
+#define	ZDB_OT_OTHER	(DMU_OT_NUMTYPES + 3)
+#define	ZDB_OT_TOTAL	(DMU_OT_NUMTYPES + 4)
 
 static const char *zdb_ot_extname[] = {
 	"deferred free",
 	"dedup ditto",
+	"DDT pending free",
 	"other",
 	"Total",
 };
@@ -7663,6 +7666,63 @@ bpobj_count_block_cb(void *arg, const blkptr_t *bp, boolean_t bp_freed,
 	return (count_block_cb(arg, bp, tx));
 }
 
+/*
+ * With fast dedup, the last decref of a block lands in the DDT log, and
+ * the physical free happens only when the log entry is flushed back into
+ * the DDT (see ddt_sync_flush_entry()). Until then the block is not
+ * referenced by any block pointer but is still allocated, so the
+ * traversal would misreport it as leaked. Count the phys that the flush
+ * will free here, the same way as the deferred-free bplist: they are
+ * frees in flight. Entries behind the log checkpoint are already flushed
+ * and are not loaded into the in-memory log trees, so everything found
+ * here is genuinely pending.
+ */
+static void
+zdb_count_ddt_log_frees(spa_t *spa, zdb_cb_t *zcb)
+{
+	for (enum zio_checksum c = 0; c < ZIO_CHECKSUM_FUNCTIONS; c++) {
+		ddt_t *ddt = spa->spa_ddt[c];
+		if (ddt == NULL || !(ddt->ddt_flags & DDT_FLAG_LOG))
+			continue;
+		for (int n = 0; n < 2; n++) {
+			ddt_log_t *ddl = &ddt->ddt_log[n];
+			for (ddt_log_entry_t *ddle = avl_first(&ddl->ddl_tree);
+			    ddle; ddle = AVL_NEXT(&ddl->ddl_tree, ddle)) {
+				ddt_lightweight_entry_t ddlwe;
+				DDT_LOG_ENTRY_TO_LIGHTWEIGHT(ddt, ddle,
+				    &ddlwe);
+				for (int p = 0; p < DDT_NPHYS(ddt); p++) {
+					ddt_phys_variant_t v =
+					    DDT_PHYS_VARIANT(ddt, p);
+					/*
+					 * Mirror ddt_sync_flush_entry(): an
+					 * unborn phys owns nothing, an
+					 * obsolete ditto slot is freed
+					 * whatever its refcount, and any
+					 * other slot is freed once its last
+					 * reference is gone.
+					 */
+					if (ddt_phys_birth(&ddlwe.ddlwe_phys,
+					    v) == 0)
+						continue;
+					if (!DDT_PHYS_IS_DITTO(ddt, p) &&
+					    ddt_phys_refcnt(&ddlwe.ddlwe_phys,
+					    v) != 0)
+						continue;
+					blkptr_t blk;
+					ddt_bp_create(ddt->ddt_checksum,
+					    &ddlwe.ddlwe_key, &ddlwe.ddlwe_phys,
+					    v, &blk);
+					/* As ddt_phys_free() does at flush. */
+					BP_SET_DEDUP(&blk, 0);
+					zdb_count_block(zcb, NULL, &blk,
+					    ZDB_OT_DDT_PENDING);
+				}
+			}
+		}
+	}
+}
+
 static int
 livelist_entry_count_blocks_cb(void *args, dsl_deadlist_entry_t *dle)
 {
@@ -7787,6 +7847,8 @@ dump_block_stats(spa_t *spa)
 		(void) bpobj_iterate_nofree(&spa->spa_dsl_pool->dp_free_bpobj,
 		    bpobj_count_block_cb, zcb, NULL);
 	}
+
+	zdb_count_ddt_log_frees(spa, zcb);
 
 	zdb_claim_removing(spa, zcb);
 

--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -6624,24 +6624,54 @@ ddt_done:
 		uint64_t offset = DVA_GET_OFFSET(&bp->blk_dva[0]);
 		vdev_t *vd = vdev_lookup_top(zcb->zcb_spa, vdev);
 		ASSERT(vd != NULL);
-		metaslab_t *ms = vd->vdev_ms[offset >> vd->vdev_ms_shift];
-		ASSERT(ms != NULL);
-		metaslab_group_t *mg = ms->ms_group;
-		ASSERT(mg != NULL);
-		metaslab_class_t *mc = mg->mg_class;
-		ASSERT(mc != NULL);
-
-		spa_config_exit(zcb->zcb_spa, SCL_CONFIG, FTAG);
 
 		int class;
-		if (mc == spa_normal_class(zcb->zcb_spa)) {
-			class = CLASS_NORMAL;
-		} else if (mc == spa_special_class(zcb->zcb_spa)) {
-			class = CLASS_SPECIAL;
-		} else if (mc == spa_dedup_class(zcb->zcb_spa)) {
-			class = CLASS_DEDUP;
+		if (vd->vdev_ops == &vdev_indirect_ops) {
+			/*
+			 * A removed vdev has no metaslabs of its own. Without
+			 * -L we synthesize them (see
+			 * zdb_leak_init_prepare_indirect_vdevs()), but under
+			 * -L there is no metaslab array to index. Classify
+			 * from the allocation bias, which determines the
+			 * vdev's primary metaslab group, and does not depend
+			 * on whether those synthetic metaslabs happen to
+			 * exist.
+			 */
+			switch (vd->vdev_alloc_bias) {
+			case VDEV_BIAS_SPECIAL:
+				class = CLASS_SPECIAL;
+				break;
+			case VDEV_BIAS_DEDUP:
+				class = CLASS_DEDUP;
+				break;
+			case VDEV_BIAS_LOG:
+				class = CLASS_OTHER;
+				break;
+			default:
+				class = CLASS_NORMAL;
+				break;
+			}
+			spa_config_exit(zcb->zcb_spa, SCL_CONFIG, FTAG);
 		} else {
-			class = CLASS_OTHER;
+			metaslab_t *ms =
+			    vd->vdev_ms[offset >> vd->vdev_ms_shift];
+			ASSERT(ms != NULL);
+			metaslab_group_t *mg = ms->ms_group;
+			ASSERT(mg != NULL);
+			metaslab_class_t *mc = mg->mg_class;
+			ASSERT(mc != NULL);
+
+			spa_config_exit(zcb->zcb_spa, SCL_CONFIG, FTAG);
+
+			if (mc == spa_normal_class(zcb->zcb_spa)) {
+				class = CLASS_NORMAL;
+			} else if (mc == spa_special_class(zcb->zcb_spa)) {
+				class = CLASS_SPECIAL;
+			} else if (mc == spa_dedup_class(zcb->zcb_spa)) {
+				class = CLASS_DEDUP;
+			} else {
+				class = CLASS_OTHER;
+			}
 		}
 
 		if (!(block_classes & class)) {

--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -6108,16 +6108,19 @@ typedef struct zdb_blkstats {
 } zdb_blkstats_t;
 
 /*
- * Extended object types to report deferred frees and dedup auto-ditto blocks.
+ * Extended object types to report deferred frees, dedup auto-ditto blocks
+ * and pending DDT-log frees.
  */
 #define	ZDB_OT_DEFERRED	(DMU_OT_NUMTYPES + 0)
 #define	ZDB_OT_DITTO	(DMU_OT_NUMTYPES + 1)
-#define	ZDB_OT_OTHER	(DMU_OT_NUMTYPES + 2)
-#define	ZDB_OT_TOTAL	(DMU_OT_NUMTYPES + 3)
+#define	ZDB_OT_DDT_PENDING	(DMU_OT_NUMTYPES + 2)
+#define	ZDB_OT_OTHER	(DMU_OT_NUMTYPES + 3)
+#define	ZDB_OT_TOTAL	(DMU_OT_NUMTYPES + 4)
 
 static const char *zdb_ot_extname[] = {
 	"deferred free",
 	"dedup ditto",
+	"DDT pending free",
 	"other",
 	"Total",
 };
@@ -7679,6 +7682,65 @@ bpobj_count_block_cb(void *arg, const blkptr_t *bp, boolean_t bp_freed,
 	return (count_block_cb(arg, bp, tx));
 }
 
+/*
+ * With fast dedup, the last decref of a block lands in the DDT log, and
+ * the physical free happens only when the log entry is flushed back into
+ * the DDT (see ddt_sync_flush_entry()). Until then the block is not
+ * referenced by any block pointer but is still allocated, so the
+ * traversal would misreport it as leaked. Count the phys that the flush
+ * will free here, the same way as the deferred-free bplist: they are
+ * frees in flight. Entries behind the log checkpoint are already flushed
+ * and are not loaded into the in-memory log trees, so everything found
+ * here is genuinely pending. ddt_log_load() merge-normalizes duplicate
+ * keys across the active and flushing logs, and ddt_lookup() searches the
+ * logs before stored DDT objects, so these trees need no DDT ZAP replay.
+ */
+static void
+zdb_count_ddt_log_frees(spa_t *spa, zdb_cb_t *zcb)
+{
+	for (enum zio_checksum c = 0; c < ZIO_CHECKSUM_FUNCTIONS; c++) {
+		ddt_t *ddt = spa->spa_ddt[c];
+		if (ddt == NULL || !(ddt->ddt_flags & DDT_FLAG_LOG))
+			continue;
+		for (int n = 0; n < 2; n++) {
+			ddt_log_t *ddl = &ddt->ddt_log[n];
+			for (ddt_log_entry_t *ddle = avl_first(&ddl->ddl_tree);
+			    ddle; ddle = AVL_NEXT(&ddl->ddl_tree, ddle)) {
+				ddt_lightweight_entry_t ddlwe;
+				DDT_LOG_ENTRY_TO_LIGHTWEIGHT(ddt, ddle,
+				    &ddlwe);
+				for (int p = 0; p < DDT_NPHYS(ddt); p++) {
+					ddt_phys_variant_t v =
+					    DDT_PHYS_VARIANT(ddt, p);
+					/*
+					 * Mirror ddt_sync_flush_entry(): an
+					 * unborn phys owns nothing, an
+					 * obsolete ditto slot is freed
+					 * whatever its refcount, and any
+					 * other slot is freed once its last
+					 * reference is gone.
+					 */
+					if (ddt_phys_birth(&ddlwe.ddlwe_phys,
+					    v) == 0)
+						continue;
+					if (!DDT_PHYS_IS_DITTO(ddt, p) &&
+					    ddt_phys_refcnt(&ddlwe.ddlwe_phys,
+					    v) != 0)
+						continue;
+					blkptr_t blk;
+					ddt_bp_create(ddt->ddt_checksum,
+					    &ddlwe.ddlwe_key, &ddlwe.ddlwe_phys,
+					    v, &blk);
+					/* As ddt_phys_free() does at flush. */
+					BP_SET_DEDUP(&blk, 0);
+					zdb_count_block(zcb, NULL, &blk,
+					    ZDB_OT_DDT_PENDING);
+				}
+			}
+		}
+	}
+}
+
 static int
 livelist_entry_count_blocks_cb(void *args, dsl_deadlist_entry_t *dle)
 {
@@ -7803,6 +7865,8 @@ dump_block_stats(spa_t *spa)
 		(void) bpobj_iterate_nofree(&spa->spa_dsl_pool->dp_free_bpobj,
 		    bpobj_count_block_cb, zcb, NULL);
 	}
+
+	zdb_count_ddt_log_frees(spa, zcb);
 
 	zdb_claim_removing(spa, zcb);
 

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -719,6 +719,7 @@ tags = ['functional', 'deadman']
 tests = ['dedup_bclone', 'dedup_bclone_pruned', 'dedup_fdt_create',
     'dedup_fdt_import',
     'dedup_fdt_pacing', 'dedup_legacy_create', 'dedup_legacy_import',
+    'dedup_log_zdb_leak',
     'dedup_legacy_fdt_upgrade', 'dedup_legacy_fdt_mixed', 'dedup_quota',
     'dedup_prune', 'dedup_prune_leak', 'dedup_zap_shrink']
 pre =

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -950,7 +950,8 @@ tags = ['functional', 'refreserv']
 [tests/functional/removal]
 pre =
 tests = ['removal_all_vdev', 'removal_cancel', 'removal_check_space',
-    'removal_condense_export', 'removal_multiple_indirection',
+    'removal_condense_export', 'removal_indirect_class',
+    'removal_multiple_indirection',
     'removal_nopwrite', 'removal_remap_deadlists',
     'removal_resume_export', 'removal_sanity', 'removal_with_add',
     'removal_with_create_fs', 'removal_with_dedup',

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -954,7 +954,8 @@ tags = ['functional', 'refreserv']
 [tests/functional/removal]
 pre =
 tests = ['removal_all_vdev', 'removal_cancel', 'removal_check_space',
-    'removal_condense_export', 'removal_multiple_indirection',
+    'removal_condense_export', 'removal_indirect_class',
+    'removal_multiple_indirection',
     'removal_nopwrite', 'removal_remap_deadlists',
     'removal_resume_export', 'removal_sanity', 'removal_with_add',
     'removal_with_create_fs', 'removal_with_dedup',

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -723,6 +723,7 @@ tests = ['dedup_bclone', 'dedup_bclone_pruned', 'dedup_fdt_create',
     'dedup_fdt_import',
     'dedup_fdt_pacing', 'dedup_legacy_create', 'dedup_legacy_import',
     'dedup_legacy_fdt_upgrade', 'dedup_legacy_fdt_mixed', 'dedup_quota',
+    'dedup_log_zdb_leak',
     'dedup_prune', 'dedup_prune_leak', 'dedup_zap_shrink']
 pre =
 post =

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1560,6 +1560,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/dedup/dedup_fdt_pacing.ksh \
 	functional/dedup/dedup_legacy_create.ksh \
 	functional/dedup/dedup_legacy_import.ksh \
+	functional/dedup/dedup_log_zdb_leak.ksh \
 	functional/dedup/dedup_legacy_fdt_upgrade.ksh \
 	functional/dedup/dedup_legacy_fdt_mixed.ksh \
 	functional/dedup/dedup_prune.ksh \

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -2021,6 +2021,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/removal/removal_cancel.ksh \
 	functional/removal/removal_check_space.ksh \
 	functional/removal/removal_condense_export.ksh \
+	functional/removal/removal_indirect_class.ksh \
 	functional/removal/removal_multiple_indirection.ksh \
 	functional/removal/removal_nopwrite.ksh \
 	functional/removal/removal_remap_deadlists.ksh \

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1583,6 +1583,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/dedup/dedup_legacy_import.ksh \
 	functional/dedup/dedup_legacy_fdt_upgrade.ksh \
 	functional/dedup/dedup_legacy_fdt_mixed.ksh \
+	functional/dedup/dedup_log_zdb_leak.ksh \
 	functional/dedup/dedup_prune.ksh \
 	functional/dedup/dedup_prune_leak.ksh \
 	functional/dedup/dedup_quota.ksh \

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -2054,6 +2054,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/removal/removal_cancel.ksh \
 	functional/removal/removal_check_space.ksh \
 	functional/removal/removal_condense_export.ksh \
+	functional/removal/removal_indirect_class.ksh \
 	functional/removal/removal_multiple_indirection.ksh \
 	functional/removal/removal_nopwrite.ksh \
 	functional/removal/removal_remap_deadlists.ksh \

--- a/tests/zfs-tests/tests/functional/dedup/dedup_log_zdb_leak.ksh
+++ b/tests/zfs-tests/tests/functional/dedup/dedup_log_zdb_leak.ksh
@@ -1,0 +1,223 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+# DESCRIPTION:
+#	With fast dedup, the last decref of a block lands in the DDT log
+#	and the physical free happens only when the log flushes. Blocks
+#	inside that window are referenced by no block pointer but still
+#	allocated, and zdb used to misreport them: as "leaked space" in
+#	the generic accounting, and as a fatal "obsolete indirect mapping
+#	count mismatch" when such a block sits behind a removed vdev's
+#	mapping. Verify zdb accounts pending DDT-log frees instead — and
+#	only those: live entries and pruned-entry tombstones in the log
+#	must not be claimed.
+#
+# STRATEGY:
+#	1. Write dedup'd blocks (one shared twice, one unique) with the
+#	   DDT log flushing every txg, so the entries land in the ZAP.
+#	2. Pin the log, ddtprune the unique entries (leaving zero-phys
+#	   tombstones), and drop one reference to the shared blocks
+#	   (leaving a positive-refcount log entry). Neither describes a
+#	   pending free.
+#	3. Pre-delete zdb: the "DDT pending free" bucket must be empty and
+#	   nothing may be double-claimed — this exercises both the birth
+#	   and refcount exclusions.
+#	4. Drop the last reference to the shared blocks; their
+#	   decref-to-zero entries stay pending in the pinned log.
+#	5. Post-delete zdb: exactly those blocks must be accounted in the
+#	   "DDT pending free" bucket with no leaked space.
+#	6. Write the same content again before the log flushes: the pending
+#	   entries are resurrected, so nothing may remain pending.
+#	7. Repeat the window on a pool whose data was migrated by device
+#	   removal, so the pending frees point at an indirect vdev: zdb
+#	   must exit 0 with no obsolete mapping count mismatch.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/removal/removal.kshlib
+
+verify_runnable "global"
+verify_disk_count "$DISKS" 2
+
+log_assert "zdb accounts pending DDT-log frees instead of reporting leaks"
+
+log_must save_tunable DEDUP_LOG_TXG_MAX
+log_must save_tunable DEDUP_LOG_FLUSH_ENTRIES_MIN
+
+# Content is written from a seed outside the pool so it can be written
+# again later, to resurrect an entry that is pending free.
+typeset seed=$TEST_BASE_DIR/dedup_log_zdb_leak.seed
+
+function cleanup
+{
+	if poolexists $TESTPOOL ; then
+		destroy_pool $TESTPOOL
+	fi
+	rm -f $seed
+	log_must restore_tunable DEDUP_LOG_TXG_MAX
+	log_must restore_tunable DEDUP_LOG_FLUSH_ENTRIES_MIN
+}
+
+log_onexit cleanup
+
+set -A disks $DISKS
+
+# Extract the block count of the "DDT pending free" bucket; the table
+# prints "-" when the bucket is empty.
+function pending_count
+{
+	echo "$1" | awk '/DDT pending free/ {print $1; exit}'
+}
+
+# True when the DDT log holds at least one entry. zdb's status is checked
+# separately, so a zdb failure cannot be hidden by grep finding nothing.
+function ddt_log_has_entries
+{
+	typeset out
+	out=$(zdb -D $TESTPOOL 2>&1) || log_fail "zdb -D failed: $out"
+	echo "$out" | grep -q 'DDT-log-.*entries=[1-9]'
+}
+
+# Phase 1: pending frees on a concrete vdev must show up as "DDT pending
+# free" — and nothing else from the log (live entries, prune tombstones)
+# may be claimed.
+log_must zpool create -f -o feature@fast_dedup=enabled \
+    -O dedup=on -O compression=off -O xattr=sa $TESTPOOL ${disks[0]}
+log_must zfs create -o recordsize=128k $TESTPOOL/$TESTFS
+typeset mountpoint=$(get_prop mountpoint $TESTPOOL/$TESTFS)
+
+# Flush the log every txg while writing, so the entries land in the
+# DDT ZAP where ddtprune can see them.
+log_must set_tunable32 DEDUP_LOG_TXG_MAX 1
+log_must set_tunable32 DEDUP_LOG_FLUSH_ENTRIES_MIN 100000
+log_must dd if=/dev/urandom of=$seed bs=128k count=4
+log_must cp $seed $mountpoint/file1
+log_must cp $seed $mountpoint/file2
+log_must dd if=/dev/urandom of=$mountpoint/file3 bs=128k count=4
+sync_pool $TESTPOOL
+sync_pool $TESTPOOL
+# The log must be empty here (everything flushed to the ZAP); capture
+# zdb's output and status separately so a zdb failure can't be masked by
+# the grep finding nothing.
+ddt_out=$(zdb -D $TESTPOOL 2>&1)
+log_must test $? -eq 0
+log_mustnot eval "echo \"\$ddt_out\" | grep -q 'DDT-log-.*entries=[1-9]'"
+
+# Age the entries past ddtprune's cutoff, then pin the log so that
+# everything logged from here on stays pending.
+sleep 1
+log_must set_tunable32 DEDUP_LOG_TXG_MAX 1000000
+
+# Prune file3's unique entries: the pinned log now holds zero-phys
+# tombstones for blocks that file3 still references. Then drop one of
+# the two references to the shared blocks, so the log also holds a
+# positive-refcount (2->1) entry for blocks that file2 still references.
+log_must zpool ddtprune -p 100 $TESTPOOL
+sync_pool $TESTPOOL
+# Assert the tombstones separately, before anything is dereferenced: at
+# this point a log entry can only have come from the prune. Checking only
+# after the rm below would be satisfied by the 2->1 decref alone.
+log_must ddt_log_has_entries
+
+log_must rm $mountpoint/file1
+sync_pool $TESTPOOL
+log_must ddt_log_has_entries
+
+# Pre-delete: no block is pending free yet. The log holds only
+# tombstones (birth 0) and a positive-refcount entry — neither may be
+# claimed. A bogus claim would collide with the traversal claiming the
+# still-live file2/file3 blocks and fail zdb outright, and would show a
+# nonzero "DDT pending free" bucket.
+zdb_out=$(zdb -bbcc $TESTPOOL 2>&1)
+rc=$?
+echo "$zdb_out"
+if (( rc != 0 )) || echo "$zdb_out" | grep -q "leaked space"; then
+	log_fail "zdb claimed a tombstone or a live log entry as pending"
+fi
+typeset pending=$(pending_count "$zdb_out")
+[[ "$pending" == "-" ]] || \
+    log_fail "blocks claimed as pending while none are: '$pending'"
+
+# Drop the last reference; the shared blocks' decref-to-zero entries
+# now stay pending in the pinned log. There are four such blocks.
+log_must rm $mountpoint/file2
+sync_pool $TESTPOOL
+log_must ddt_log_has_entries
+
+zdb_out=$(zdb -bbcc $TESTPOOL 2>&1)
+rc=$?
+echo "$zdb_out"
+if (( rc != 0 )) || echo "$zdb_out" | grep -q "leaked space"; then
+	log_fail "zdb misreported pending DDT-log frees as leaks"
+fi
+log_must eval "echo \"\$zdb_out\" | grep -q 'No leaks'"
+pending=$(pending_count "$zdb_out")
+[[ "$pending" == "4" ]] || \
+    log_fail "expected 4 blocks in the DDT pending free bucket, got '$pending'"
+
+# Writing the same content again while those entries are still pending
+# must resurrect them: the log-aware lookup finds the zero-refcount entry
+# and bumps it, so nothing is pending and nothing has been freed.
+log_must cp $seed $mountpoint/file4
+sync_pool $TESTPOOL
+
+zdb_out=$(zdb -bbcc $TESTPOOL 2>&1)
+rc=$?
+echo "$zdb_out"
+if (( rc != 0 )) || echo "$zdb_out" | grep -q "leaked space"; then
+	log_fail "zdb misreported a resurrected DDT-log entry"
+fi
+pending=$(pending_count "$zdb_out")
+[[ "$pending" == "-" ]] || \
+    log_fail "blocks still pending after resurrection: '$pending'"
+log_must cmp_xxh128 $mountpoint/file4 $seed
+
+# Phase 2: the same window behind a removed vdev's indirect mapping used
+# to fail zdb outright with an obsolete mapping count mismatch.
+destroy_pool $TESTPOOL
+log_must zpool create -f -o feature@fast_dedup=enabled \
+    -O dedup=on -O compression=off -O xattr=sa $TESTPOOL ${disks[0]}
+log_must zfs create -o recordsize=128k $TESTPOOL/$TESTFS
+mountpoint=$(get_prop mountpoint $TESTPOOL/$TESTFS)
+log_must dd if=/dev/urandom of=$mountpoint/file1 bs=128k count=4
+log_must dd if=$mountpoint/file1 of=$mountpoint/file2 bs=128k
+sync_pool $TESTPOOL
+
+# Migrate everything to a second disk; the dedup'd blocks now live
+# behind the removed vdev's indirect mapping.
+log_must zpool add $TESTPOOL ${disks[1]}
+log_must zpool remove $TESTPOOL ${disks[0]}
+log_must wait_for_removal $TESTPOOL
+
+log_must rm $mountpoint/file1 $mountpoint/file2
+sync_pool $TESTPOOL
+log_must ddt_log_has_entries
+
+zdb_out=$(zdb -bcc $TESTPOOL 2>&1)
+rc=$?
+echo "$zdb_out"
+if (( rc != 0 )) || \
+    echo "$zdb_out" | grep -q "obsolete indirect mapping count mismatch"; then
+	log_fail "pending DDT-log frees tripped the obsolete mapping check"
+fi
+
+log_pass "zdb accounts pending DDT-log frees instead of reporting leaks"

--- a/tests/zfs-tests/tests/functional/dedup/dedup_log_zdb_leak.ksh
+++ b/tests/zfs-tests/tests/functional/dedup/dedup_log_zdb_leak.ksh
@@ -1,0 +1,214 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
+#
+
+# DESCRIPTION:
+#	With fast dedup, the last decref of a block lands in the DDT log
+#	and the physical free happens only when the log flushes. Blocks
+#	inside that window are referenced by no block pointer but still
+#	allocated, and zdb used to misreport them: as "leaked space" in
+#	the generic accounting, and as a fatal "obsolete indirect mapping
+#	count mismatch" when such a block sits behind a removed vdev's
+#	mapping. Verify zdb accounts pending DDT-log frees instead — and
+#	only those: live entries and pruned-entry tombstones in the log
+#	must not be claimed.
+#
+# STRATEGY:
+#	1. Write dedup'd blocks (one shared twice, one unique) with the
+#	   DDT log flushing every txg, so the entries land in the ZAP.
+#	2. Pin the log, ddtprune the unique entries (leaving zero-phys
+#	   tombstones), and drop one reference to the shared blocks
+#	   (leaving a positive-refcount log entry). Neither describes a
+#	   pending free.
+#	3. Pre-delete zdb: the "DDT pending free" bucket must be empty and
+#	   nothing may be double-claimed — this exercises both the birth
+#	   and refcount exclusions.
+#	4. Drop the last reference to the shared blocks; their
+#	   decref-to-zero entries stay pending in the pinned log.
+#	5. Post-delete zdb: exactly those blocks must be accounted in the
+#	   "DDT pending free" bucket with no leaked space.
+#	6. Write the same content again before the log flushes: the pending
+#	   entries are resurrected, so nothing may remain pending.
+#	7. Repeat the window on a pool whose data was migrated by device
+#	   removal, so the pending frees point at an indirect vdev: zdb
+#	   must exit 0 with no obsolete mapping count mismatch.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/removal/removal.kshlib
+
+verify_runnable "global"
+verify_disk_count "$DISKS" 2
+
+log_assert "zdb accounts pending DDT-log frees instead of reporting leaks"
+
+log_must save_tunable DEDUP_LOG_TXG_MAX
+log_must save_tunable DEDUP_LOG_FLUSH_ENTRIES_MIN
+
+# Content is written from a seed outside the pool so it can be written
+# again later, to resurrect an entry that is pending free.
+typeset seed=$TEST_BASE_DIR/dedup_log_zdb_leak.seed
+
+function cleanup
+{
+	if poolexists $TESTPOOL ; then
+		destroy_pool $TESTPOOL
+	fi
+	rm -f $seed
+	log_must restore_tunable DEDUP_LOG_TXG_MAX
+	log_must restore_tunable DEDUP_LOG_FLUSH_ENTRIES_MIN
+}
+
+log_onexit cleanup
+
+set -A disks $DISKS
+
+# Extract the block count of the "DDT pending free" bucket; the table
+# prints "-" when the bucket is empty.
+function pending_count
+{
+	echo "$1" | awk '/DDT pending free/ {print $1; exit}'
+}
+
+# True when the DDT log holds at least one entry. zdb's status is checked
+# separately, so a zdb failure cannot be hidden by grep finding nothing.
+function ddt_log_has_entries
+{
+	typeset out
+	out=$(zdb -D $TESTPOOL 2>&1) || log_fail "zdb -D failed: $out"
+	echo "$out" | grep -q 'DDT-log-.*entries=[1-9]'
+}
+
+# Phase 1: pending frees on a concrete vdev must show up as "DDT pending
+# free" — and nothing else from the log (live entries, prune tombstones)
+# may be claimed.
+log_must zpool create -f -o feature@fast_dedup=enabled \
+    -O dedup=on -O compression=off -O xattr=sa $TESTPOOL ${disks[0]}
+log_must zfs create -o recordsize=128k $TESTPOOL/$TESTFS
+typeset mountpoint=$(get_prop mountpoint $TESTPOOL/$TESTFS)
+
+# Flush the log every txg while writing, so the entries land in the
+# DDT ZAP where ddtprune can see them.
+log_must set_tunable32 DEDUP_LOG_TXG_MAX 1
+log_must set_tunable32 DEDUP_LOG_FLUSH_ENTRIES_MIN 100000
+log_must dd if=/dev/urandom of=$seed bs=128k count=4
+log_must cp $seed $mountpoint/file1
+log_must cp $seed $mountpoint/file2
+log_must dd if=/dev/urandom of=$mountpoint/file3 bs=128k count=4
+sync_pool $TESTPOOL
+sync_pool $TESTPOOL
+# The log must be empty here (everything flushed to the ZAP); capture
+# zdb's output and status separately so a zdb failure can't be masked by
+# the grep finding nothing.
+ddt_out=$(zdb -D $TESTPOOL 2>&1)
+log_must test $? -eq 0
+log_mustnot eval "echo \"\$ddt_out\" | grep -q 'DDT-log-.*entries=[1-9]'"
+
+# Age the entries past ddtprune's cutoff, then pin the log so that
+# everything logged from here on stays pending.
+sleep 1
+log_must set_tunable32 DEDUP_LOG_TXG_MAX 1000000
+
+# Prune file3's unique entries: the pinned log now holds zero-phys
+# tombstones for blocks that file3 still references. Then drop one of
+# the two references to the shared blocks, so the log also holds a
+# positive-refcount (2->1) entry for blocks that file2 still references.
+log_must zpool ddtprune -p 100 $TESTPOOL
+sync_pool $TESTPOOL
+# Assert the tombstones separately, before anything is dereferenced: at
+# this point a log entry can only have come from the prune. Checking only
+# after the rm below would be satisfied by the 2->1 decref alone.
+log_must ddt_log_has_entries
+
+log_must rm $mountpoint/file1
+sync_pool $TESTPOOL
+log_must ddt_log_has_entries
+
+# Pre-delete: no block is pending free yet. The log holds only
+# tombstones (birth 0) and a positive-refcount entry — neither may be
+# claimed. A bogus claim would collide with the traversal claiming the
+# still-live file2/file3 blocks and fail zdb outright, and would show a
+# nonzero "DDT pending free" bucket.
+zdb_out=$(zdb -bbcc $TESTPOOL 2>&1)
+rc=$?
+echo "$zdb_out"
+if (( rc != 0 )) || echo "$zdb_out" | grep -q "leaked space"; then
+	log_fail "zdb claimed a tombstone or a live log entry as pending"
+fi
+typeset pending=$(pending_count "$zdb_out")
+[[ "$pending" == "-" ]] || \
+    log_fail "blocks claimed as pending while none are: '$pending'"
+
+# Drop the last reference; the shared blocks' decref-to-zero entries
+# now stay pending in the pinned log. There are four such blocks.
+log_must rm $mountpoint/file2
+sync_pool $TESTPOOL
+log_must ddt_log_has_entries
+
+zdb_out=$(zdb -bbcc $TESTPOOL 2>&1)
+rc=$?
+echo "$zdb_out"
+if (( rc != 0 )) || echo "$zdb_out" | grep -q "leaked space"; then
+	log_fail "zdb misreported pending DDT-log frees as leaks"
+fi
+log_must eval "echo \"\$zdb_out\" | grep -q 'No leaks'"
+pending=$(pending_count "$zdb_out")
+[[ "$pending" == "4" ]] || \
+    log_fail "expected 4 blocks in the DDT pending free bucket, got '$pending'"
+
+# Writing the same content again while those entries are still pending
+# must resurrect them: the log-aware lookup finds the zero-refcount entry
+# and bumps it, so nothing is pending and nothing has been freed.
+log_must cp $seed $mountpoint/file4
+sync_pool $TESTPOOL
+
+zdb_out=$(zdb -bbcc $TESTPOOL 2>&1)
+rc=$?
+echo "$zdb_out"
+if (( rc != 0 )) || echo "$zdb_out" | grep -q "leaked space"; then
+	log_fail "zdb misreported a resurrected DDT-log entry"
+fi
+pending=$(pending_count "$zdb_out")
+[[ "$pending" == "-" ]] || \
+    log_fail "blocks still pending after resurrection: '$pending'"
+log_must cmp_xxh128 $mountpoint/file4 $seed
+
+# Phase 2: the same window behind a removed vdev's indirect mapping used
+# to fail zdb outright with an obsolete mapping count mismatch.
+destroy_pool $TESTPOOL
+log_must zpool create -f -o feature@fast_dedup=enabled \
+    -O dedup=on -O compression=off -O xattr=sa $TESTPOOL ${disks[0]}
+log_must zfs create -o recordsize=128k $TESTPOOL/$TESTFS
+mountpoint=$(get_prop mountpoint $TESTPOOL/$TESTFS)
+log_must dd if=/dev/urandom of=$mountpoint/file1 bs=128k count=4
+log_must dd if=$mountpoint/file1 of=$mountpoint/file2 bs=128k
+sync_pool $TESTPOOL
+
+# Migrate everything to a second disk; the dedup'd blocks now live
+# behind the removed vdev's indirect mapping.
+log_must zpool add $TESTPOOL ${disks[1]}
+log_must zpool remove $TESTPOOL ${disks[0]}
+log_must wait_for_removal $TESTPOOL
+
+log_must rm $mountpoint/file1 $mountpoint/file2
+sync_pool $TESTPOOL
+log_must ddt_log_has_entries
+
+zdb_out=$(zdb -bcc $TESTPOOL 2>&1)
+rc=$?
+echo "$zdb_out"
+if (( rc != 0 )) || \
+    echo "$zdb_out" | grep -q "obsolete indirect mapping count mismatch"; then
+	log_fail "pending DDT-log frees tripped the obsolete mapping check"
+fi
+
+log_pass "zdb accounts pending DDT-log frees instead of reporting leaks"

--- a/tests/zfs-tests/tests/functional/removal/removal_indirect_class.ksh
+++ b/tests/zfs-tests/tests/functional/removal/removal_indirect_class.ksh
@@ -1,0 +1,71 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+# DESCRIPTION:
+#	zdb's --class block filter resolves a block's allocation class
+#	through the top vdev's metaslab array. An indirect vdev has no
+#	metaslabs of its own; zdb synthesizes them only when leak tracking
+#	is enabled, so under -L the array is absent and any block whose
+#	first DVA names a removed vdev used to dereference it.
+#
+# STRATEGY:
+#	1. Create a pool on a single disk and write a file to it, so every
+#	   data block is allocated from that disk.
+#	2. Add a second disk and remove the first, leaving an indirect vdev
+#	   that every one of those blocks is now reached through.
+#	3. Run zdb -bL with a class filter. It must not crash.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/removal/removal.kshlib
+
+verify_runnable "global"
+
+log_assert "zdb -L --class does not fault on an indirect vdev"
+
+set -A disks $DISKS
+if [[ ${#disks[@]} -lt 2 ]]; then
+	log_unsupported "needs at least two disks"
+fi
+
+function cleanup
+{
+	if poolexists $TESTPOOL ; then
+		destroy_pool $TESTPOOL
+	fi
+}
+
+log_onexit cleanup
+
+# The pool starts as a single vdev, so the file below can only be
+# allocated from ${disks[0]} and is guaranteed to be reached through the
+# indirect vdev once that disk is removed.
+log_must zpool create -f -O compression=off $TESTPOOL ${disks[0]}
+log_must zfs create $TESTPOOL/$TESTFS
+typeset mountpoint=$(get_prop mountpoint $TESTPOOL/$TESTFS)
+log_must dd if=/dev/urandom of=$mountpoint/file1 bs=128k count=8
+sync_pool $TESTPOOL
+
+log_must zpool add $TESTPOOL ${disks[1]}
+log_must zpool remove $TESTPOOL ${disks[0]}
+log_must wait_for_removal $TESTPOOL
+log_mustnot vdevs_in_pool $TESTPOOL ${disks[0]}
+
+# -L skips the synthesized metaslabs, and any class filter enters the
+# classification path for every traversed block.
+log_must zdb -bL --class=normal $TESTPOOL
+log_must zdb -bL --class=normal,special,dedup,other $TESTPOOL
+
+log_pass "zdb -L --class does not fault on an indirect vdev"

--- a/tests/zfs-tests/tests/functional/removal/removal_indirect_class.ksh
+++ b/tests/zfs-tests/tests/functional/removal/removal_indirect_class.ksh
@@ -1,0 +1,73 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
+#
+# shellcheck disable=SC2086,SC2154
+# ZTS supplies the framework variables; DISKS intentionally expands to vdev args.
+#
+
+# DESCRIPTION:
+#	zdb's --class block filter resolves a block's allocation class
+#	through the top vdev's metaslab array. An indirect vdev has no
+#	metaslabs of its own; zdb synthesizes them only when leak tracking
+#	is enabled, so under -L the array is absent and any block whose
+#	first DVA names a removed vdev used to dereference it.
+#
+# STRATEGY:
+#	1. Create a pool on a single disk and write a file to it, so every
+#	   data block is allocated from that disk.
+#	2. Add a second disk and remove the first, leaving an indirect vdev
+#	   that every one of those blocks is now reached through.
+#	3. Run zdb -bL with a class filter. It must not crash.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/removal/removal.kshlib
+
+verify_runnable "global"
+
+log_assert "zdb -L --class does not fault on an indirect vdev"
+
+set -A disks $DISKS
+if (( ${#disks[@]} < 2 )); then
+	log_unsupported "needs at least two disks"
+fi
+
+function cleanup
+{
+	if poolexists $TESTPOOL ; then
+		destroy_pool $TESTPOOL
+	fi
+}
+
+log_onexit cleanup
+
+# The pool starts as a single vdev, so the file below can only be
+# allocated from ${disks[0]} and is guaranteed to be reached through the
+# indirect vdev once that disk is removed.
+log_must zpool create -f -O compression=off $TESTPOOL ${disks[0]}
+log_must zfs create $TESTPOOL/$TESTFS
+typeset mountpoint
+mountpoint=$(get_prop mountpoint $TESTPOOL/$TESTFS)
+log_must dd if=/dev/urandom of=$mountpoint/file1 bs=128k count=8
+sync_pool $TESTPOOL
+
+log_must zpool add $TESTPOOL ${disks[1]}
+log_must zpool remove $TESTPOOL ${disks[0]}
+log_must wait_for_removal $TESTPOOL
+log_mustnot vdevs_in_pool $TESTPOOL ${disks[0]}
+
+# -L skips the synthesized metaslabs, and any class filter enters the
+# classification path for every traversed block.
+log_must zdb -bL --class=normal $TESTPOOL
+log_must zdb -bL --class=normal,special,dedup,other $TESTPOOL
+
+log_pass "zdb -L --class does not fault on an indirect vdev"


### PR DESCRIPTION
### Motivation and Context

With fast dedup, the final decref of a block is recorded in the DDT log. The physical free happens only when that log entry is flushed into the DDT. During that interval no block pointer references the block, but its space is still allocated.

`zdb` leak detection does not enumerate DDT logs. It can therefore report pending frees as leaked space and as a block-traversal mismatch. When a pending free is behind a removed vdev's indirect mapping, the same accounting gap can produce a fatal `obsolete indirect mapping count mismatch`.

Separately, `zdb -bL --class=...` can dereference an absent metaslab array when the first DVA is on an indirect vdev. This is an independent `zdb` crash fix included in the same series because the related removal tests exercise the same indirect-vdev accounting paths.

### Description

- Classify indirect vdevs for `--class` from their allocation bias instead of indexing a metaslab array that is not present under `-L`.
- Reconstruct and claim the DDT physical records that the next log flush will free.

The pending-free selection mirrors `ddt_sync_flush_entry()`:

- Unborn records are skipped.
- Obsolete ditto slots are freed regardless of refcount.
- Other slots are freed only when their refcount reaches zero.

The DDT log is already normalized during import: `ddt_log_load()` resolves active/flushing duplicates, and `ddt_lookup()` searches the logs before stored DDT objects. The leak walk can therefore account the in-memory log trees without replaying them against the DDT ZAP.

Clearing the dedup bit before claiming each reconstructed BP matches `ddt_phys_free()` and leaves existing DDT refcount checking intact. Claiming the pending extents also removes them from the indirect vdev accounting used by the obsolete-mapping check.

### How Has This Been Tested?

The `dedup_log_zdb_leak` test covers:

- Pending frees on a concrete vdev.
- Prune tombstones and live positive-refcount entries that must not be claimed.
- Resurrecting an entry before the log flushes.
- Pending frees behind a removed vdev's indirect mapping.

The `removal_indirect_class` test removes the only data vdev, verifies that the normal-class histogram does not lose the original blocks, and exercises both the `-L` normal-class path and all-class traversal.

Local validation:

```text
perl scripts/cstyle.pl -p cmd/zdb/zdb.c
nix-shell -p ksh --run 'ksh -n tests/zfs-tests/tests/functional/removal/removal_indirect_class.ksh'
make 'shellcheck-here-tests^zfs-tests^tests^functional^removal^removal_indirect_class.ksh'
nix-shell -p openssl pkg-config --run 'make CPPFLAGS="$(pkg-config --cflags openssl)" cmd/zdb/zdb.o'
./scripts/commitcheck.sh HEAD
git diff --check
```

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
