### PR TITLE
L2ARC: bound the rebuild by the write hand on a first sweep

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -11580,9 +11580,15 @@ l2arc_log_blkptr_valid(l2arc_dev_t *dev, const l2arc_log_blkptr_t *lbp)
 	    l2arc_range_check_overlap(dev->l2ad_hand, dev->l2ad_evict, start) ||
 	    l2arc_range_check_overlap(dev->l2ad_hand, dev->l2ad_evict, end);
 
-	return (start >= dev->l2ad_start && end <= dev->l2ad_end &&
-	    asize > 0 && asize <= sizeof (l2arc_log_blk_phys_t) &&
-	    (!evicted || dev->l2ad_first));
+	if (asize == 0 || asize > sizeof (l2arc_log_blk_phys_t) ||
+	    start < dev->l2ad_start || end > dev->l2ad_end)
+		return (B_FALSE);
+
+	/* On a first sweep only the region below the write hand was written. */
+	if (dev->l2ad_first)
+		return (end < dev->l2ad_hand);
+
+	return (!evicted);
 }
 
 /*


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
l2arc_log_blkptr_valid() ends with `(!evicted || dev->l2ad_first)`, which disables the eviction-overlap test entirely while the device is on its first sweep. The test is meaningless in that state, because l2arc_evict() returns immediately and l2ad_evict never advances off l2ad_start, so the [l2ad_hand, l2ad_evict] range it consults is degenerate. But dropping it leaves the log block bounded only by device geometry, and on a first sweep only the region below the write hand has been written. A log block at or beyond l2ad_hand therefore describes data this incarnation never wrote, and l2arc_hdr_restore() performs no per-entry validation: it allocates an l2only header and adds the entry's aligned size to arcstat_l2_psize and, via vdev_space_update(), to the cache vdev's vs_alloc. Since l2arc_evict() never runs on a first sweep nothing reconciles the inflation, and once vs_alloc exceeds vs_space the unclamped subtraction in print_iostat_default() wraps and the cache device reports 16.0E free.

This is not only an accounting defect. Restored-but-stale entries let the L2ARC issue reads against offsets never written in this sweep, which fail checksum verification and fall back to the pool.

Removing and re-adding a cache vdev is what sets this up: l2arc_add_vdev() resets l2ad_hand to l2ad_start and l2ad_first to B_TRUE and starts writing from the bottom of the device again, but nothing erases the previous incarnation's log blocks higher up and L2ARC is not trimmed by default. The backward walk can then cross l2ad_start, wrap to the top of the device, and consume the old chain.

<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #12779

Earlier reports of the same symptom, all still describing this behavior:

- https://github.com/openzfs/zfs/issues/10224 — the only prior maintainer analysis, which measured ~4.9 GB of unaccounted L2ARC space on a 284 GB device and suspected a leak in l2arc_evict(). Closed incidentally by https://github.com/openzfs/zfs/pull/9789 rather than by a fix.
- https://github.com/openzfs/zfs/issues/5583
- https://github.com/openzfs/zfs/issues/3400 — 59.6G device reporting 667G alloc, 16.0E free, 1118% capacity
- https://github.com/openzfs/zfs/issues/3114
- https://github.com/openzfs/zfs/discussions/12519
- https://www.truenas.com/community/threads/zpool-iostat-showing-odd-numbers-for-cache-device.37102/

Also reported on FreeBSD as PR 250323:
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=250323

Related but distinct, listed because they are frequently cited as duplicates and are **not** this defect:

- https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=271772 — VERIFY3(dev->l2ad_hand <= dev->l2ad_evict) panic, fixed June 2023 via https://github.com/openzfs/zfs/issues/14936. Filed by the same reporter as #12779, and what first pointed me at the rebuild path, but ruled out here: that assertion is compiled in on the affected host and has not fired.
- https://github.com/openzfs/zfs/pull/8298 — fixes vs_alloc underflowing *below zero*, the opposite direction to this.
- https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=195746 (2014, fixed 2015) and https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=216178 (fixed 2017)
- https://www.illumos.org/issues/5701, ported in https://github.com/illumos/illumos-gate/commit/a52fc31

### Description
<!--- Describe your changes in detail -->
Bound the first-sweep case by the write hand rather than skipping the eviction check, so a log block whose payload lies at or beyond l2ad_hand is rejected. The geometry and size conditions are stated once instead of being duplicated across both branches.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Root-caused and verified on a 415G cache vdev under FreeBSD 16.0-CURRENT with ZFS_DEBUG enabled, on a device that had never wrapped and that had been removed and re-added three times over the preceding weeks.

Reading the on-disk l2arc_dev_hdr_phys_t confirmed dh_flags = 1 (L2ARC_DEV_HDR_EVICT_FIRST) and dh_evict == dh_start. The rebuild consumed 5024 log blocks of 1022 entries each, exactly the 5134528 buffers it reported, describing 445573849088 bytes of payload against a ring (l2ad_end - l2ad_start) of 445598134272 bytes, 0.005% apart. The walk therefore made one complete loop of the device before aborting on a stale block whose checksum did not verify. Sampling the device above the write hand confirmed those regions hold real leftover data rather than zeroes.

DTrace ruled out the steady-state feed path: over a 150s window the write hand advanced 155648 bytes and vdev_space_update() added exactly 155648 bytes to the cache vdev, so every byte the feed thread accounts for corresponds to a byte written.

Before and after booting the fix, same host and device, same first-sweep state:

| | before | after |
|---|---|---|
| zpool iostat free | 16.0E | 199G |
| vs_alloc | 482492137472 | 232079503360 |
| l2_rebuild_asize | 445573849088 | 240753942528 |
| l2_rebuild_success | 0 (aborted) | 1 |
| l2_rebuild_cksum_lb_errors | 1 | 0 |
| l2_cksum_bad | 19 | 0 |

vs_alloc is now below the bytes the write hand has advanced, as it must be on a first sweep, and the rebuild completes rather than aborting because it no longer reaches the stale block.

Checked for regressions on a healthy pool in a VM: six export/import cycles on a deliberately non-wrapping cache device, where vs_alloc equalled bytes written exactly both before and after the change.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).