### PR TITLE
Fix double free when cloning a block with a pending free

### DIFF
--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -2828,6 +2828,44 @@ dmu_read_l0_bps(objset_t *os, uint64_t object, uint64_t offset, uint64_t length,
 			bp = db->db_blkptr;
 		}
 
+		/*
+		 * A block with a pending free (a truncate or hole
+		 * punch not yet synced) must not be cloned: the clone
+		 * would add a BRT reference to a block about to be
+		 * freed, so the pending clone would apply onto an
+		 * already-freed DVA and double free it.  Report
+		 * EAGAIN and let the caller retry once the free
+		 * syncs (the block then reads as a hole).
+		 *
+		 * A hole (or absent BP) has nothing to free and is
+		 * cloned as a hole below.  When the head dirty record
+		 * overrode the BP (a clone in this txg) only frees
+		 * recorded after the override count against it;
+		 * earlier frees predate it.  This mirrors
+		 * dbuf_read_hole().
+		 */
+		if (bp != NULL && !BP_IS_HOLE(bp)) {
+			dbuf_dirty_record_t *dr =
+			    list_head(&db->db_dirty_records);
+			boolean_t freed;
+
+			DB_DNODE_ENTER(db);
+			dnode_t *rdn = DB_DNODE(db);
+			if (dr != NULL && dr->dt.dl.dr_brtwrite) {
+				freed = dnode_block_freed_after(rdn,
+				    db->db_blkid, dr->dr_txg);
+			} else {
+				freed = dnode_block_freed(rdn,
+				    db->db_blkid);
+			}
+			DB_DNODE_EXIT(db);
+			if (freed) {
+				mutex_exit(&db->db_mtx);
+				error = SET_ERROR(EAGAIN);
+				goto out;
+			}
+		}
+
 		mutex_exit(&db->db_mtx);
 
 		if (bp == NULL) {

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -2836,24 +2836,38 @@ dmu_read_l0_bps(objset_t *os, uint64_t object, uint64_t offset, uint64_t length,
 			}
 		} else {
 			bp = db->db_blkptr;
+		}
 
-			/*
-			 * A block with a pending free (a
-			 * truncate not yet synced) must not be
-			 * cloned: the clone would add a BRT
-			 * reference to a block about to be freed,
-			 * so the pending clone applies onto an
-			 * already-freed DVA and double frees it.
-			 * Report EAGAIN and let the caller retry
-			 * once the free syncs (the block then
-			 * reads as a hole).  Mirrors the
-			 * dnode_block_freed() check in
-			 * dbuf_read_hole().
-			 */
+		/*
+		 * A block with a pending free (a truncate or hole
+		 * punch not yet synced) must not be cloned: the clone
+		 * would add a BRT reference to a block about to be
+		 * freed, so the pending clone would apply onto an
+		 * already-freed DVA and double free it.  Report
+		 * EAGAIN and let the caller retry once the free
+		 * syncs (the block then reads as a hole).
+		 *
+		 * A hole (or absent BP) has nothing to free and is
+		 * cloned as a hole below.  When the head dirty record
+		 * overrode the BP (a clone in this txg) only frees
+		 * recorded after the override count against it;
+		 * earlier frees predate it.  This mirrors
+		 * dbuf_read_hole().
+		 */
+		if (bp != NULL && !BP_IS_HOLE(bp)) {
+			dbuf_dirty_record_t *dr =
+			    list_head(&db->db_dirty_records);
+			boolean_t freed;
+
 			DB_DNODE_ENTER(db);
 			dnode_t *rdn = DB_DNODE(db);
-			boolean_t freed =
-			    dnode_block_freed(rdn, db->db_blkid);
+			if (dr != NULL && dr->dt.dl.dr_brtwrite) {
+				freed = dnode_block_freed_after(rdn,
+				    db->db_blkid, dr->dr_txg);
+			} else {
+				freed = dnode_block_freed(rdn,
+				    db->db_blkid);
+			}
 			DB_DNODE_EXIT(db);
 			if (freed) {
 				mutex_exit(&db->db_mtx);

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -2836,6 +2836,30 @@ dmu_read_l0_bps(objset_t *os, uint64_t object, uint64_t offset, uint64_t length,
 			}
 		} else {
 			bp = db->db_blkptr;
+
+			/*
+			 * A block with a pending free (a
+			 * truncate not yet synced) must not be
+			 * cloned: the clone would add a BRT
+			 * reference to a block about to be freed,
+			 * so the pending clone applies onto an
+			 * already-freed DVA and double frees it.
+			 * Report EAGAIN and let the caller retry
+			 * once the free syncs (the block then
+			 * reads as a hole).  Mirrors the
+			 * dnode_block_freed() check in
+			 * dbuf_read_hole().
+			 */
+			DB_DNODE_ENTER(db);
+			dnode_t *rdn = DB_DNODE(db);
+			boolean_t freed =
+			    dnode_block_freed(rdn, db->db_blkid);
+			DB_DNODE_EXIT(db);
+			if (freed) {
+				mutex_exit(&db->db_mtx);
+				error = SET_ERROR(EAGAIN);
+				goto out;
+			}
 		}
 
 		mutex_exit(&db->db_mtx);


### PR DESCRIPTION
### Motivation and Context

`generic/733` reliably panics an `--enable-debug` build within a minute: a
BRT-cloned block is double-freed, tripping the metaslab verifier in the
free-bpobj drain (`panic: segment already in tree`, via
`metaslab_check_free` <- `zio_free_sync` <- `dsl_scan_free_block_cb`). On a
release build this silently corrupts the space map, and the damage persists
on disk. Reproduced on unmodified master `d98fa72ca05a`.

Closes #18842

### Description

`dmu_read_l0_bps()` captured a clone's source block pointers from
`db->db_blkptr` without checking `dnode_block_freed()`. A block with a
pending free (a truncate/hole-punch not yet synced) still has a valid BP,
so it could be cloned -- registering a BRT reference to a DVA that is then
returned to the allocator and freed a second time. Deferring the free
doesn't help: the free bpobj drains in the same TXG, before the clone's
`brt_pending_apply()`, so the fix is on the clone side.

Mirror the existing `dbuf_read_hole()` guard: return `EAGAIN` from
`dmu_read_l0_bps()` when the source block has a pending free.
`zfs_clone_range()` already retries on the next TXG, by which point the
block reads as a hole. One file, `module/zfs/dmu.c` (+24).

### How Has This Been Tested?

- `generic/733` on a debug build: panicked within a minute before, clean
  across repeated runs after.
- Full ZFS Test Suite (incl. `block_cloning` / `bclone`) and full fstests
  `-g auto` across single-disk (ashift 9/12), stripe, and raidz1 -- no new
  failures.
- Clone data compares identical, `bclonesaved` correct, scrub clean.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)

### Checklist:
- [x] My code follows the OpenZFS code style requirements.
- [x] I have read the contributing document.
- [x] I have run tests to cover my changes (existing fstests generic/733).
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain Signed-off-by.

