### PR TITLE
ZTS: make the rsend resume checks real and stop a tunable leak

### DIFF
--- a/tests/zfs-tests/tests/functional/rsend/rsend.kshlib
+++ b/tests/zfs-tests/tests/functional/rsend/rsend.kshlib
@@ -583,14 +583,34 @@ function file_check
 {
 	sendfs=$1
 	recvfs=$2
+	typeset -i compared=0
 
-	if [[ -d /$recvfs/.zfs/snapshot/a && -d \
-	    /$sendfs/.zfs/snapshot/a ]]; then
-		log_must directory_diff /$recvfs/.zfs/snapshot/a /$sendfs/.zfs/snapshot/a
-	fi
-	if [[ -d /$recvfs/.zfs/snapshot/b && -d \
-	    /$sendfs/.zfs/snapshot/b ]]; then
-		log_must directory_diff /$recvfs/.zfs/snapshot/b /$sendfs/.zfs/snapshot/b
+	#
+	# The datasets are often not mounted at this point (the receive
+	# side is usually created with -u), and the .zfs directories the
+	# diffs need only exist once they are mounted.
+	#
+	ismounted $sendfs || log_must zfs mount $sendfs
+	ismounted $recvfs || log_must zfs mount $recvfs
+
+	#
+	# Only compare the snapshots both sides have; some tests send
+	# just one of them.  Comparing nothing means the caller's
+	# expectations are wrong, and historically this function did
+	# exactly that whenever the receive side was unmounted.
+	#
+	typeset snap
+	for snap in a b; do
+		[[ -d /$sendfs/.zfs/snapshot/$snap && \
+		    -d /$recvfs/.zfs/snapshot/$snap ]] || continue
+		log_must directory_diff /$recvfs/.zfs/snapshot/$snap \
+		    /$sendfs/.zfs/snapshot/$snap
+		compared=$((compared + 1))
+	done
+
+	if [[ $compared -eq 0 ]]; then
+		log_fail "file_check: no snapshots compared for" \
+		    "$sendfs and $recvfs"
 	fi
 }
 

--- a/tests/zfs-tests/tests/functional/rsend/rsend_024_pos.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/rsend_024_pos.ksh
@@ -48,7 +48,12 @@ log_onexit resume_cleanup $sendfs $streamfs
 test_fs_setup $sendfs $recvfs $streamfs
 log_must zfs unmount -f $sendfs
 resume_test "zfs send $sendfs" $streamfs $recvfs 0
-file_check $sendfs $recvfs
+
+# The stream was taken from the head, not from the a/b snapshots
+# file_check compares, so diff the mounted heads instead
+log_must zfs mount $sendfs
+log_must zfs mount $recvfs
+log_must directory_diff /$sendfs /$recvfs
 
 log_pass "Verify resumability of a full ZFS send/receive with the source " \
     "filesystem unmounted"

--- a/tests/zfs-tests/tests/functional/rsend/send_large_microzap_incremental.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send_large_microzap_incremental.ksh
@@ -61,7 +61,8 @@ typeset second=$POOL2/second
 log_onexit cleanup
 
 # Allow micro ZAPs to grow beyond SPA_OLD_MAXBLOCKSIZE.
-set_tunable64 ZAP_MICRO_MAX_SIZE 1048576
+log_must save_tunable ZAP_MICRO_MAX_SIZE
+log_must set_tunable64 ZAP_MICRO_MAX_SIZE 1048576
 
 # Create a dataset with a large recordsize (1MB)
 log_must zfs create -o recordsize=1M $src

--- a/tests/zfs-tests/tests/functional/rsend/send_large_microzap_transitive.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send_large_microzap_transitive.ksh
@@ -65,7 +65,8 @@ typeset third=$POOL3/third
 log_onexit cleanup
 
 # Allow micro ZAPs to grow beyond SPA_OLD_MAXBLOCKSIZE.
-set_tunable64 ZAP_MICRO_MAX_SIZE 1048576
+log_must save_tunable ZAP_MICRO_MAX_SIZE
+log_must set_tunable64 ZAP_MICRO_MAX_SIZE 1048576
 
 # Ensure the third pool exists.
 datasetexists $POOL3 || log_must zpool create $POOL3 $DISK3

--- a/tests/zfs-tests/tests/functional/rsend/send_partial_dataset.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send_partial_dataset.ksh
@@ -70,7 +70,9 @@ log_mustnot eval "zfs send --saved $POOL/recvfullfs | zfs recv -s " \
 	"$POOL/partialfs"
 token=$(zfs get -Hp -o value receive_resume_token $POOL/partialfs)
 log_must eval "zfs send -t $token | zfs recv -s $POOL/partialfs"
-file_check $POOL/recvfullfs $POOL/partialfs
+# recvfullfs never completes and has no snapshots to compare, so
+# check the result against the dataset the stream originally came from
+file_check $POOL/testfs2 $POOL/partialfs
 log_must zfs destroy -r $POOL/partialfs
 
 # Perform saved send with incremental


### PR DESCRIPTION
### Motivation and Context
Two rsend test suite problems that hide real coverage. file_check() in
rsend.kshlib guards its diffs on the .zfs snapshot directories existing,
but the resume tests receive with -u, so the receive side is never mounted
and the function has been comparing nothing in rsend_019-022, rsend_024,
rsend_030 and send-c_resume. Separately, the send_large_microzap tests set
ZAP_MICRO_MAX_SIZE without saving it first, so restore_tunable in their
cleanup is a no-op and any later rsend run on the same module load fails
seven tests once their setup directories become large microzaps.

### Description
file_check now mounts both sides, compares the snapshots both sides have,
and fails when nothing was compared at all. Two callers needed adjusting
once the checks came alive: rsend_024 streams from the head rather than
the a/b snapshots, so it diffs the mounted heads, and the first check in
send_partial_dataset pointed at a partial dataset with no snapshots, so it
compares against the stream's origin instead. The microzap tests get the
missing save_tunable.

### How Has This Been Tested?
rsend group run twice back to back on one module load (Linux VM): both
runs pass with the comparisons active, where before the second run failed
the seven tests above. The received data all matches, so the dormant
checks were not hiding a real send/recv bug.

### Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
