### PR TITLE
cstyle: better tolerance for struct literals

### DIFF
--- a/lib/libefi/rdwr_efi.c
+++ b/lib/libefi/rdwr_efi.c
@@ -410,8 +410,8 @@ efi_alloc_and_read(int fd, struct dk_gpt **vtoc)
 
 	/* figure out the number of entries that would fit into 16K */
 	nparts = EFI_MIN_ARRAY_SIZE / sizeof (efi_gpe_t);
-	length = (int) sizeof (struct dk_gpt) +
-	    (int) sizeof (struct dk_part) * (nparts - 1);
+	length = (int)(sizeof (struct dk_gpt)) +
+	    (int)(sizeof (struct dk_part)) * (nparts - 1);
 	vptr = calloc(1, length);
 
 	if (vptr == NULL)
@@ -422,8 +422,8 @@ efi_alloc_and_read(int fd, struct dk_gpt **vtoc)
 
 	if ((rval == VT_EINVAL) && vptr->efi_nparts > nparts) {
 		void *tmp;
-		length = (int) sizeof (struct dk_gpt) +
-		    (int) sizeof (struct dk_part) * (vptr->efi_nparts - 1);
+		length = (int)(sizeof (struct dk_gpt)) +
+		    (int)(sizeof (struct dk_part)) * (vptr->efi_nparts - 1);
 		if ((tmp = realloc(vptr, length)) == NULL) {
 			/* cppcheck-suppress doubleFree */
 			free(vptr);
@@ -695,7 +695,7 @@ efi_read(int fd, struct dk_gpt *vtoc)
 	if (NBLOCKS(vtoc->efi_nparts, disk_info.dki_lbsize) < 34) {
 		label_len = EFI_MIN_ARRAY_SIZE + disk_info.dki_lbsize;
 	} else {
-		label_len = vtoc->efi_nparts * (int) sizeof (efi_gpe_t) +
+		label_len = vtoc->efi_nparts * (int)(sizeof (efi_gpe_t)) +
 		    disk_info.dki_lbsize;
 		if (label_len % disk_info.dki_lbsize) {
 			/* pad to physical sector size */

--- a/scripts/cstyle.pl
+++ b/scripts/cstyle.pl
@@ -97,6 +97,9 @@ $hdr_comment_start = qr/^\s*\/\*$/;
 my $typename = '(int|char|short|long|unsigned|float|double' .
     '|\w+_t|struct\s+\w+|union\s+\w+|FILE)';
 
+# cast or compound-literal type, e.g. "(foo_t *)"
+my $cast = qr/\($typename(?: \*+)?\)/;
+
 # mapping of old types to POSIX compatible types
 my %old2posix = (
 	'unchar' => 'uchar_t',
@@ -683,12 +686,14 @@ line: while (<$filehandle>) {
 	}
 	if ($picky) {
 		# try to detect spaces after casts, but allow (e.g.)
-		# "sizeof (int) + 1", "void (*funcptr)(int) = foo;", and
-		# "int foo(int) __NORETURN;"
-		if ((/^\($typename( \*+)?\)\s/o ||
-		    /\W\($typename( \*+)?\)\s/o) &&
-		    !/sizeof\s*\($typename( \*)?\)\s/o &&
-		    !/\($typename( \*+)?\)\s+=[^=]/o) {
+		# "sizeof (int) + 1", "void (*funcptr)(int) = foo;",
+		# "int foo(int) __NORETURN;", and "(foo_t) { ... }"
+		#
+		# sizeof (type) is not a cast; remove it so it can't mask
+		# a real cast elsewhere on the line.
+		my $tmp = $_;
+		$tmp =~ s/\bsizeof\s*$cast/sizeof/g;
+		if ($tmp =~ /(?:^|\W)$cast(?>\s+)(?!\{|=[^=])/) {
 			err("space after cast");
 		}
 		if (/\b$typename\s*\*\s/o &&
@@ -801,12 +806,18 @@ process_indent($)
 	my $case = 'case\b[^:]*$';
 
 	# skip over enumerations, array definitions, initializers, etc.
-	if ($cont_off <= 0 && !/^\s*$special/ &&
-	    (/(?:(?:\b(?:enum|struct|union)\s*[^\{]*)|(?:\s+=\s*))\{/ ||
-	    (/^\s*\{/ && $prev =~ /=\s*(?:\/\*.*\*\/\s*)*$/))) {
-		$cont_in = 0;
-		$cont_off = tr/{/{/ - tr/}/}/;
-		return;
+	if ($cont_off <= 0 && !/^\s*$special/) {
+		my $aggregate = /\b(?:enum|struct|union)\s*[^{]*\{/;
+		my $initializer = /\s+=\s*(?:$cast\s*)?\{/;
+		# "= {" split across lines, "=" possibly trailed by comments
+		my $split_init = /^\s*\{/ &&
+		    $prev =~ /=\s*(?:$cast\s*)?(?:\/\*.*\*\/\s*)?$/;
+
+		if ($aggregate || $initializer || $split_init) {
+			$cont_in = 0;
+			$cont_off = tr/{/{/ - tr/}/}/;
+			return;
+		}
 	}
 	if ($cont_off) {
 		$cont_off += tr/{/{/ - tr/}/}/;


### PR DESCRIPTION
`cstyle.pl` currently doesn't have much patience for code such as:

```
*myvar = (mystruct_t) {
	.ms_field = 42,
	.ms_other_field = "chow time"
};
```

The first line is a Catch-22. If there's a space before the curly brace, then it's an illegal cast because of the trailing space. If there isn't a space, then it's an illegal curly brace without a preceding space.

Either way, tagging the first line as `/* CSTYLED */` gets you nowhere because `cstyle.pl` doesn't understand the structure. It sees the fields as continuation lines and complains about the indentation.

This PR makes three changes:

- It suppresses both types of first-line warnings, allowing `(mystruct_t) {` with or without a space.
- It adds first lines of this type to the patterns recognized as introducing blocks of code-indented (rather than continuation-indented) content.
- It modifies a few clauses in `lib/libefi/rdwr_efi.c` that used to squeak through `cstyle.pl` but are now (correctly?) detected. These are of the form `(int) sizeof (type_t)`. I've changed these to `(int)(sizeof (type_t))`. Easy to reverse if the original form is in fact preferred.

If it's preferred to either require or forbid a space in `(mystruct_t) {', that's also easily fixed.

### Motivation and Context
As far as I can tell, use of this type of transient structure isn't frowned upon in the ZFS codebase. But the current `cstyle` checks push you toward creating an intermediate struct instead. For example, the existing `cstyle` is fine with this:

```
mystruct_t temp_struct = {
	.ms_field = 42,
	.ms_other_field = "chow time"
};
*myvar = temp_struct; 
```

This looks potentially somewhat less efficient, but in fact Clang -O2 generates the same code either way if the field values are not known at compile time. It just looks a little clunkier in code.

### How Has This Been Tested?
The modified version accepts the targeted code and does not raise any spurious warnings when checking the rest of the codebase. The changes use `cstyle`'s existing `$typename` regex.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
