### PR TITLE
zstream: add unit tests

### DIFF
--- a/cmd/zstream/Makefile.am
+++ b/cmd/zstream/Makefile.am
@@ -7,6 +7,8 @@ CPPCHECKTARGETS += zstream
 zstream_SOURCES = \
 	%D%/zstream.c \
 	%D%/zstream.h \
+	%D%/zstream_backtrace.c \
+	%D%/zstream_backtrace.h \
 	%D%/zstream_byteswap.c \
 	%D%/zstream_byteswap.h \
 	%D%/zstream_chain.c \
@@ -24,6 +26,9 @@ zstream_SOURCES = \
 	%D%/zstream_recompress.c \
 	%D%/zstream_recompress.h \
 	%D%/zstream_redup.c \
+	%D%/zstream_selftest.c \
+	%D%/zstream_selftest.h \
+	%D%/zstream_selftest_queue.c \
 	%D%/zstream_token.c \
 	%D%/zstream_queue.c \
 	%D%/zstream_queue.h \

--- a/cmd/zstream/zstream.c
+++ b/cmd/zstream/zstream.c
@@ -15,11 +15,13 @@
  * Copyright (c) 2020 by Datto Inc. All rights reserved.
  */
 
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "zstream.h"
+#include "zstream_util.h"
 
 void
 zstream_usage(void)
@@ -46,9 +48,27 @@ zstream_usage(void)
 	exit(1);
 }
 
+/*
+ * Set the signal mask to allow THREAD_BACKTRACE_SIGNAL. WATCHDOG_SIGNAL
+ * must be blocked in all threads so that its intended recipient can listen
+ * for it with sigwait(), which detects only pending signals.
+ */
+static void
+set_signal_mask(void)
+{
+	sigset_t mask;
+
+	safe_pthread_sigmask(SIG_SETMASK, NULL, &mask);
+	sigaddset(&mask, WATCHDOG_SIGNAL);
+	sigdelset(&mask, THREAD_BACKTRACE_SIGNAL);
+	safe_pthread_sigmask(SIG_SETMASK, &mask, NULL);
+}
+
 int
 main(int argc, char *argv[])
 {
+	set_signal_mask();
+
 	char *basename = strrchr(argv[0], '/');
 	basename = basename ? (basename + 1) : argv[0];
 	if (argc >= 1 && strcmp(basename, "zstreamdump") == 0)
@@ -73,6 +93,9 @@ main(int argc, char *argv[])
 		return (zstream_do_token(argc - 1, argv + 1));
 	} else if (strcmp(subcommand, "redup") == 0) {
 		return (zstream_do_redup(argc - 1, argv + 1));
+	} else if (strcmp(subcommand, "selftest") == 0) {
+		/* Undocumented; used by the ZFS test suite */
+		return (zstream_do_selftest(argc - 1, argv + 1));
 	} else {
 		zstream_usage();
 	}

--- a/cmd/zstream/zstream.h
+++ b/cmd/zstream/zstream.h
@@ -17,9 +17,18 @@
 #ifndef	_ZSTREAM_H
 #define	_ZSTREAM_H
 
+#include <signal.h>
+
 #ifdef	__cplusplus
 extern "C" {
 #endif
+
+/*
+ * Signals used by the watchdog timer and zstream_queue. The signal mask
+ * must be set properly before any threads are spawned.
+ */
+#define	WATCHDOG_SIGNAL		SIGALRM
+#define	THREAD_BACKTRACE_SIGNAL	SIGRTMIN
 
 extern int zstream_do_redup(int, char *[]);
 extern int zstream_do_dump(int, char *[]);
@@ -28,6 +37,7 @@ extern int zstream_do_drop_record(int argc, char *argv[]);
 extern int zstream_do_recompress(int argc, char *argv[]);
 extern int zstream_do_token(int, char *[]);
 extern int zstream_do_raw(int, char *[]);
+extern int zstream_do_selftest(int, char *[]);
 extern void zstream_usage(void) __attribute__((noreturn));
 
 #ifdef	__cplusplus

--- a/cmd/zstream/zstream_backtrace.c
+++ b/cmd/zstream/zstream_backtrace.c
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: CDDL-1.0
+/*
+ * CDDL HEADER START
+ *
+ * This file and its contents are supplied under the terms of the Common
+ * Development and Distribution License ("CDDL"), version 1.0. You may only use
+ * this file in accordance with the terms of version 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this source. A
+ * copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2026 by Garth Snyder. All rights reserved.
+ */
+
+/*
+ * This is a watchdog timer and multithread backtrace dumper that's used by
+ * zstream selftest. libspl_backtrace() does all the real work, but it can
+ * only dump the current thread's stack. We need to get every thread to call
+ * libspl_backtrace() in an organized sequence. However, there's no "give me
+ * a list of all pthreads" function in the POSIX API.
+ *
+ * Rather than constructing an ad-hoc thread registry, we can approach the
+ * problem by unblocking THREAD_BACKTRACE_SIGNAL (an arbitrary choice) when
+ * zstream first starts. All created threads then inherit this signal mask.
+ *
+ * In selftest mode, we add the backtrace dumper as a handler for
+ * THREAD_BACKTRACE_SIGNAL. The handler calls libspl_backtrace(), which is
+ * signal-handler safe. It then signals a semaphore to indicate that the
+ * current thread has finished its dump and suspends itself.
+ *
+ * The watchdog supervisor is a separate thread that sigwait()s for SIGALRM.
+ * It blocks THREAD_BACKTRACE_SIGNAL and runs its own libspl_backtrace(). It
+ * then enters a loop in which it sends THREAD_BACKTRACE_SIGNAL to the
+ * process as a whole and runs sem_timedwait() to see if any thread woke up
+ * and dumped its backtrace. If that call times out, either the receiving
+ * thread wedged while trying to backtrace or there were no more threads to
+ * backtrace.
+ *
+ * These two scenarios can be distinguished by calling sigpending(). If
+ * THREAD_BACKTRACE_SIGNAL still shows as being pending on the process, then
+ * there was no thread to receive it and we are done. If there's no pending
+ * signal, then some thread did receive the signal but failed to post to the
+ * semaphore; we print a "thread wedged while backtracing" message and
+ * continue the loop.
+ */
+
+#include <err.h>
+#include <errno.h>
+#include <semaphore.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/backtrace.h>
+#include <sys/debug.h>
+#include <sys/stdtypes.h>
+#include <sys/types.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "zstream.h"
+#include "zstream_backtrace.h"
+#include "zstream_util.h"
+
+/*
+ * Watchdog timeout in seconds. A test that hits this limit is almost
+ * certainly deadlocked, and the watchdog converts the hang into a test
+ * failure instead of a stuck test run.
+ */
+#define	WATCHDOG_TIMEOUT_SECS	120
+#define	MAX_SECS_FOR_BACKTRACE	2
+
+static sem_t sem_thread_bt_complete;	/* thread -> watchdog */
+
+/*
+ * Signal handler for THREAD_BACKTRACE_SIGNAL, run by all threads except the
+ * watchdog thread
+ */
+static void
+backtrace_self(int signal)
+{
+	(void) signal;
+	ssize_t dummy __maybe_unused = write(STDERR_FILENO, "\n", 1);
+	libspl_backtrace(STDERR_FILENO);
+	sem_post(&sem_thread_bt_complete);
+
+	sigset_t mask;
+	sigfillset(&mask);
+	sigsuspend(&mask);
+}
+
+static void
+backtrace_all_threads(void)
+{
+	while (B_TRUE) {
+		if (kill(getpid(), THREAD_BACKTRACE_SIGNAL) != 0)
+			err(1, "failed to send thread backtrace signal");
+		struct timespec deadline;
+		clock_gettime(CLOCK_REALTIME, &deadline);
+		deadline.tv_sec += MAX_SECS_FOR_BACKTRACE;
+		if (sem_timedwait(&sem_thread_bt_complete, &deadline) != 0) {
+			sigset_t pending;
+			if (sigpending(&pending) != 0)
+				err(1, "sigpending failed");
+			if (sigismember(&pending, THREAD_BACKTRACE_SIGNAL)) {
+				return;
+			} else {
+				warnx("a thread failed to generate a backtrace,"
+				    " continuing...");
+			}
+		}
+	}
+}
+
+/*
+ * Body of the watchdog thread
+ */
+static void *
+watchdog(void *nope)
+{
+	(void) nope;
+	int signal;
+	sigset_t bt_mask, dog_mask;
+
+	/*
+	 * This thread does its own backtrace, so we block the
+	 * backtrace signal.
+	 */
+	sigemptyset(&bt_mask);
+	sigaddset(&bt_mask, THREAD_BACKTRACE_SIGNAL);
+	if (pthread_sigmask(SIG_BLOCK, &bt_mask, NULL) != 0)
+		err(1, "pthread_sigmask failed");
+
+	sigemptyset(&dog_mask);
+	sigaddset(&dog_mask, WATCHDOG_SIGNAL);
+
+	int rc = sigwait(&dog_mask, &signal);
+	if (rc != 0) {
+		errno = rc;
+		err(1, "watchdog sigwait failed");
+	} else if (signal != WATCHDOG_SIGNAL) {
+		errx(1, "unexpected signal %d received by watchdog", signal);
+	}
+
+	fprintf(stderr, "\n\nWATCHDOG TIMER EXPIRED\n"
+	    "Dumping backtrace for all threads...\n\n");
+	fflush(stderr);
+	libspl_backtrace(STDERR_FILENO);
+	backtrace_all_threads();
+	fprintf(stderr, "\nAll threads backtraced, exiting.\n");
+	exit(1);
+}
+
+void
+watchdog_init(void)
+{
+	if (sem_init(&sem_thread_bt_complete, 0, 0) != 0)
+		err(1, "watchdog sem_init failed");
+
+	safe_create_thread(watchdog, NULL, "watchdog", B_TRUE);
+
+	struct sigaction sa = {
+		.sa_handler = backtrace_self,
+		.sa_flags = SA_RESTART
+	};
+	if (sigaction(THREAD_BACKTRACE_SIGNAL, &sa, NULL) != 0)
+		err(1, "backtrace sigaction failed");
+}
+
+void
+watchdog_arm(void)
+{
+	(void) alarm(WATCHDOG_TIMEOUT_SECS);
+}
+
+void
+watchdog_disarm(void)
+{
+	(void) alarm(0);
+}

--- a/cmd/zstream/zstream_backtrace.h
+++ b/cmd/zstream/zstream_backtrace.h
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: CDDL-1.0
+/*
+ * CDDL HEADER START
+ *
+ * This file and its contents are supplied under the terms of the Common
+ * Development and Distribution License ("CDDL"), version 1.0. You may only use
+ * this file in accordance with the terms of version 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this source. A
+ * copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2026 by Garth Snyder. All rights reserved.
+ */
+
+#ifndef _ZSTREAM_BACKTRACE_H
+#define	_ZSTREAM_BACKTRACE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void
+watchdog_init(void);
+
+void
+watchdog_arm(void);
+
+void
+watchdog_disarm(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* _ZSTREAM_BACKTRACE_H */

--- a/cmd/zstream/zstream_chain.c
+++ b/cmd/zstream/zstream_chain.c
@@ -14,14 +14,12 @@
  * Copyright (c) 2026 by Garth Snyder. All rights reserved.
  */
 
-#include <time.h>
 #include <assert.h>
 #include <err.h>
 #include <libspl.h>
 #include <pthread.h>
 #include <stddef.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <sys/abd.h>
 #include <sys/param.h>
 #include <sys/stdtypes.h>
@@ -32,6 +30,7 @@
 
 #include "zstream_chain.h"
 #include "zstream_queue.h"
+#include "zstream_util.h"
 
 #define	MAX_CHAIN_LENGTH 32
 
@@ -56,8 +55,6 @@ typedef struct {
 	zstream_queue_t	*wc_in_queue;
 	zstream_queue_t	*wc_out_queue;
 } worker_context_t;
-
-typedef void *chain_worker_f(void *);
 
 chain_attrs_t *chain_attrs;
 
@@ -94,8 +91,9 @@ libraries_fini(void)
  * Body function for worker threads
  */
 static void *
-zstream_chain_worker(worker_context_t *ctxt)
+zstream_chain_worker(void *ctxt_in)
 {
+	worker_context_t *ctxt = (worker_context_t *)ctxt_in;
 	uint8_t buffer[ctxt->wc_buffer_size];
 	boolean_t done = B_FALSE;
 
@@ -262,13 +260,10 @@ zstream_chain_exec(zstream_chain_t chain, chain_attrs_t *attrs)
 
 	/* Spawn threads */
 	for (int i = 0; i < num_workers; i++) {
-		char buff[32];
-		int ret = pthread_create(&worker_threads[i], NULL,
-		    (chain_worker_f *)zstream_chain_worker,
-		    &contexts[i]);
-		VERIFY3S(ret, ==, 0);
-		snprintf(buff, sizeof (buff), "chain-%d", i);
-		pthread_setname_np(worker_threads[i], buff);
+		char name[32];
+		snprintf(name, sizeof (name), "chain-%d", i);
+		worker_threads[i] = safe_create_thread(zstream_chain_worker,
+		    &contexts[i], name, B_FALSE);
 	}
 
 	/* Reap threads */

--- a/cmd/zstream/zstream_queue.c
+++ b/cmd/zstream/zstream_queue.c
@@ -26,6 +26,7 @@
 #include <sys/param.h>
 #include <sys/random.h>
 #include <sys/stdtypes.h>
+#include <sys/sysmacros.h>
 #include <unistd.h>
 
 #include "zstream_queue.h"
@@ -146,8 +147,8 @@ static void *
 queue_worker(void *);
 
 #ifdef MONITOR_QUEUES
-static void
-start_monitor_thread(void);
+static void *
+cpu_and_queue_monitor(void *);
 #endif
 
 static thread_pool_t	pool = {0};
@@ -209,15 +210,12 @@ thread_pool_spinup(void)
 		pool.tp_num_threads = MAX(pool.tp_num_threads, MIN_THREADS);
 	}
 	for (int i = 0; i < pool.tp_num_threads; i++) {
-		char buff[32];
-		pthread_t thread;
-		int ret = pthread_create(&thread, NULL, queue_worker, NULL);
-		VERIFY3S(ret, ==, 0);
-		snprintf(buff, sizeof (buff), "queue-%d", i);
-		pthread_setname_np(thread, buff);
+		char name[32];
+		snprintf(name, sizeof (name), "queue-%d", i);
+		safe_create_thread(queue_worker, NULL, name, B_TRUE);
 	}
 #ifdef MONITOR_QUEUES
-	start_monitor_thread();
+	safe_create_thread(cpu_and_queue_monitor, NULL, "monitor", B_TRUE);
 #endif
 }
 
@@ -749,20 +747,6 @@ cpu_and_queue_monitor(void *dummy)
 		start_us = end_us;
 	}
 	return (NULL);
-}
-
-static void
-start_monitor_thread(void)
-{
-	static boolean_t started = B_FALSE;
-	pthread_t monitor;
-
-	if (!started) {
-		pthread_create(&monitor, NULL, cpu_and_queue_monitor, NULL);
-		pthread_setname_np(monitor, "monitor-0");
-		pthread_detach(monitor);
-		started = B_TRUE;
-	}
 }
 
 #endif	/* MONITOR_QUEUES */

--- a/cmd/zstream/zstream_selftest.c
+++ b/cmd/zstream/zstream_selftest.c
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: CDDL-1.0
+/*
+ * CDDL HEADER START
+ *
+ * This file and its contents are supplied under the terms of the Common
+ * Development and Distribution License ("CDDL"), version 1.0. You may only use
+ * this file in accordance with the terms of version 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this source. A
+ * copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2026 by Garth Snyder. All rights reserved.
+ */
+
+/*
+ * zstream selftest: in-process unit tests for zstream's internal machinery.
+ *
+ *   zstream selftest [-l] [-s seed] [-t nthreads] module [test ...]
+ *
+ * Tests are grouped into modules (see zstream_selftest.h). With no test
+ * names, all of a module's tests run in order. -l lists the available
+ * tests. -s replays a previous run's PRNG seed. -t sets the size of the
+ * shared worker thread pool before any test runs.
+ *
+ * This subcommand is intentionally undocumented in zstream_usage() and the
+ * man page; it exists to be driven by the ZFS test suite.
+ */
+
+#include <assert.h>
+#include <err.h>
+#include <libspl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/random.h>
+#include <sys/stdtypes.h>
+#include <unistd.h>
+
+#include "zstream.h"
+#include "zstream_backtrace.h"
+#include "zstream_queue.h"
+#include "zstream_selftest.h"
+
+typedef struct {
+	const char		*sm_name;
+	const test_case_t	*sm_cases;
+} selftest_module_t;
+
+static const selftest_module_t modules[] = {
+	{ "queue", selftest_queue_cases },
+};
+
+#define	NUM_MODULES	(sizeof (modules) / sizeof (modules[0]))
+
+uint64_t selftest_seed;
+
+static const char *current_test = "(startup)";
+
+static void
+selftest_usage(void)
+{
+	(void) fprintf(stderr,
+	    "usage: zstream selftest [-l] [-s seed] [-t nthreads] "
+	    "module [test ...]\n"
+	    "\n"
+	    "\t-l         list available tests\n"
+	    "\t-s seed    seed for pseudo-random workloads (for replays)\n"
+	    "\t-t num     size of the shared worker thread pool\n"
+	    "\n"
+	    "Available modules:");
+	for (int i = 0; i < NUM_MODULES; i++)
+		(void) fprintf(stderr, " %s", modules[i].sm_name);
+	(void) fprintf(stderr, "\n");
+	exit(1);
+}
+
+static const selftest_module_t *
+find_module(const char *name)
+{
+	for (int i = 0; i < NUM_MODULES; i++) {
+		if (strcmp(name, modules[i].sm_name) == 0)
+			return (&modules[i]);
+	}
+	warnx("unknown module '%s'", name);
+	selftest_usage();
+	return (NULL);	/* NOTREACHED */
+}
+
+static void
+list_tests(const selftest_module_t *module)
+{
+	for (int i = 0; i < NUM_MODULES; i++) {
+		if (module != NULL && module != &modules[i])
+			continue;
+		(void) printf("%s:\n", modules[i].sm_name);
+		for (const test_case_t *tc = modules[i].sm_cases;
+		    tc->tc_name != NULL; tc++) {
+			(void) printf("\t%s\n", tc->tc_name);
+		}
+	}
+}
+
+static void
+run_case(const test_case_t *tc)
+{
+	(void) printf("Running %-20s ... ", tc->tc_name);
+	(void) fflush(stdout);
+	current_test = tc->tc_name;
+	watchdog_arm();
+	tc->tc_func();
+	watchdog_disarm();
+	(void) printf("OK\n");
+}
+
+static const test_case_t *
+find_case(const selftest_module_t *module, const char *name)
+{
+	for (const test_case_t *tc = module->sm_cases;
+	    tc->tc_name != NULL; tc++) {
+		if (strcmp(name, tc->tc_name) == 0)
+			return (tc);
+	}
+	errx(2, "module '%s' has no test named '%s' (try -l)",
+	    module->sm_name, name);
+	return (NULL);	/* NOTREACHED */
+}
+
+int
+zstream_do_selftest(int argc, char *argv[])
+{
+	boolean_t list_only = B_FALSE;
+	boolean_t have_seed = B_FALSE;
+	uint_t nthreads = 0;
+	char *end;
+	int c;
+
+	while ((c = getopt(argc, argv, "ls:t:")) != -1) {
+		switch (c) {
+		case 'l':
+			list_only = B_TRUE;
+			break;
+		case 's':
+			selftest_seed = strtoull(optarg, &end, 0);
+			if (*optarg == '\0' || *end != '\0') {
+				warnx("failed to parse seed '%s'", optarg);
+				selftest_usage();
+			}
+			have_seed = B_TRUE;
+			break;
+		case 't':
+			if (sscanf(optarg, "%u", &nthreads) != 1 ||
+			    nthreads == 0) {
+				warnx("failed to parse num_threads '%s'",
+				    optarg);
+				selftest_usage();
+			}
+			break;
+		case '?':
+			warnx("invalid option '%c'", optopt);
+			selftest_usage();
+			break;
+		}
+	}
+	argc -= optind;
+	argv += optind;
+
+	if (list_only) {
+		list_tests(argc > 0 ? find_module(argv[0]) : NULL);
+		return (0);
+	}
+	if (argc < 1)
+		selftest_usage();
+
+	const selftest_module_t *module = find_module(argv[0]);
+
+	/* Needed for random_get_pseudo_bytes() */
+	libspl_init();
+	watchdog_init();
+
+	if (!have_seed)
+		random_get_pseudo_bytes((uint8_t *)&selftest_seed,
+		    sizeof (selftest_seed));
+	(void) printf("Using seed 0x%016jx (replay with -s 0x%jx)\n",
+	    (uintmax_t)selftest_seed, (uintmax_t)selftest_seed);
+
+	if (nthreads > 0)
+		zstream_queue_set_num_threads(nthreads);
+
+
+	int count = 0;
+	if (argc == 1) {
+		for (const test_case_t *tc = module->sm_cases;
+		    tc->tc_name != NULL; tc++) {
+			run_case(tc);
+			count++;
+		}
+	} else {
+		for (int i = 1; i < argc; i++) {
+			run_case(find_case(module, argv[i]));
+			count++;
+		}
+	}
+	(void) printf("All %d %s selftest%s passed\n", count, module->sm_name,
+	    count == 1 ? "" : "s");
+	libspl_fini();
+	return (0);
+}

--- a/cmd/zstream/zstream_selftest.h
+++ b/cmd/zstream/zstream_selftest.h
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: CDDL-1.0
+/*
+ * CDDL HEADER START
+ *
+ * This file and its contents are supplied under the terms of the Common
+ * Development and Distribution License ("CDDL"), version 1.0. You may only use
+ * this file in accordance with the terms of version 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this source. A
+ * copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2026 by Garth Snyder. All rights reserved.
+ */
+
+#ifndef	_ZSTREAM_SELFTEST_H
+#define	_ZSTREAM_SELFTEST_H
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+/*
+ * Shared harness for "zstream selftest". Each module under test supplies a
+ * NULL-terminated array of named test cases. The harness in
+ * zstream_selftest.c handles argument parsing, test selection, seeding of
+ * pseudo-random number generators, watchdog timeouts, and status output.
+ *
+ * Test cases report failure by exiting with a nonzero exit code. Any test
+ * case that returns has passed.
+ */
+
+typedef void test_function_f(void);
+
+typedef struct {
+	const char	*tc_name;
+	test_function_f	*tc_func;
+} test_case_t;
+
+/*
+ * Modules with test cases to offer. Each array ends with a NULL tc_name.
+ */
+extern const test_case_t selftest_queue_cases[];
+
+/*
+ * The seed for this run, set by the harness before any test runs. Printed
+ * at startup and settable with -s so failures can be replayed.
+ */
+extern uint64_t selftest_seed;
+
+/*
+ * A small deterministic PRNG (splitmix64). Tests derive per-thread
+ * generators from selftest_seed plus a caller-chosen stream number, so
+ * workloads are reproducible for a given seed regardless of scheduling.
+ */
+typedef struct {
+	uint64_t	sr_state;
+} selftest_rng_t;
+
+static inline uint64_t
+selftest_mix64(uint64_t z)
+{
+	z += 0x9e3779b97f4a7c15ULL;
+	z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9ULL;
+	z = (z ^ (z >> 27)) * 0x94d049bb133111ebULL;
+	return (z ^ (z >> 31));
+}
+
+static inline void
+selftest_rng_init(selftest_rng_t *rng, uint64_t stream)
+{
+	rng->sr_state = selftest_seed ^ selftest_mix64(stream);
+}
+
+static inline uint64_t
+selftest_rng_next(selftest_rng_t *rng)
+{
+	rng->sr_state += 0x9e3779b97f4a7c15ULL;
+	return (selftest_mix64(rng->sr_state));
+}
+
+/* Uniform value in [0, bound); returns 0 if bound is 0 */
+static inline uint64_t
+selftest_rng_below(selftest_rng_t *rng, uint64_t bound)
+{
+	return (bound ? selftest_rng_next(rng) % bound : 0);
+}
+
+#ifdef	__cplusplus
+}
+#endif
+
+#endif	/* _ZSTREAM_SELFTEST_H */

--- a/cmd/zstream/zstream_selftest_queue.c
+++ b/cmd/zstream/zstream_selftest_queue.c
@@ -1,0 +1,567 @@
+// SPDX-License-Identifier: CDDL-1.0
+/*
+ * CDDL HEADER START
+ *
+ * This file and its contents are supplied under the terms of the Common
+ * Development and Distribution License ("CDDL"), version 1.0. You may only use
+ * this file in accordance with the terms of version 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this source. A
+ * copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2026 by Garth Snyder. All rights reserved.
+ */
+
+/*
+ * Selftests for the zstream_queue multithreaded FIFO queue API.
+ *
+ * All tests are built on one generic workload runner. A workload is
+ * described by a qtest_config_t: some number of producer threads each
+ * enqueue a stream of self-describing items with randomized costs,
+ * payloads, and processing delays, while one consumer thread per queue
+ * dequeues and verifies. Several workloads can run concurrently on separate
+ * queues to exercise the shared thread pool.
+ *
+ * Every item carries enough information to be verified independently:
+ *
+ * - The tuple (qi_producer, qi_seq) identifies each item; the consumer
+ *   checks that each producer's items arrive in the same order they
+ *   were enqueued.
+ *
+ * - qi_check is a hash of (qi_seed, qi_producer, qi_seq). The processing
+ *   function verifies it and then XORs in TRANSFORM_MAGIC. The consumer
+ *   checks that the transform happened iff cost > 0.
+ *
+ * - qi_pattern[] is filled from qi_check and verified both by the process
+ *   function and the consumer, to catch any corruption of the shallow
+ *   copies in and out of the ring buffer.
+ *
+ * - qi_process_count counts invocations of the process function, which
+ *   must be exactly one for cost > 0 items and zero for cost == 0 items.
+ *
+ * Global conservation checks: the number of items dequeued must equal the
+ * number enqueued, and the total number of process-function invocations
+ * must equal the number of nonzero-cost items enqueued.
+ */
+
+#include <assert.h>
+#include <atomic.h>
+#include <err.h>
+#include <pthread.h>
+#include <stdalign.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "zstream_queue.h"
+#include "zstream_selftest.h"
+
+#define	TRANSFORM_MAGIC	0xf00dfeedbeefcafeULL
+
+/*
+ * Number of times per 1000 processing function invocations to use an
+ * extra-long "outlier" processing delay to force overtly out-of-order
+ * completion.
+ */
+#define	LONG_DELAYS_PER_THOUSAND	3
+#define	LONG_DELAY_MULTIPLIER		20
+
+typedef struct {
+	uint32_t	qi_producer;
+	uint32_t	qi_delay_us;
+	uint64_t	qi_seq;
+	uint64_t	qi_check;
+	size_t		qi_cost;
+	uint32_t	qi_process_count;
+	uint8_t		qi_pattern[];
+} qtest_item_t;
+
+typedef struct {
+	uint32_t	qc_producers;		/* Number of producers */
+	uint64_t	qc_items;		/* Items per producer */
+	size_t		qc_queue_length;
+	size_t		qc_batch_budget;
+	size_t		qc_pattern_len;		/* Extra payload bytes */
+	uint32_t	qc_zero_cost_pct;	/* % of items fast-tracked */
+	size_t		qc_max_cost;		/* Nonzero costs are 1..max */
+	uint32_t	qc_delay_pct;		/* % of items slept on */
+	uint32_t	qc_max_delay_us;
+	uint32_t	qc_producer_stall_pct;	/* % chance producer naps */
+	uint32_t	qc_consumer_stall_pct;	/* % chance consumer naps */
+	uint32_t	qc_stall_max_us;
+	uint64_t	qc_rng_stream;		/* base PRNG stream number */
+} qtest_config_t;
+
+typedef struct {
+	const qtest_config_t	*qr_cfg;
+	zstream_queue_t		*qr_queue;
+	uint32_t		qr_producers_left;
+	uint64_t		qr_expect_processed;	/* Atomic */
+	uint64_t		qr_processed;		/* Atomic */
+	uint64_t		qr_dequeued;
+} qtest_run_t;
+
+typedef struct {
+	qtest_run_t	*qp_run;
+	uint32_t	qp_id;
+} qtest_producer_arg_t;
+
+static uint64_t
+item_check_value(uint32_t producer, uint64_t seq)
+{
+	return (selftest_mix64(selftest_seed ^
+	    (((uint64_t)producer << 40) + seq)));
+}
+
+static void
+fill_pattern(uint8_t *pattern, size_t len, uint64_t check)
+{
+	for (size_t i = 0; i < len; i++)
+		pattern[i] = (uint8_t)(check >> ((i & 7) << 3)) ^ (uint8_t)i;
+}
+
+static void
+verify_pattern(const uint8_t *pattern, size_t len, uint64_t check,
+    const char *who)
+{
+	for (size_t i = 0; i < len; i++) {
+		uint8_t expect =
+		    (uint8_t)(check >> ((i & 7) << 3)) ^ (uint8_t)i;
+		if (pattern[i] != expect) {
+			errx(1, "%s: payload corrupted at byte %zu "
+			    "(0x%02x != 0x%02x)", who, i, pattern[i], expect);
+		}
+	}
+}
+
+static size_t
+qtest_cost(void *item_in, void *context)
+{
+	(void) context;
+	qtest_item_t *item = item_in;
+	return (item->qi_cost);
+}
+
+static void
+qtest_process(void *item_in, void *context)
+{
+	qtest_run_t *run = context;
+	qtest_item_t *item = item_in;
+
+	/* Cost-0 items should never reach the process function */
+	VERIFY3U(item->qi_cost, >, 0);
+	VERIFY3U(item->qi_check, ==,
+	    item_check_value(item->qi_producer, item->qi_seq));
+	verify_pattern(item->qi_pattern, run->qr_cfg->qc_pattern_len,
+	    item->qi_check, "process");
+	VERIFY3U(atomic_add_32_nv(&item->qi_process_count, 1), ==, 1);
+
+	if (item->qi_delay_us > 0)
+		(void) usleep(item->qi_delay_us);
+
+	item->qi_check ^= TRANSFORM_MAGIC;
+	atomic_add_64(&run->qr_processed, 1);
+}
+
+/*
+ * Pthreads worker function for enqueuers
+ */
+static void *
+qtest_producer(void *arg)
+{
+	qtest_producer_arg_t *pa = arg;
+	qtest_run_t *run = pa->qp_run;
+	const qtest_config_t *cfg = run->qr_cfg;
+	uint64_t local_expect = 0;
+	selftest_rng_t rng;
+	alignas(uint64_t) uint8_t item_buffer[sizeof (qtest_item_t) +
+	    cfg->qc_pattern_len];
+	qtest_item_t *item = (qtest_item_t *)item_buffer;
+
+	selftest_rng_init(&rng, cfg->qc_rng_stream + 1000 + pa->qp_id);
+
+	for (uint64_t seq = 0; seq < cfg->qc_items; seq++) {
+
+		qtest_item_t item_xfer = {
+			.qi_producer = pa->qp_id,
+			.qi_seq = seq,
+			.qi_process_count = 0,
+			.qi_check = item_check_value(pa->qp_id, seq)
+		};
+		*item = item_xfer;
+		fill_pattern(item->qi_pattern, cfg->qc_pattern_len,
+		    item->qi_check);
+
+		if (selftest_rng_below(&rng, 100) < cfg->qc_zero_cost_pct) {
+			item->qi_cost = 0;
+		} else {
+			item->qi_cost =
+			    1 + selftest_rng_below(&rng, cfg->qc_max_cost);
+			local_expect++;
+		}
+
+		if (item->qi_cost > 0 && cfg->qc_max_delay_us > 0) {
+			if (selftest_rng_below(&rng, 1000) <
+			    LONG_DELAYS_PER_THOUSAND) {
+				item->qi_delay_us = cfg->qc_max_delay_us *
+				    LONG_DELAY_MULTIPLIER;
+			} else if (selftest_rng_below(&rng, 100) <
+			    cfg->qc_delay_pct) {
+				item->qi_delay_us = selftest_rng_below(&rng,
+				    cfg->qc_max_delay_us);
+			}
+		}
+
+		if (cfg->qc_producer_stall_pct > 0 &&
+		    selftest_rng_below(&rng, 100) < cfg->qc_producer_stall_pct)
+			(void) usleep(selftest_rng_below(&rng,
+			    cfg->qc_stall_max_us));
+
+		zstream_enqueue(run->qr_queue, item);
+	}
+
+	atomic_add_64(&run->qr_expect_processed, local_expect);
+	if (atomic_add_32_nv(&run->qr_producers_left, -1) == 0)
+		zstream_queue_fini(run->qr_queue);
+	return (NULL);
+}
+
+/*
+ * Pthreads worker function for dequeuers
+ */
+static void *
+qtest_consumer(void *arg)
+{
+	qtest_run_t *run = arg;
+	const qtest_config_t *cfg = run->qr_cfg;
+	selftest_rng_t rng;
+	uint64_t expected_seq[cfg->qc_producers];
+	alignas(uint64_t) uint8_t item_buffer[sizeof (qtest_item_t) +
+	    cfg->qc_pattern_len];
+	qtest_item_t *item = (qtest_item_t *)item_buffer;
+
+	memset(expected_seq, 0, sizeof (expected_seq));
+	selftest_rng_init(&rng, cfg->qc_rng_stream + 999);
+
+	while (zstream_dequeue(run->qr_queue, item)) {
+		VERIFY3U(item->qi_producer, <, cfg->qc_producers);
+		if (item->qi_seq != expected_seq[item->qi_producer]) {
+			errx(1, "consumer: FIFO order violated: got "
+			    "producer %u seq %ju, expected seq %ju",
+			    item->qi_producer, (uintmax_t)item->qi_seq,
+			    (uintmax_t)expected_seq[item->qi_producer]);
+		}
+		expected_seq[item->qi_producer]++;
+
+		uint64_t check =
+		    item_check_value(item->qi_producer, item->qi_seq);
+		if (item->qi_cost > 0) {
+			VERIFY3U(item->qi_process_count, ==, 1);
+			VERIFY3U(item->qi_check, ==, check ^ TRANSFORM_MAGIC);
+		} else {
+			VERIFY3U(item->qi_process_count, ==, 0);
+			VERIFY3U(item->qi_check, ==, check);
+		}
+		verify_pattern(item->qi_pattern, cfg->qc_pattern_len, check,
+		    "consumer");
+		run->qr_dequeued++;
+
+		if (cfg->qc_consumer_stall_pct > 0 &&
+		    selftest_rng_below(&rng, 100) < cfg->qc_consumer_stall_pct)
+			(void) usleep(selftest_rng_below(&rng,
+			    cfg->qc_stall_max_us));
+	}
+
+	for (uint32_t p = 0; p < cfg->qc_producers; p++)
+		VERIFY3U(expected_seq[p], ==, cfg->qc_items);
+	VERIFY3U(run->qr_dequeued, ==,
+	    (uint64_t)cfg->qc_producers * cfg->qc_items);
+
+	return (NULL);
+}
+
+/*
+ * Run several workloads at once, one queue per config, with a dedicated
+ * consumer thread and qc_producers producer threads per queue. Returns
+ * after every queue has been drained to end-of-stream (and therefore
+ * destroyed) and all verification checks have passed.
+ */
+static void
+run_queue_workloads(const qtest_config_t *cfgs, int ncfg)
+{
+	qtest_run_t runs[ncfg];
+	pthread_t consumers[ncfg];
+	uint32_t total_producers = 0;
+
+	for (int i = 0; i < ncfg; i++)
+		total_producers += cfgs[i].qc_producers;
+
+	pthread_t producers[total_producers];
+	qtest_producer_arg_t pargs[total_producers];
+	memset(runs, 0, sizeof (runs));
+	memset(pargs, 0, sizeof (pargs));
+
+	for (int i = 0; i < ncfg; i++) {
+		runs[i].qr_cfg = &cfgs[i];
+		runs[i].qr_producers_left = cfgs[i].qc_producers;
+		zq_params_t params = {
+			.qp_process = qtest_process,
+			.qp_cost = qtest_cost,
+			.qp_context = &runs[i],
+			.qp_item_size =
+			    sizeof (qtest_item_t) + cfgs[i].qc_pattern_len,
+			.qp_batch_budget = cfgs[i].qc_batch_budget,
+			.qp_queue_length = cfgs[i].qc_queue_length,
+		};
+		runs[i].qr_queue = zstream_queue_create(&params);
+	}
+
+	int p = 0;
+	for (int i = 0; i < ncfg; i++) {
+		VERIFY3S(pthread_create(&consumers[i], NULL, qtest_consumer,
+		    &runs[i]), ==, 0);
+		for (uint32_t j = 0; j < cfgs[i].qc_producers; j++, p++) {
+			pargs[p].qp_run = &runs[i];
+			pargs[p].qp_id = j;
+			VERIFY3S(pthread_create(&producers[p], NULL,
+			    qtest_producer, &pargs[p]), ==, 0);
+		}
+	}
+
+	for (uint32_t i = 0; i < total_producers; i++)
+		VERIFY3S(pthread_join(producers[i], NULL), ==, 0);
+	for (int i = 0; i < ncfg; i++)
+		VERIFY3S(pthread_join(consumers[i], NULL), ==, 0);
+
+	for (int i = 0; i < ncfg; i++)
+		VERIFY3U(runs[i].qr_processed, ==, runs[i].qr_expect_processed);
+}
+
+static void
+run_queue_workload(const qtest_config_t *cfg)
+{
+	run_queue_workloads(cfg, 1);
+}
+
+/*
+ * Basic single-producer smoke test: deterministic-ish costs, no delays.
+ */
+static void
+queue_basic(void)
+{
+	qtest_config_t cfg = {
+		.qc_producers = 1,
+		.qc_items = 5000,
+		.qc_queue_length = 64,
+		.qc_batch_budget = 256,
+		.qc_pattern_len = 32,
+		.qc_zero_cost_pct = 20,
+		.qc_max_cost = 64,
+	};
+	run_queue_workload(&cfg);
+}
+
+/*
+ * A long, randomized stream with heavy-tailed processing delays, a large
+ * fraction of fast-tracked items, costs that exceed the batch budget, and a
+ * consumer that periodically stalls so the queue backs up and enqueue
+ * blocks on Q_FULL. The ring indices wrap hundreds of times.
+ */
+static void
+queue_torture(void)
+{
+	qtest_config_t cfg = {
+		.qc_producers = 1,
+		.qc_items = 100000,
+		.qc_queue_length = 512,
+		.qc_batch_budget = 2048,
+		.qc_pattern_len = 64,
+		.qc_zero_cost_pct = 30,
+		.qc_max_cost = 4096,
+		.qc_delay_pct = 5,
+		.qc_max_delay_us = 100,
+		.qc_consumer_stall_pct = 1,
+		.qc_stall_max_us = 500,
+		.qc_rng_stream = 100,
+	};
+	run_queue_workload(&cfg);
+}
+
+/*
+ * Off-by-one hunting: sweep the degenerate corners of queue length,
+ * batch budget, and stream length, including a zero-item stream and
+ * zero-length payloads.
+ */
+static void
+queue_edge_cases(void)
+{
+	static const size_t lengths[] =
+	    { 1, 2, MAX_BATCH - 1, MAX_BATCH, MAX_BATCH + 1, 64 };
+	static const size_t budgets[] = { 0, 1, 16, SIZE_MAX / 2 };
+	uint64_t stream = 200;
+
+	for (int l = 0; l < 6; l++) {
+		for (int b = 0; b < 4; b++) {
+			uint64_t counts[] = { 0, lengths[l], lengths[l] + 1,
+			    4 * lengths[l] + 3 };
+			for (int n = 0; n < 4; n++) {
+				qtest_config_t cfg = {
+					.qc_producers = 1,
+					.qc_items = counts[n],
+					.qc_queue_length = lengths[l],
+					.qc_batch_budget = budgets[b],
+					.qc_pattern_len =
+					    (lengths[l] & 1) ? 0 : 24,
+					.qc_zero_cost_pct = 25,
+					.qc_max_cost = 8,
+					.qc_rng_stream = stream++,
+				};
+				run_queue_workload(&cfg);
+			}
+		}
+	}
+}
+
+/*
+ * All items cost 0, so every item takes the fast track and the process
+ * function must never run (qtest_process VERIFYs cost > 0, and the
+ * conservation check at the end of the run confirms zero invocations).
+ * This exercises the completion-index sweep for items no worker ever
+ * touches.
+ */
+static void
+queue_zero_cost(void)
+{
+	qtest_config_t cfg = {
+		.qc_producers = 1,
+		.qc_items = 20000,
+		.qc_queue_length = 128,
+		.qc_batch_budget = 1024,
+		.qc_pattern_len = 16,
+		.qc_zero_cost_pct = 100,
+		.qc_max_cost = 8,
+		.qc_rng_stream = 300,
+	};
+	run_queue_workload(&cfg);
+}
+
+/*
+ * Eight producer threads hammering one queue with random pacing. The
+ * consumer verifies per-producer FIFO order and exact counts.
+ */
+static void
+queue_multi_producer(void)
+{
+	qtest_config_t cfg = {
+		.qc_producers = 8,
+		.qc_items = 15000,
+		.qc_queue_length = 256,
+		.qc_batch_budget = 512,
+		.qc_pattern_len = 24,
+		.qc_zero_cost_pct = 25,
+		.qc_max_cost = 512,
+		.qc_delay_pct = 2,
+		.qc_max_delay_us = 50,
+		.qc_producer_stall_pct = 1,
+		.qc_stall_max_us = 200,
+		.qc_rng_stream = 400,
+	};
+	run_queue_workload(&cfg);
+}
+
+/*
+ * Many dissimilar queues live at once, stressing worker scoring and
+ * assignment, per-queue index isolation, and destruction of queues while
+ * others remain active (which compacts the pool's queue array).
+ */
+static void
+queue_multi_queue(void)
+{
+	qtest_config_t cfgs[12];
+	for (int i = 0; i < 12; i++) {
+		uint32_t producers = 1 + i % 3;
+		qtest_config_t cfg = {
+			.qc_producers = producers,
+			.qc_items = 4000 / producers,
+			.qc_queue_length = (size_t)4 << (i % 6),
+			.qc_batch_budget =
+			    (i % 4 == 0) ? 0 : (size_t)64 << (i % 5),
+			.qc_pattern_len = 8 * (i % 5),
+			.qc_zero_cost_pct = 10 * (i % 6),
+			.qc_max_cost = (size_t)16 << (i % 8),
+			.qc_delay_pct = i % 3,
+			.qc_max_delay_us = 60,
+			.qc_rng_stream = 500 + i * 10000,
+		};
+		cfgs[i] = cfg;
+	}
+	run_queue_workloads(cfgs, 12);
+}
+
+/*
+ * Seeded chaos: randomize every workload parameter within sane bounds
+ * and run a few rounds of concurrent queues. Whatever the targeted tests
+ * miss, this net catches over many CI runs; failures replay with -s.
+ */
+static void
+queue_stress(void)
+{
+	selftest_rng_t rng;
+	selftest_rng_init(&rng, 900);
+
+	for (int iter = 0; iter < 8; iter++) {
+		int nqueues = 1 + selftest_rng_below(&rng, 4);
+		qtest_config_t cfgs[4];
+
+		for (int i = 0; i < nqueues; i++) {
+			uint32_t producers = 1 + selftest_rng_below(&rng, 4);
+			qtest_config_t cfg = {
+				.qc_producers = producers,
+				.qc_items = (2000 +
+				    selftest_rng_below(&rng, 8000)) /
+				    producers,
+				.qc_queue_length = (size_t)1 <<
+				    selftest_rng_below(&rng, 10),
+				.qc_batch_budget =
+				    (selftest_rng_below(&rng, 3) == 0) ? 0 :
+				    selftest_rng_below(&rng, 4096),
+				.qc_pattern_len =
+				    selftest_rng_below(&rng, 64),
+				.qc_zero_cost_pct =
+				    selftest_rng_below(&rng, 101),
+				.qc_max_cost =
+				    1 + selftest_rng_below(&rng, 2048),
+				.qc_delay_pct = selftest_rng_below(&rng, 4),
+				.qc_max_delay_us =
+				    selftest_rng_below(&rng, 120),
+				.qc_producer_stall_pct =
+				    selftest_rng_below(&rng, 2),
+				.qc_consumer_stall_pct =
+				    selftest_rng_below(&rng, 2),
+				.qc_stall_max_us =
+				    selftest_rng_below(&rng, 400),
+				.qc_rng_stream = 1000000 + iter * 1000 +
+				    i * 100,
+			};
+			cfgs[i] = cfg;
+		}
+		run_queue_workloads(cfgs, nqueues);
+	}
+}
+
+const test_case_t selftest_queue_cases[] = {
+	{ "queue_basic",		queue_basic },
+	{ "queue_edge_cases",		queue_edge_cases },
+	{ "queue_zero_cost",		queue_zero_cost },
+	{ "queue_torture",		queue_torture },
+	{ "queue_multi_producer",	queue_multi_producer },
+	{ "queue_multi_queue",		queue_multi_queue },
+	{ "queue_stress",		queue_stress },
+	{ NULL,				NULL },
+};

--- a/cmd/zstream/zstream_util.c
+++ b/cmd/zstream/zstream_util.c
@@ -27,10 +27,10 @@
 #include <assert.h>
 #include <err.h>
 #include <errno.h>
+#include <pthread.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <sys/abd.h>
 #include <sys/fs/zfs.h>
 #include <sys/stdtypes.h>
@@ -39,7 +39,6 @@
 #include <sys/zio.h>
 #include <sys/zio_compress.h>
 #include <unistd.h>
-#include <zfs_fletcher.h>
 
 #include "zstream_util.h"
 
@@ -61,6 +60,54 @@ safe_calloc(size_t size)
 		errx(1, "failed to allocate %zu bytes, aborting...", size);
 	}
 	return (rv);
+}
+
+void
+safe_pthread_sigmask(int how, const sigset_t *set, sigset_t *oldset)
+{
+	int error = pthread_sigmask(how, set, oldset);
+	if (error != 0) {
+		errno = error;
+		err(1, "pthread_sigmask failed");
+	}
+}
+
+pthread_t
+safe_create_thread(thread_f *body, void *body_arg, const char *name,
+    boolean_t detach)
+{
+	pthread_t tid;
+	int ret;
+	int name_attempts = 3;
+
+	ret = pthread_create(&tid, NULL, body, body_arg);
+	if (ret != 0) {
+		errno = ret;
+		err(1, "pthread_create for %s failed", name);
+	}
+	/*
+	 * pthread_setname_np() fails randomly on some Debian systems
+	 * because of difficulty reading /proc/self/task. The characteristic
+	 * error is "No such file or directory." The name is just a
+	 * debugging aid, so we can ignore the error, but we'll make three
+	 * attempts to set it. This code previously printed a warning
+	 * message, but that interferes with zstream dump output comparisons
+	 * in ZTS.
+	 */
+	while (name_attempts-- > 0) {
+		ret = pthread_setname_np(tid, name);
+		if (ret == 0)
+			break;
+		usleep(100);
+	}
+	if (detach) {
+		ret = pthread_detach(tid);
+		if (ret != 0) {
+			errno = ret;
+			err(1, "failed to detach %s thread", name);
+		}
+	}
+	return (tid);
 }
 
 char *

--- a/cmd/zstream/zstream_util.h
+++ b/cmd/zstream/zstream_util.h
@@ -21,8 +21,15 @@
 extern "C" {
 #endif
 
+#include <assert.h>
+#include <pthread.h>
+#include <signal.h>
 #include <stddef.h>
 #include <stdlib.h>
+#include <stdint.h>
+#include <sys/types.h>
+#include <sys/stdtypes.h>
+#include <sys/spa_checksum.h>
 #include <sys/zfs_ioctl.h>
 #include <sys/zio_checksum.h>
 #include <sys/zio_compress.h>
@@ -32,17 +39,27 @@ typedef struct {
 	int			cs_level;
 } compression_spec_t;
 
+typedef void *
+thread_f(void *);
+
 /*
  * The safe_ versions of the functions below terminate the process if the
  * operation doesn't succeed instead of returning an error.
  */
-extern void *
+void *
 safe_malloc(size_t size);
 
-extern void *
+void *
 safe_calloc(size_t n);
 
-extern char *
+void
+safe_pthread_sigmask(int how, const sigset_t *set, sigset_t *oldset);
+
+pthread_t
+safe_create_thread(thread_f *body, void *body_arg, const char *name,
+    boolean_t detach);
+
+char *
 checksum_str(zio_cksum_t *cksum, char *buff, size_t buff_size);
 
 /*

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -1170,6 +1170,7 @@ tests = ['zstream_checksum_001_pos',
     'zstream_recompress_003_pos', 'zstream_recompress_004_pos',
     'zstream_recompress_005_pos',
     'zstream_redup_001_pos',
+    'zstream_selftest_queue_001_pos',
     'zstream_validate_001_neg']
 tags = ['functional', 'zstream']
 

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -2463,6 +2463,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/zstream/zstream_recompress_005_pos.ksh \
 	functional/zstream/zstream_redup_001_pos.ksh \
 	functional/zstream/zstream_validate_001_neg.ksh \
+	functional/zstream/zstream_selftest_queue_001_pos.ksh \
 	functional/zvol/zvol_cli/cleanup.ksh \
 	functional/zvol/zvol_cli/setup.ksh \
 	functional/zvol/zvol_cli/zvol_cli_001_pos.ksh \

--- a/tests/zfs-tests/tests/functional/zstream/zstream_selftest_queue_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/zstream/zstream_selftest_queue_001_pos.ksh
@@ -1,0 +1,37 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2026 by Garth Snyder. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# Description:
+# Run zstream's built-in unit tests ("zstream selftest").
+#
+# Strategy:
+# 1. Run all selftests for each module with the default worker thread pool.
+# 2. Run them again with a single worker thread.
+#
+
+verify_runnable "both"
+
+log_assert "zstream self-tests for zstream_queue all pass"
+
+log_must zstream selftest queue
+log_must zstream selftest -t 1 queue
+
+log_pass "zstream self-tests for zstream_queue all pass"


### PR DESCRIPTION
This PR adds a unit-testing harness to the `zstream` command along with additional tests for `zstream_queue.`

Tests are run with the (undocumented) `zstream selftest` subcommand:

```
usage: zstream selftest [-l] [-s seed] [-t nthreads] module [test ...]

	-l         list available tests
	-s seed    seed for pseudo-random workloads (for replays)
	-t num     size of the shared worker thread pool

Available modules: queue
```

There are 7 tests within the `queue` group, each of which prepares a workload specification that's then sent to `run_queue_workloads()` for execution. The individual tests exercise a variety of load conditions and edge cases.

I added a test to the `zstream` group to run `zstream selftest queue` and `zstream selftest -t 1 queue`. I see that there's a provision for unit tests in ZTS, but this seemed like a cleaner approach given the dependencies among parts of `zstream`.

The selftest harness includes a watchdog timer set at 120 seconds. If a test times out, the backtrace code in zstream_backtrace.[ch] runs to dump a stack trace of every thread. That backtrace seems to work correctly on all the test VMs.
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [ x All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
