### PR TITLE
mmp: skip holes when counting required uberblock writes

### DIFF
--- a/module/zfs/mmp.c
+++ b/module/zfs/mmp.c
@@ -570,7 +570,9 @@ mmp_claim_uberblock_sync(zio_t *zio, uint64_t *good_writes,
 	for (uint64_t c = 0; c < vd->vdev_children; c++) {
 		vdev_t *cvd = vd->vdev_child[c];
 
-		if (cvd->vdev_islog || cvd->vdev_isspare || cvd->vdev_isl2cache)
+		if (cvd->vdev_islog || cvd->vdev_isspare ||
+		    cvd->vdev_isl2cache || cvd->vdev_ishole ||
+		    cvd->vdev_ops == &vdev_indirect_ops)
 			continue;
 
 		if (cvd->vdev_top == cvd) {

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -1732,6 +1732,15 @@ zio_flush(zio_t *pio, vdev_t *vd)
 		return;
 
 	if (vd->vdev_children == 0) {
+		/*
+		 * A non-concrete vdev (a hole or indirect vdev left behind
+		 * by removing a log or data device) has no leaf device to
+		 * flush.  Skip it; issuing a flush to an indirect vdev would
+		 * trip the ZIO_TYPE_WRITE assertion in
+		 * vdev_indirect_io_start().
+		 */
+		if (!vdev_is_concrete(vd))
+			return;
 		zio_nowait(zio_create(pio, vd->vdev_spa, 0, NULL, NULL, 0, 0,
 		    NULL, NULL, ZIO_TYPE_FLUSH, ZIO_PRIORITY_NOW, flags, vd, 0,
 		    NULL, ZIO_STAGE_OPEN, ZIO_FLUSH_PIPELINE));

--- a/tests/zfs-tests/tests/functional/mmp/mmp.kshlib
+++ b/tests/zfs-tests/tests/functional/mmp/mmp.kshlib
@@ -83,10 +83,11 @@ function mmp_clear_hostid
 	rm -f $HOSTID_FILE
 }
 
-function mmp_pool_create_simple # pool dir
+function mmp_pool_create_simple # pool dir enriched
 {
 	typeset pool=${1:-$MMP_POOL}
 	typeset dir=${2:-$MMP_DIR}
+	typeset enriched=${3:-""}
 
 	log_must mkdir -p $dir
 	log_must rm -f $dir/*
@@ -96,6 +97,28 @@ function mmp_pool_create_simple # pool dir
 	log_must mmp_set_hostid $HOSTID1
 	log_must zpool create -f -o cachefile=$MMP_CACHE $pool \
 	    mirror $dir/vdev1 $dir/vdev2
+
+	if [[ -n "$enriched" ]]; then
+		#
+		# Add then remove a data vdev to leave an indirect vdev, and
+		# add then remove a log to leave a hole vdev, so the pool
+		# exercises the non-writeable top-level vdev types skipped by
+		# the MMP claim check.  Round it out with a log, a cache, and
+		# a spare vdev.
+		#
+		log_must truncate -s $MINVDEVSIZE $dir/vdev3 $dir/vdev4 \
+		    $dir/vdev5 $dir/vdev6 $dir/vdev7
+		log_must zpool add -f $pool $dir/vdev3
+		log_must zpool remove $pool $dir/vdev3
+		log_must zpool wait -t remove $pool
+		log_must sync_pool $pool
+		log_must zpool add -f $pool log $dir/vdev4
+		log_must zpool remove $pool $dir/vdev4
+		log_must zpool add -f $pool log $dir/vdev5
+		log_must zpool add -f $pool cache $dir/vdev6
+		log_must zpool add -f $pool spare $dir/vdev7
+	fi
+
 	log_must zpool set multihost=on $pool
 }
 
@@ -148,7 +171,7 @@ function mmp_pool_set_hostid # pool hostid
 	log_must mmp_clear_hostid
 	log_must mmp_set_hostid $hostid
 	log_must zpool export $pool
-	log_must zpool import $pool
+	log_must zpool import -d $MMP_DIR $pool
 
 	return 0
 }

--- a/tests/zfs-tests/tests/functional/mmp/mmp_concurrent_import.ksh
+++ b/tests/zfs-tests/tests/functional/mmp/mmp_concurrent_import.ksh
@@ -93,7 +93,7 @@ log_assert "multihost=on concurrent imports"
 log_onexit cleanup
 
 # 1. Create a multihost enabled pool with HOSTID1
-mmp_pool_create_simple $MMP_POOL $MMP_DIR
+mmp_pool_create_simple $MMP_POOL $MMP_DIR enriched
 log_must zpool export -F $MMP_POOL
 
 # 2. zhack imports: $HOSTID1 (matching) and $HOSTID1 (matching)

--- a/tests/zfs-tests/tests/functional/mmp/mmp_exported_import.ksh
+++ b/tests/zfs-tests/tests/functional/mmp/mmp_exported_import.ksh
@@ -40,34 +40,34 @@ verify_runnable "both"
 
 function cleanup
 {
-	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+	mmp_pool_destroy $MMP_POOL $MMP_DIR
 	log_must mmp_clear_hostid
 }
 
 log_assert "multihost=on|off activity checks exported pool"
 log_onexit cleanup
 
-# 1. Create a zpool
-log_must mmp_set_hostid $HOSTID1
-log_must zpool create -f $TESTPOOL $DISK
+# 1. Create an enriched zpool (hole, indirect, log, cache, and spare
+#    vdevs) so the activity checks exercise the non-writeable types.
+mmp_pool_create_simple $MMP_POOL $MMP_DIR enriched
 
 # 2. Verify multihost=off and hostids match (no activity check)
 log_note "Verify multihost=off and hostids match (no activity check)"
-log_must zpool set multihost=off $TESTPOOL
+log_must zpool set multihost=off $MMP_POOL
 
 for opt in "" "-f"; do
-	log_must zpool export $TESTPOOL
-	log_must import_no_activity_check $TESTPOOL $opt
+	log_must zpool export $MMP_POOL
+	log_must import_no_activity_check $MMP_POOL "-d $MMP_DIR $opt"
 done
 
 # 3. Verify multihost=off and hostids differ (no activity check)
 log_note "Verify multihost=off and hostids differ (no activity check)"
 for opt in "" "-f"; do
-	log_must mmp_pool_set_hostid $TESTPOOL $HOSTID1
-	log_must zpool export $TESTPOOL
+	log_must mmp_pool_set_hostid $MMP_POOL $HOSTID1
+	log_must zpool export $MMP_POOL
 	log_must mmp_clear_hostid
 	log_must mmp_set_hostid $HOSTID2
-	log_must import_no_activity_check $TESTPOOL $opt
+	log_must import_no_activity_check $MMP_POOL "-d $MMP_DIR $opt"
 done
 
 # 4. Verify multihost=off and hostid zero allowed (no activity check)
@@ -75,39 +75,39 @@ log_note "Verify multihost=off and hostid zero allowed (no activity check)"
 log_must mmp_clear_hostid
 
 for opt in "" "-f"; do
-	log_must zpool export $TESTPOOL
-	log_must import_no_activity_check $TESTPOOL $opt
+	log_must zpool export $MMP_POOL
+	log_must import_no_activity_check $MMP_POOL "-d $MMP_DIR $opt"
 done
 
 # 5. Verify multihost=on and hostids match (no activity check)
 log_note "Verify multihost=on and hostids match (no activity check)"
-log_must mmp_pool_set_hostid $TESTPOOL $HOSTID1
-log_must zpool set multihost=on $TESTPOOL
+log_must mmp_pool_set_hostid $MMP_POOL $HOSTID1
+log_must zpool set multihost=on $MMP_POOL
 
 for opt in "" "-f"; do
-	log_must zpool export $TESTPOOL
-	log_must import_no_activity_check $TESTPOOL $opt
+	log_must zpool export $MMP_POOL
+	log_must import_no_activity_check $MMP_POOL "-d $MMP_DIR $opt"
 done
 
 # 6. Verify multihost=on and hostids differ (activity check)
 log_note "Verify multihost=on and hostids differ (activity check)"
 for opt in "" "-f"; do
-	log_must mmp_pool_set_hostid $TESTPOOL $HOSTID1
-	log_must zpool export $TESTPOOL
+	log_must mmp_pool_set_hostid $MMP_POOL $HOSTID1
+	log_must zpool export $MMP_POOL
 	log_must mmp_clear_hostid
 	log_must mmp_set_hostid $HOSTID2
-	log_must import_activity_check $TESTPOOL $opt
+	log_must import_activity_check $MMP_POOL "-d $MMP_DIR $opt"
 done
 
 # 7. Verify multihost=on and hostid zero fails (no activity check)
 log_note "Verify multihost=on and hostid zero fails (no activity check)"
-log_must zpool export $TESTPOOL
+log_must zpool export $MMP_POOL
 log_must mmp_clear_hostid
 
 for opt in "" "-f"; do
 	MMP_IMPORTED_MSG="Set a unique system hostid"
-	log_must check_pool_import $TESTPOOL "" "action" "$MMP_IMPORTED_MSG"
-	log_mustnot import_no_activity_check $TESTPOOL $opt
+	log_must check_pool_import $MMP_POOL "-d $MMP_DIR" "action" "$MMP_IMPORTED_MSG"
+	log_mustnot import_no_activity_check $MMP_POOL "-d $MMP_DIR $opt"
 done
 
 log_pass "multihost=on|off exported pool activity checks passed"

--- a/tests/zfs-tests/tests/functional/mmp/mmp_inactive_import.ksh
+++ b/tests/zfs-tests/tests/functional/mmp/mmp_inactive_import.ksh
@@ -42,7 +42,7 @@ verify_runnable "both"
 
 function cleanup
 {
-	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+	mmp_pool_destroy $MMP_POOL $MMP_DIR
 	log_must mmp_clear_hostid
 	log_must set_tunable64 MULTIHOST_INTERVAL $MMP_INTERVAL_DEFAULT
 }
@@ -50,63 +50,63 @@ function cleanup
 log_assert "multihost=on|off inactive pool activity checks"
 log_onexit cleanup
 
-# 1. Create a zpool
-log_must mmp_set_hostid $HOSTID1
-log_must zpool create -f $TESTPOOL $DISK
+# 1. Create an enriched zpool (hole, indirect, log, cache, and spare
+#    vdevs) so the activity checks exercise the non-writeable types.
+mmp_pool_create_simple $MMP_POOL $MMP_DIR enriched
 
 # 2. Verify multihost=off and hostids match (no activity check)
 log_note "Verify multihost=off and hostids match (no activity check)"
-log_must zpool set multihost=off $TESTPOOL
+log_must zpool set multihost=off $MMP_POOL
 
 for opt in "" "-f"; do
-	log_must zpool export -F $TESTPOOL
-	log_must import_no_activity_check $TESTPOOL $opt
+	log_must zpool export -F $MMP_POOL
+	log_must import_no_activity_check $MMP_POOL "-d $MMP_DIR $opt"
 done
 
 # 3. Verify multihost=off and hostids differ (no activity check)
 log_note "Verify multihost=off and hostids differ (no activity check)"
-log_must zpool export -F $TESTPOOL
+log_must zpool export -F $MMP_POOL
 log_must mmp_clear_hostid
 log_must mmp_set_hostid $HOSTID2
-log_mustnot import_no_activity_check $TESTPOOL ""
-log_must import_no_activity_check $TESTPOOL "-f"
+log_mustnot import_no_activity_check $MMP_POOL "-d $MMP_DIR"
+log_must import_no_activity_check $MMP_POOL "-d $MMP_DIR -f"
 
 # 4. Verify multihost=off and hostid zero allowed (no activity check)
 log_note "Verify multihost=off and hostid zero allowed (no activity check)"
-log_must zpool export -F $TESTPOOL
+log_must zpool export -F $MMP_POOL
 log_must mmp_clear_hostid
-log_mustnot import_no_activity_check $TESTPOOL ""
-log_must import_no_activity_check $TESTPOOL "-f"
+log_mustnot import_no_activity_check $MMP_POOL "-d $MMP_DIR"
+log_must import_no_activity_check $MMP_POOL "-d $MMP_DIR -f"
 
 # 5. Verify multihost=on and hostids match (activity check)
 log_note "Verify multihost=on and hostids match (activity check)"
-log_must mmp_pool_set_hostid $TESTPOOL $HOSTID1
-log_must zpool set multihost=on $TESTPOOL
+log_must mmp_pool_set_hostid $MMP_POOL $HOSTID1
+log_must zpool set multihost=on $MMP_POOL
 
 for opt in "" "-f"; do
-	log_must zpool export -F $TESTPOOL
-	log_must import_activity_check $TESTPOOL $opt
+	log_must zpool export -F $MMP_POOL
+	log_must import_activity_check $MMP_POOL "-d $MMP_DIR $opt"
 done
 
 # 6. Verify multihost=on and hostids differ (activity check)
 log_note "Verify multihost=on and hostids differ (activity check)"
-log_must zpool export -F $TESTPOOL
+log_must zpool export -F $MMP_POOL
 log_must mmp_clear_hostid
 log_must mmp_set_hostid $HOSTID2
-log_mustnot import_activity_check $TESTPOOL ""
-log_must import_activity_check $TESTPOOL "-f"
+log_mustnot import_activity_check $MMP_POOL "-d $MMP_DIR"
+log_must import_activity_check $MMP_POOL "-d $MMP_DIR -f"
 
 # 7. Verify mmp_write and mmp_fail are set correctly
 log_note "Verify mmp_write and mmp_fail are set correctly"
-log_must zpool export -F $TESTPOOL
-log_must verify_mmp_write_fail_present ${DISK[0]}
+log_must zpool export -F $MMP_POOL
+log_must verify_mmp_write_fail_present $MMP_DIR/vdev1
 
 # 8. Verify multihost=on and hostid zero fails (no activity check)
 log_note "Verify multihost=on and hostid zero fails (no activity check)"
 log_must mmp_clear_hostid
 MMP_IMPORTED_MSG="Set a unique system hostid"
-log_must check_pool_import $TESTPOOL "-f" "action" "$MMP_IMPORTED_MSG"
-log_mustnot import_no_activity_check $TESTPOOL "-f"
+log_must check_pool_import $MMP_POOL "-d $MMP_DIR -f" "action" "$MMP_IMPORTED_MSG"
+log_mustnot import_no_activity_check $MMP_POOL "-d $MMP_DIR -f"
 
 # 9. Verify activity check duration based on mmp_write and mmp_fail
 # Specify a short test via tunables but import pool imported while
@@ -115,6 +115,6 @@ log_note "Verify activity check duration based on mmp_write and mmp_fail"
 log_must set_tunable64 MULTIHOST_INTERVAL $MMP_INTERVAL_MIN
 log_must mmp_clear_hostid
 log_must mmp_set_hostid $HOSTID1
-log_must import_activity_check $TESTPOOL "-f"
+log_must import_activity_check $MMP_POOL "-d $MMP_DIR -f"
 
 log_pass "multihost=on|off inactive pool activity checks passed"


### PR DESCRIPTION
### Motivation and Context

Closes #18823.

Since c710f8792 ("mmp: claim sequence id before final import") a pool with
`multihost=on` cannot be imported on a second host if a log device has been
removed at some point. The import fails with

```
cannot import 'p': pool is imported on host '<unknown>' (hostid=0).
```

even though the pool was cleanly exported. The trigger is the hole that
`zpool remove` leaves behind in the vdev config. Pools that never had a log
device are unaffected, which is why this went unnoticed. 2.4.0 is fine, the
regression is present from 2.4.1 onwards.

### Description

`mmp_claim_uberblock_sync()` walks the vdev tree accumulating `req_writes`,
and the new activity check then requires that many good writes before it will
allow the import. The walk skips log, spare and l2cache vdevs:

```c
if (cvd->vdev_islog || cvd->vdev_isspare || cvd->vdev_isl2cache)
        continue;
```

A hole is a top level vdev and is none of those types, so it survives the
filter and contributes one to `req_writes`. It is not writeable, so the
function returns at the `vdev_writeable()` check before submitting any write
and `good_writes` never accounts for it. `good_writes` can therefore never
reach `req_writes`, the activity check concludes the pool is active on another
host, and the import is refused. The reported hostid is zero because a hole
carries no label to read one from.

This skips holes alongside the other vdev types. `vdev_label.c` already guards
`vdev_ishole` in the equivalent places, so this follows existing practice
rather than introducing a new convention.

I am not attached to this particular shape of fix. Deriving `req_writes` from
writeable leaves instead of filtering by vdev type would also work and may be
more robust against a similar omission later.

### How Has This Been Tested?

Ubuntu 24.04, kernel 6.8, `--enable-debug`, QEMU with file vdevs. A second host
is simulated by changing the hostid between export and import.

Reproduction, which fails without this change and succeeds with it:

```
zpool create -f p mirror d1 d2 mirror d3 d4
zpool set multihost=on p
zpool add p log mirror d5 d6
zpool remove p mirror-2          # leaves type: 'hole' in the config
zpool export p
zgenhostid -f feedface
zpool import -d . p
```

A control that never adds or removes a log imports cleanly either way, which is
what isolates the hole rather than multihost itself.

The same reproduction was used to bisect the regression to c710f8792, with its
parent 96ffe5100 verified good. Each bisect step was built with
`--enable-debug` and checked that the loaded module srcversion matched the
freshly built one.

The `mmp` test group passes with this applied, 17/17, including
`mmp_active_import`, `mmp_concurrent_import` and `mmp_exported_import`, so the
activity check still behaves for the cases it is meant to catch.

`make checkstyle` is clean.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:

- [x] My code follows the OpenZFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have run the ZFS Test Suite with my changes.
- [x] All commit messages are properly formatted and contain Signed-off-by.
