### PR TITLE
Make systemd-udev-settle optional for the import units

### DIFF
--- a/etc/systemd/system/zfs-import-cache.service.in
+++ b/etc/systemd/system/zfs-import-cache.service.in
@@ -2,8 +2,10 @@
 Description=Import ZFS pools by cache file
 Documentation=man:zpool(8)
 DefaultDependencies=no
-Requires=systemd-udev-settle.service
+Wants=systemd-udev-settle.service
 After=systemd-udev-settle.service
+After=systemd-udev-trigger.service
+After=systemd-modules-load.service
 After=cryptsetup.target
 After=multipathd.service
 After=systemd-remount-fs.service

--- a/etc/systemd/system/zfs-import-scan.service.in
+++ b/etc/systemd/system/zfs-import-scan.service.in
@@ -2,8 +2,10 @@
 Description=Import ZFS pools by device scanning
 Documentation=man:zpool(8)
 DefaultDependencies=no
-Requires=systemd-udev-settle.service
+Wants=systemd-udev-settle.service
 After=systemd-udev-settle.service
+After=systemd-udev-trigger.service
+After=systemd-modules-load.service
 After=cryptsetup.target
 After=multipathd.service
 Before=zfs-import.target

--- a/etc/systemd/system/zfs-mount.service.in
+++ b/etc/systemd/system/zfs-mount.service.in
@@ -2,7 +2,6 @@
 Description=Mount ZFS filesystems
 Documentation=man:zfs(8)
 DefaultDependencies=no
-After=systemd-udev-settle.service
 After=zfs-import.target
 After=systemd-remount-fs.service
 Before=local-fs.target

--- a/etc/systemd/system/zfs-mount@.service.in
+++ b/etc/systemd/system/zfs-mount@.service.in
@@ -2,7 +2,6 @@
 Description=Mount ZFS filesystem %I
 Documentation=man:zfs(8)
 DefaultDependencies=no
-After=systemd-udev-settle.service
 After=zfs-import.target
 After=zfs-mount.service
 After=systemd-remount-fs.service

--- a/etc/systemd/system/zfs-volume-wait.service.in
+++ b/etc/systemd/system/zfs-volume-wait.service.in
@@ -1,7 +1,6 @@
 [Unit]
 Description=Wait for ZFS Volume (zvol) links in /dev
 DefaultDependencies=no
-After=systemd-udev-settle.service
 After=zfs-import.target
 ConditionPathIsDirectory=/sys/module/zfs
 


### PR DESCRIPTION
### Motivation and Context
systemd-udev-settle.service is deprecated and newer distributions ship
without it, which turns the hard Requires= in the import units into a
service that never starts: a Requires= on a masked or removed unit
keeps zfs-import-cache from running at all, so pools silently stay
unimported. Where the unit still exists it draws a deprecation warning
on every boot. Issue #10891.

### Description
Demote the settle dependency in zfs-import-cache and zfs-import-scan
from Requires= to Wants=, keeping the After= ordering. On systems that
ship the settle unit and where it completes, the boot is what it
always was: Wants= pulls settle in, the import waits for it, and the
device-symlink guarantee it provided is intact. Where it is masked or
gone the wish is quietly dropped and the import runs anyway, which
beats not importing at all. One deliberate behavior change: if settle
itself times out, the old Requires= cancelled the import, while the
new units proceed at the timeout mark with whatever udev has
enumerated by then.

Settle-less boots get two ordering edges in place of the queue wait:
After=systemd-udev-trigger.service so coldplug events are at least
queued, and After=systemd-modules-load.service, which closes a
condition race the settle delay used to hide — both import units gate
on ConditionPathIsDirectory=/sys/module/zfs, and without the settle
wait that condition could be evaluated before modules-load.d finished
loading zfs.ko, silently skipping the import on a healthy boot. Beyond
that, a symlink that appears a moment too late has only the short
zfs_vdev_open_timeout_ms open-retry window for slack. The stray
After= lines in zfs-mount, zfs-mount@ and zfs-volume-wait go away,
they only ordered against a unit that may not exist.

An earlier revision of this PR also pulled in modprobe@zfs.service to
paper over the ConditionPathIsDirectory=/sys/module/zfs silent skip.
That turned out to be a behavior change of its own (the module, and
with it zed, started on every boot even with no pools), and the
condition predates this change, so it is dropped here and can be
discussed separately.

Waiting on exactly the devices a pool needs instead of the whole udev
queue is what #18486 is shaped to solve; this is the minimal stopgap
that keeps settle-less systems importing today without changing
behavior anywhere else.

### How Has This Been Tested?
On a systemd 259 VM with a cachefile pool, rebooted twice with the
rendered unit. With settle available the boot pulls it in and the pool
imports as before. With settle masked (what a distro removing the unit
looks like) the boot comes up with no failed units and the pool still
imports, where a masked settle previously kept zfs-import-cache from
starting at all. systemd-analyze verify is clean on the rendered unit.

### Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
