### PR TITLE
zpool export: return EBUSY when zvol minors are in use

### DIFF
--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -7761,10 +7761,7 @@ spa_export_common(const char *pool, int new_state, nvlist_t **oldconfig,
 	spa_condense_debug_cancel(spa);
 #endif
 	spa_async_suspend(spa);
-	if (spa->spa_zvol_taskq) {
-		zvol_remove_minors(spa, spa_name(spa), B_TRUE);
-		taskq_wait(spa->spa_zvol_taskq);
-	}
+
 	spa_namespace_enter(FTAG);
 	spa->spa_export_thread = curthread;
 	spa_close(spa, FTAG);
@@ -7801,6 +7798,11 @@ spa_export_common(const char *pool, int new_state, nvlist_t **oldconfig,
 	 * notice the spa->spa_export_thread and wait until we signal
 	 * that we are finshed.
 	 */
+
+	if (spa->spa_zvol_taskq) {
+		zvol_remove_minors(spa, spa_name(spa), B_TRUE);
+		taskq_wait(spa->spa_zvol_taskq);
+	}
 
 	if (spa->spa_sync_on) {
 		vdev_t *rvd = spa->spa_root_vdev;

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -1309,6 +1309,13 @@ zvol_first_open(zvol_state_t *zv, boolean_t readonly)
 	if (error) {
 		dmu_objset_disown(os, 1, zv);
 		zv->zv_objset = NULL;
+	} else {
+		/*
+		 * Take a hold on the spa so that spa_export_common() will
+		 * return EBUSY while the zvol block device is open, just
+		 * as it does for mounted datasets.
+		 */
+		spa_open_ref(dmu_objset_spa(os), zv);
 	}
 
 	return (error);
@@ -1323,10 +1330,14 @@ zvol_last_close(zvol_state_t *zv)
 	if (zv->zv_flags & ZVOL_REMOVING)
 		cv_broadcast(&zv->zv_removing_cv);
 
+	spa_t *spa = dmu_objset_spa(zv->zv_objset);
+
 	zvol_shutdown_zv(zv);
 
 	dmu_objset_disown(zv->zv_objset, 1, zv);
 	zv->zv_objset = NULL;
+
+	spa_close(spa, zv);
 }
 
 typedef struct minors_job {

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -463,7 +463,7 @@ tags = ['functional', 'cli_root', 'zpool_events']
 [tests/functional/cli_root/zpool_export]
 tests = ['zpool_export_001_pos', 'zpool_export_002_pos',
     'zpool_export_003_neg', 'zpool_export_004_pos',
-    'zpool_export_parallel_pos', 'zpool_export_parallel_admin']
+    'zpool_export_005_neg', 'zpool_export_parallel_pos', 'zpool_export_parallel_admin']
 tags = ['functional', 'cli_root', 'zpool_export']
 
 [tests/functional/cli_root/zpool_get]

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1191,6 +1191,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zpool_export/zpool_export_002_pos.ksh \
 	functional/cli_root/zpool_export/zpool_export_003_neg.ksh \
 	functional/cli_root/zpool_export/zpool_export_004_pos.ksh \
+	functional/cli_root/zpool_export/zpool_export_005_neg.ksh \
 	functional/cli_root/zpool_export/zpool_export_parallel_admin.ksh \
 	functional/cli_root/zpool_export/zpool_export_parallel_pos.ksh \
 	functional/cli_root/zpool_get/cleanup.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_005_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_export/zpool_export_005_neg.ksh
@@ -1,0 +1,89 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2025 by Heonje LEE. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_export/zpool_export.kshlib
+
+#
+# DESCRIPTION:
+#	Exporting a pool with a mounted zvol block device must fail with
+#	EBUSY rather than hanging the system in an uninterruptible sleep.
+#	This mirrors the behavior already provided for mounted ZFS
+#	filesystems (see zpool_export_002_pos.ksh).
+#
+# STRATEGY:
+#	1. Create a pool with a zvol.
+#	2. Format and mount the zvol block device.
+#	3. Attempt to export the pool -- must fail (EBUSY).
+#	4. Unmount the zvol.
+#	5. Export should now succeed.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	ismounted $mntpnt $NEWFS_DEFAULT_FS && log_must umount $mntpnt
+	[[ -d $mntpnt ]] && log_must rmdir $mntpnt
+	datasetexists $TESTPOOL1/vol && log_must zfs destroy $TESTPOOL1/vol
+	poolexists $TESTPOOL1 && destroy_pool $TESTPOOL1
+	[[ -f $vdev ]] && log_must rm -f $vdev
+	zpool_export_cleanup
+}
+
+mntpnt=$TESTDIR0/zvol_export_mnt
+vdev=$TESTDIR0/zvol_export_vdev
+
+log_onexit cleanup
+
+log_assert "Exporting a pool with a mounted zvol returns EBUSY"
+
+log_must mkdir -p $TESTDIR0
+log_must truncate -s $MINVDEVSIZE $vdev
+
+# 1. Create pool + zvol
+log_must zpool create $TESTPOOL1 $vdev
+log_must zfs create -V 100M $TESTPOOL1/vol
+block_device_wait ${ZVOL_DEVDIR}/$TESTPOOL1/vol
+
+# 2. Format and mount the zvol block device
+log_must eval "new_fs ${ZVOL_RDEVDIR}/$TESTPOOL1/vol >/dev/null 2>&1"
+log_must mkdir -p $mntpnt
+log_must mount ${ZVOL_DEVDIR}/$TESTPOOL1/vol $mntpnt
+
+# 3. Export must fail with EBUSY (not hang)
+log_mustnot zpool export $TESTPOOL1
+log_must poolexists $TESTPOOL1
+
+# 4. Unmount the zvol
+log_must umount $mntpnt
+
+# 5. Export should now succeed
+log_must zpool export $TESTPOOL1
+log_mustnot poolexists $TESTPOOL1
+
+log_pass "Export with mounted zvol correctly returned EBUSY"


### PR DESCRIPTION
### Motivation and Context

Exporting a pool that contains a mounted zvol block device causes `zpool export`
to enter an uninterruptible D-state sleep. `zvol_remove_minors_impl()` blocks
indefinitely on `cv_wait()` because the zvol's open count never reaches zero
while the block device is held open by the OS (ext4, xfs, etc.). The only
recovery is a system reboot.

In contrast, exporting a pool with a mounted ZFS dataset correctly returns
`EBUSY` (verified by `zpool_export_002_pos.ksh`). The same protection did not
exist for zvols.

### Description

Add `zvol_minors_in_use(spa_t *spa)`, a non-blocking function that checks
whether any zvol minor for the pool has `zv_open_count > 0`. Call it in
`spa_export_common()` before `zvol_remove_minors()`. If any minor is in use,
return `EBUSY` immediately.

The existing `zvol_remove_minors_impl()` blocking logic is unchanged. It still
correctly handles brief open/close races. The new check only short-circuits
the permanent-mount case.

### How Has This Been Tested?

New test `zpool_export_005_neg.ksh` mirrors `002_pos.ksh` for zvol block
devices: creates a zvol, formats and mounts it, verifies export fails with
`EBUSY`, then unmounts and verifies export succeeds.

Manually tested on Rocky Linux 8.10 (kernel 4.18.0-553), OpenZFS master:
`zpool export` and `zpool destroy` both return `EBUSY` with a mounted zvol,
and succeed after unmounting.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).