### PR TITLE
zfs: fix stale POSIX ACL cache after rollback

### DIFF
--- a/module/os/linux/zfs/zfs_znode_os.c
+++ b/module/os/linux/zfs/zfs_znode_os.c
@@ -60,6 +60,9 @@
 #include <sys/zfs_sa.h>
 #include <sys/zfs_stat.h>
 #include <linux/mm_compat.h>
+#ifdef CONFIG_FS_POSIX_ACL
+#include <linux/posix_acl.h>
+#endif
 
 #include "zfs_prop.h"
 #include "zfs_comutil.h"
@@ -1210,6 +1213,12 @@ zfs_rezget(znode_t *zp)
 		zp->z_acl_cached = NULL;
 	}
 	mutex_exit(&zp->z_acl_lock);
+
+#ifdef CONFIG_FS_POSIX_ACL
+	/* The VFS cache can still describe the pre-rollback inode. */
+	forget_cached_acl(ZTOI(zp), ACL_TYPE_ACCESS);
+	forget_cached_acl(ZTOI(zp), ACL_TYPE_DEFAULT);
+#endif
 
 	rw_enter(&zp->z_xattr_lock, RW_WRITER);
 	if (zp->z_xattr_cached) {

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -23,7 +23,8 @@ failsafe = callbacks/zfs_failsafe
 tags = ['functional']
 
 [tests/functional/acl/posix:Linux]
-tests = ['posix_001_pos', 'posix_002_pos', 'posix_003_pos', 'posix_004_pos']
+tests = ['posix_001_pos', 'posix_002_pos', 'posix_003_pos',
+    'posix_004_pos', 'posix_005_pos']
 tags = ['functional', 'acl', 'posix']
 
 [tests/functional/acl/posix-sa:Linux]

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -456,6 +456,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/acl/posix/posix_002_pos.ksh \
 	functional/acl/posix/posix_003_pos.ksh \
 	functional/acl/posix/posix_004_pos.ksh \
+	functional/acl/posix/posix_005_pos.ksh \
 	functional/acl/posix-sa/cleanup.ksh \
 	functional/acl/posix-sa/posix_001_pos.ksh \
 	functional/acl/posix-sa/posix_002_pos.ksh \

--- a/tests/zfs-tests/tests/functional/acl/acl_common.kshlib
+++ b/tests/zfs-tests/tests/functional/acl/acl_common.kshlib
@@ -165,6 +165,7 @@ function cleanup
 	if [[ -d $TESTDIR ]]; then
 		cd $TESTDIR
 		rm -rf $TESTDIR/*
+		log_must setfacl -b $TESTDIR
 	fi
 }
 

--- a/tests/zfs-tests/tests/functional/acl/posix/posix_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/acl/posix/posix_004_pos.ksh
@@ -41,6 +41,7 @@
 
 verify_runnable "both"
 log_assert "Verify chown works with POSIX ACLs"
+log_onexit cleanup
 
 log_must setfacl -d -m u:$ZFS_ACL_STAFF1:rwx $TESTDIR
 log_must setfacl -b $TESTDIR

--- a/tests/zfs-tests/tests/functional/acl/posix/posix_005_pos.ksh
+++ b/tests/zfs-tests/tests/functional/acl/posix/posix_005_pos.ksh
@@ -1,0 +1,71 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the License at usr/src/OPENSOLARIS.LICENSE.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+#
+# CDDL HEADER END
+#
+#
+# DESCRIPTION:
+#	Verify that online rollback invalidates cached POSIX ACLs.
+#
+# STRATEGY:
+#	1. Snapshot a file whose group mode bit requires an ACL check, but where
+#	   the test user has no access.
+#	2. Grant the test user read access so the VFS caches the newer ACL.
+#	3. Keep the inode active over rollback, then verify the test user cannot
+#	   read the recovered file without dropping inode or page caches.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/acl/acl_common.kshlib
+
+verify_runnable "both"
+log_assert "Online rollback invalidates cached POSIX ACLs"
+
+typeset file=$TESTDIR/posix-acl-rollback
+typeset snap=$TESTPOOL/$TESTFS@posix-acl-rollback
+typeset user=$ZFS_ACL_STAFF1
+
+function cleanup
+{
+	snapexists $snap && destroy_dataset $snap -f
+	rm -f $file
+}
+
+log_onexit cleanup
+
+log_must touch $file
+# Keep a group read bit so generic_permission() consults a cached POSIX ACL.
+# The test user is not in root's group, so this still denies the initial read.
+log_must chmod 640 $file
+log_mustnot user_run $user cat $file
+log_must zfs snapshot $snap
+
+# setfacl updates the VFS ACL cache before rollback.
+log_must setfacl -m u:$user:r-- $file
+log_must user_run $user cat $file
+
+# Online rollback shrinks the dcache.  Hold the inode alive so the following
+# pathname lookup reuses its VFS ACL cache instead of allocating a new inode.
+log_must eval "exec 9< $file"
+log_must zfs rollback $snap
+log_mustnot user_run $user cat $file
+log_must eval "exec 9>&-"
+
+log_pass "Online rollback invalidates cached POSIX ACLs"


### PR DESCRIPTION
 ### Motivation and Context

 Online rollback clears the OpenZFS ACL cache but can leave the Linux
 VFS POSIX ACL cache attached to a live inode. A later non-root
 permission check can then use an ACL added after the rollback target.

 ### Description

 Invalidate the VFS access and default POSIX ACL caches from zfs_rezget().
 Add a regression test which keeps the inode active across online rollback
 and checks recovered access as a non-root user.

 ### How Has This Been Tested?

 - The new posix_005 test fails on a baseline module: the named user can
   still read the file after rollback.
 - With this fix, ZTS setup / posix_005 / cleanup pass: 3/3 PASS.
 - git diff --check passed.

### Types of Changes
- [x] Bug fix
- [x] Quality assurance