### PR TITLE
tests: add mmap_read_truncate regression test

### DIFF
--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -833,7 +833,8 @@ tags = ['functional', 'migration']
 
 [tests/functional/mmap]
 tests = ['mmap_mixed', 'mmap_read_001_pos', 'mmap_seek_001_pos',
-    'mmap_sync_001_pos', 'mmap_write_001_pos', 'mmap_ftruncate']
+    'mmap_sync_001_pos', 'mmap_write_001_pos', 'mmap_ftruncate',
+    'mmap_read_truncate']
 tags = ['functional', 'mmap']
 
 [tests/functional/mount]

--- a/tests/zfs-tests/cmd/.gitignore
+++ b/tests/zfs-tests/cmd/.gitignore
@@ -27,6 +27,7 @@
 /mmap_exec
 /mmap_ftruncate
 /mmap_libaio
+/mmap_read_truncate
 /mmap_seek
 /mmap_sync
 /mmapwrite

--- a/tests/zfs-tests/cmd/Makefile.am
+++ b/tests/zfs-tests/cmd/Makefile.am
@@ -77,7 +77,8 @@ scripts_zfs_tests_bin_PROGRAMS += %D%/mkbusy %D%/mkfile %D%/mkfiles %D%/mktree
 
 scripts_zfs_tests_bin_PROGRAMS += \
 	%D%/mmap_exec %D%/mmap_ftruncate %D%/mmap_seek \
-	%D%/mmap_sync %D%/mmapwrite %D%/readmmap %D%/mmap_write_sync
+	%D%/mmap_sync %D%/mmapwrite %D%/readmmap %D%/mmap_write_sync \
+	%D%/mmap_read_truncate
 
 if WANT_MMAP_LIBAIO
 scripts_zfs_tests_bin_PROGRAMS += %D%/mmap_libaio

--- a/tests/zfs-tests/cmd/mmap_read_truncate.c
+++ b/tests/zfs-tests/cmd/mmap_read_truncate.c
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: CDDL-1.0
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://opensource.org/licenses/CDDL-1.0.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2026, Michael Heller.
+ */
+
+/*
+ * Regression exerciser for a mmap read racing ftruncate (openzfs #18715).
+ *
+ * When a page is faulted in for read after the file has been truncated below
+ * that page, zfs_fillpage() sees io_off >= i_size. On an unfixed build the
+ * unsigned io_len = i_size - io_off underflows and dmu_read() zero-fills far
+ * past the single page, trampling memory (a physical-page sweep). The fix
+ * simply zero-fills the page and returns.
+ *
+ * Several reader processes repeatedly mmap() the file and fault every page,
+ * while a truncator process churns the file size between 0 and <size>. A read
+ * that lands entirely beyond EOF legitimately raises SIGBUS; the reader
+ * tolerates that and keeps going. The test just has to survive the race for
+ * the configured duration -- on an unfixed module the underflow corrupts
+ * memory and takes the run (or the kernel) down.
+ *
+ * usage: mmap_read_truncate <file> <size> <seconds> [nreaders]
+ */
+
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+#define	_pdfail(f, l, s)	\
+	do { perror("[" f "#" #l "] " s); exit(2); } while (0)
+#define	pdfail(str)	_pdfail(__FILE__, __LINE__, str)
+
+static sigjmp_buf jb;
+static volatile sig_atomic_t in_probe;
+
+static void
+on_bus(int sig)
+{
+	(void) sig;
+	if (in_probe)
+		siglongjmp(jb, 1);
+	_exit(4);
+}
+
+static void
+reader_loop(const char *file, off_t sz, time_t end)
+{
+	long pg = sysconf(_SC_PAGESIZE);
+	int fd = open(file, O_RDONLY);
+	if (fd < 0)
+		pdfail("reader open");
+
+	struct sigaction sa;
+	memset(&sa, 0, sizeof (sa));
+	sa.sa_handler = on_bus;
+	sigaction(SIGBUS, &sa, NULL);
+
+	volatile unsigned long acc = 0;
+	while (time(NULL) < end) {
+		char *p = mmap(NULL, sz, PROT_READ, MAP_SHARED, fd, 0);
+		if (p == MAP_FAILED)
+			continue;
+		/* volatile: must survive the SIGBUS siglongjmp */
+		for (volatile off_t off = 0; off < sz; off += pg) {
+			in_probe = 1;
+			if (sigsetjmp(jb, 1) == 0)
+				acc += (unsigned char)p[off];
+			in_probe = 0;
+		}
+		(void) munmap(p, sz);
+	}
+	close(fd);
+	(void) acc;
+	_exit(0);
+}
+
+int
+main(int argc, char **argv)
+{
+	if (argc < 4 || argc > 5) {
+		fprintf(stderr, "usage: mmap_read_truncate "
+		    "<file> <size> <secs> [nreaders]\n");
+		exit(2);
+	}
+	const char *file = argv[1];
+	off_t sz = (off_t)strtoull(argv[2], NULL, 0);
+	long secs = strtol(argv[3], NULL, 0);
+	int nreaders = (argc == 5) ? atoi(argv[4]) : 4;
+	if (sz <= 0 || secs <= 0 || nreaders <= 0) {
+		fprintf(stderr, "E: invalid args\n");
+		exit(2);
+	}
+
+	int fd = open(file, O_CREAT|O_RDWR, S_IRUSR|S_IWUSR);
+	if (fd < 0)
+		pdfail("open");
+	if (ftruncate(fd, sz) < 0)
+		pdfail("ftruncate init");
+	close(fd);
+
+	time_t end = time(NULL) + secs;
+
+	pid_t kids[64];
+	int nk = 0;
+
+	for (int i = 0; i < nreaders; i++) {
+		pid_t c = fork();
+		if (c < 0)
+			pdfail("fork reader");
+		if (c == 0)
+			reader_loop(file, sz, end);
+		kids[nk++] = c;
+	}
+
+	pid_t t = fork();
+	if (t < 0)
+		pdfail("fork truncator");
+	if (t == 0) {
+		int tfd = open(file, O_RDWR);
+		if (tfd < 0)
+			pdfail("truncator open");
+		while (time(NULL) < end) {
+			if (ftruncate(tfd, 0) < 0)
+				_exit(3);
+			if (ftruncate(tfd, sz) < 0)
+				_exit(3);
+		}
+		_exit(0);
+	}
+	kids[nk++] = t;
+
+	int rc = 0;
+	for (int i = 0; i < nk; i++) {
+		int status;
+		if (waitpid(kids[i], &status, 0) < 0)
+			pdfail("waitpid");
+		if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+			fprintf(stderr, "child %d abnormal (status=0x%x)\n",
+			    kids[i], status);
+			rc = 1;
+		}
+	}
+	return (rc);
+}

--- a/tests/zfs-tests/include/commands.cfg
+++ b/tests/zfs-tests/include/commands.cfg
@@ -213,6 +213,7 @@ export ZFSTEST_FILES_COMMON='badsend
     mmap_exec
     mmap_ftruncate
     mmap_libaio
+    mmap_read_truncate
     mmap_seek
     mmap_sync
     mmapwrite

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1805,6 +1805,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/mmap/mmap_sync_001_pos.ksh \
 	functional/mmap/mmap_write_001_pos.ksh \
 	functional/mmap/mmap_ftruncate.ksh \
+	functional/mmap/mmap_read_truncate.ksh \
 	functional/mmap/setup.ksh \
 	functional/mmp/cleanup.ksh \
 	functional/mmp/mmp_active_import.ksh \

--- a/tests/zfs-tests/tests/functional/mmap/mmap_read_truncate.ksh
+++ b/tests/zfs-tests/tests/functional/mmap/mmap_read_truncate.ksh
@@ -1,0 +1,57 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2026, Michael Heller.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+#	A mmap read that faults a page in after the file has been truncated
+#	below it must not corrupt memory or panic.
+#
+# STRATEGY:
+#	Several reader processes repeatedly mmap() a file and fault every page
+#	while a truncator process churns the file size between 0 and 64M. A
+#	read that lands beyond EOF legitimately raises SIGBUS and is tolerated;
+#	a read that races the truncate reaches zfs_fillpage() with
+#	io_off >= i_size. A correct module zero-fills that page and the run
+#	completes; before the fix the unsigned io_len underflowed and dmu_read()
+#	zero-filled far past the page (a debug build asserts, a production build
+#	silently corrupts memory).
+#
+
+verify_runnable "global"
+
+typeset TESTFILE=$TESTDIR/mmap_read_truncate.$$
+typeset -i FILESIZE=$((64 * 1024 * 1024))
+typeset -i DURATION=15
+typeset -i READERS=8
+
+function cleanup
+{
+	rm -f $TESTFILE
+}
+
+log_assert "mmap read racing ftruncate (past EOF) does not corrupt or panic"
+log_onexit cleanup
+
+log_must mmap_read_truncate $TESTFILE $FILESIZE $DURATION $READERS
+
+log_pass "mmap read racing ftruncate completed cleanly"


### PR DESCRIPTION
### Motivation and Context

223b8bc446 (#18715, "linux: handle mmap read beyond file size") fixed a real
memory-corruption bug: a page faulted in for read after the file has been
truncated below it reaches `zfs_fillpage()` with `io_off >= i_size`, the
unsigned `io_len = i_size - io_off` underflows, and `dmu_read()` then zero-fills
far past the single page. Because the damage lands on whatever physical pages
follow, the crash usually surfaces somewhere unrelated with no zfs frames in the
trace, which makes it very hard to attribute. #18787 is a report of exactly that
in production on a container host, where unrelated slab and userspace pages were
being zeroed.

That fix went in without a test, so nothing in the suite currently exercises the
read-past-EOF path it added. This adds one.

### Description

A new `mmap_read_truncate` helper plus a test in the existing `mmap` group.

Several reader processes repeatedly `mmap()` the file and fault every page while
a truncator process churns the file size between 0 and 64M. A read that lands
entirely beyond EOF legitimately raises `SIGBUS`, so the readers install a
handler and `siglongjmp` past it rather than treating it as a failure. Reads
that race the truncate are the interesting ones: they reach `zfs_fillpage()`
with the page at or beyond `i_size`, which is the case the fix handles by
zero-filling the page.

The test only has to survive the race for its duration. It runs for 15 seconds
with 8 readers, which keeps it in line with the runtime of the other tests in
the `mmap` group.

### How Has This Been Tested?

Built and run in a QEMU rig (Ubuntu, kernel 7.0, `--enable-debug`), against
master at 9b7642df9.

On master the test passes as part of the `mmap` group:

```
functional/mmap/mmap_read_truncate (run as root) [00:14] [PASS]
```

with the whole group green and nothing unexpected in `zts-report`.

To confirm the test actually covers the fix rather than merely passing, I
reverted 223b8bc446 on the same tree and rebuilt. The test then trips the
assertion the fix removed on 8 of 8 runs, each time within the first two seconds
(the resolution I was sampling at), so it reproduces promptly rather than
depending on a lucky race:

```
VERIFY3U(io_off, <, i_size) failed (12288 < 0)
PANIC at zfs_vnops_os.c:4214:zfs_fillpage()
PANIC at zfs_vnops_os.c:4265:zfs_getpage()
  spl_panic+0xf1/0x116 [spl]
  zfs_fillpage+0x228/0x250 [zfs]
```

A page at offset 12288 is faulted in while `i_size` has gone to 0, which is the
condition the fix added handling for. On a production build the same path is the
`io_len` underflow rather than an assertion.

`make checkstyle` passes in full (`cstyle` verified directly against the new
C file; ZTS `.ksh` scripts are outside the project's shellcheck scope).

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:

- [x] My code follows the OpenZFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have run the ZFS Test Suite with my changes.
- [x] All commit messages are properly formatted and contain Signed-off-by.

