### PR TITLE
dnode_sync: Relax constraint on indirect freeing

### DIFF
--- a/lib/libspl/include/assert.h
+++ b/lib/libspl/include/assert.h
@@ -219,6 +219,13 @@ do {									\
 		    (void *)__left, __VA_ARGS__);			\
 } while (0)
 
+#define	VERIFY_IMPLY(A, B)						\
+	((void)(((!(A)) || (B)) ||					\
+	    libspl_assert("(" #A ") implies (" #B ")",			\
+	    __FILE__, __FUNCTION__, __LINE__)))
+
+#define	VERIFY_EQUIV(A, B)	VERIFY3B(A, ==, B)
+
 #ifdef assert
 #undef assert
 #endif
@@ -264,11 +271,8 @@ do {									\
 #define	ASSERT		VERIFY
 #define	ASSERTF		VERIFYF
 #define	assert		VERIFY
-#define	IMPLY(A, B) \
-	((void)(((!(A)) || (B)) || \
-	    libspl_assert("(" #A ") implies (" #B ")", \
-	    __FILE__, __FUNCTION__, __LINE__)))
-#define	EQUIV(A, B)	VERIFY3B(A, ==, B)
+#define	IMPLY		VERIFY_IMPLY
+#define	EQUIV		VERIFY_EQUIV
 
 #endif  /* NDEBUG */
 

--- a/module/zfs/dnode_sync.c
+++ b/module/zfs/dnode_sync.c
@@ -305,9 +305,12 @@ free_children(dmu_buf_impl_t *db, uint64_t blkid, uint64_t nblks,
 	 * ancestor of the first or last block to be freed.  The first and
 	 * last L1 indirect blocks are always dirtied by dnode_free_range().
 	 */
-	db_lock_type_t dblt = dmu_buf_lock_parent(db, RW_READER, FTAG);
-	VERIFY(BP_GET_FILL(db->db_blkptr) == 0 || db->db_dirtycnt > 0);
-	dmu_buf_unlock_parent(db, dblt, FTAG);
+	if (!free_indirects) {
+		db_lock_type_t dblt = dmu_buf_lock_parent(db, RW_READER, FTAG);
+		VERIFY_IMPLY(BP_GET_FILL(db->db_blkptr) > 0,
+		    db->db_dirtycnt > 0);
+		dmu_buf_unlock_parent(db, dblt, FTAG);
+	}
 
 	dbuf_release_bp(db);
 	bp = db->db.db_data;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
One of the roles of the dnode sync thread is freeing.  There are two modes of this operation: freeing a portion of an object, and freeing the object itself.

Freeing is handled by `free_children()`.  This function verifies that if the dnode has children there must be at least one marked as dirty before proceeding to recursively free the tree of block pointers.

As described in a comment, this VERIFY is overly strict.  In practice, children may not be marked as dirty when the dnode itself is being freed.

Issue #17548  contains multiple reports of this VERIFY failing in ZFS versions going pretty far back in history.

### Description
<!--- Describe your changes in detail -->
Relax the VERIFY slightly by avoiding the VERIFY when indirect blocks are to be immediately freed, to more closely match the comment motivating the VERIFY.

While here, clarify the logic of the test by using VERIFY_IMPLY instead of chaining multiple tests.

Sponsored-by: Cybersecure Pty Ltd

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
The patched ZFS was able to receive a send stream that reliably panics on the VERIFY before the patch.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
