### PR TITLE
BRT: Implement partial bv_entcount writing

### DIFF
--- a/module/zfs/brt.c
+++ b/module/zfs/brt.c
@@ -759,8 +759,7 @@ brt_vdev_addref(spa_t *spa, brt_vdev_t *brtvd, const brt_entry_t *bre,
 	brtvd->bv_totalcount++;
 	brt_vdev_entcount_inc(brtvd, idx);
 	brtvd->bv_entcount_dirty = TRUE;
-	idx = idx / BRT_BLOCKSIZE / 8;
-	BT_SET(brtvd->bv_bitmap, idx);
+	BT_SET(brtvd->bv_bitmap, idx / (BRT_BLOCKSIZE / sizeof (uint16_t)));
 }
 
 static void
@@ -787,8 +786,7 @@ brt_vdev_decref(spa_t *spa, brt_vdev_t *brtvd, const brt_entry_t *bre,
 	brtvd->bv_totalcount--;
 	brt_vdev_entcount_dec(brtvd, idx);
 	brtvd->bv_entcount_dirty = TRUE;
-	idx = idx / BRT_BLOCKSIZE / 8;
-	BT_SET(brtvd->bv_bitmap, idx);
+	BT_SET(brtvd->bv_bitmap, idx / (BRT_BLOCKSIZE / sizeof (uint16_t)));
 }
 
 static void
@@ -805,13 +803,21 @@ brt_vdev_sync(spa_t *spa, brt_vdev_t *brtvd, dmu_tx_t *tx)
 	    FTAG, &db));
 
 	if (brtvd->bv_entcount_dirty) {
-		/*
-		 * TODO: Walk brtvd->bv_bitmap and write only the dirty blocks.
-		 */
 		uint64_t nblocks = BRT_RANGESIZE_TO_NBLOCKS(brtvd->bv_size);
-		dmu_write(spa->spa_meta_objset, brtvd->bv_mos_brtvdev, 0,
-		    nblocks * BRT_BLOCKSIZE, brtvd->bv_entcount, tx,
-		    DMU_READ_NO_PREFETCH | DMU_UNCACHEDIO);
+		for (uint64_t i = 0; i < nblocks; i++) {
+			if (!BT_TEST(brtvd->bv_bitmap, i))
+				continue;
+			uint64_t end = i + 1;
+			uint64_t maxend = MIN(i + DMU_MAX_ACCESS / 2 /
+			    BRT_BLOCKSIZE, nblocks);
+			while (end < maxend && BT_TEST(brtvd->bv_bitmap, end))
+				end++;
+			dmu_write(spa->spa_meta_objset, brtvd->bv_mos_brtvdev,
+			    i * BRT_BLOCKSIZE, (end - i) * BRT_BLOCKSIZE,
+			    (char *)brtvd->bv_entcount + i * BRT_BLOCKSIZE,
+			    tx, DMU_READ_NO_PREFETCH | DMU_UNCACHEDIO);
+			i = end - 1;
+		}
 		memset(brtvd->bv_bitmap, 0, BT_SIZEOFMAP(nblocks));
 		brtvd->bv_entcount_dirty = FALSE;
 	}


### PR DESCRIPTION
From the introduction of BRT the `bv_entcount` was always written all at once, even though there was a mechanism for partial writing. Implement one finally to slightly reduce per-TXG dirty data and write inflation on large pools.  On 1PB pool it meant 128MB write for each TXG modifying BRT.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
