### PR TITLE
Use abd in dbuf and arc_buf to allow buffer sharing

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -2962,10 +2962,10 @@ visit_indirect(spa_t *spa, const dnode_phys_t *dnp,
 		    ZIO_PRIORITY_ASYNC_READ, ZIO_FLAG_CANFAIL, &flags, zb);
 		if (err)
 			return (err);
-		ASSERT(buf->b_data);
+		ASSERT(buf->b_abd);
 
 		/* recursively visit blocks below this */
-		cbp = buf->b_data;
+		cbp = abd_to_buf(buf->b_abd);
 		for (i = 0; i < epb; i++, cbp++) {
 			zbookmark_phys_t czb;
 
@@ -3223,7 +3223,7 @@ dump_bptree(objset_t *os, uint64_t obj, const char *name)
 		return;
 
 	VERIFY3U(0, ==, dmu_bonus_hold(os, obj, FTAG, &db));
-	bt = db->db_data;
+	bt = abd_to_buf(db->db_abd);
 	zdb_nicenum(bt->bt_bytes, bytes, sizeof (bytes));
 	(void) printf("\n    %s: %llu datasets, %s\n",
 	    name, (unsigned long long)(bt->bt_end - bt->bt_begin), bytes);
@@ -4317,7 +4317,7 @@ dump_object(objset_t *os, uint64_t object, int verbosity,
 			if (error)
 				fatal("dmu_bonus_hold(%llu) failed, errno %u",
 				    object, error);
-			bonus = db->db_data;
+			bonus = abd_to_buf(db->db_abd);
 			bsize = db->db_size;
 			dn = DB_DNODE((dmu_buf_impl_t *)db);
 		}
@@ -4917,7 +4917,7 @@ dump_config(spa_t *spa)
 	    spa->spa_config_object, FTAG, &db);
 
 	if (error == 0) {
-		nvsize = *(uint64_t *)db->db_data;
+		nvsize = *(uint64_t *)abd_to_buf(db->db_abd);
 		dmu_buf_rele(db, FTAG);
 
 		(void) printf("\nMOS Configuration:\n");

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -1883,7 +1883,8 @@ ztest_bt_bonus(dmu_buf_t *db)
 	dmu_object_info_from_db(db, &doi);
 	ASSERT3U(doi.doi_bonus_size, <=, db->db_size);
 	ASSERT3U(doi.doi_bonus_size, >=, sizeof (*bt));
-	bt = (void *)((char *)db->db_data + doi.doi_bonus_size - sizeof (*bt));
+	bt = (void *)((char *)abd_to_buf(db->db_abd) + doi.doi_bonus_size -
+	    sizeof (*bt));
 
 	return (bt);
 }
@@ -1907,12 +1908,13 @@ ztest_fill_unused_bonus(dmu_buf_t *db, void *end, uint64_t obj,
     objset_t *os, uint64_t gen)
 {
 	uint64_t *bonusp;
+	uint64_t *start = abd_to_buf(db->db_abd);
 
-	ASSERT(IS_P2ALIGNED((char *)end - (char *)db->db_data, 8));
+	ASSERT(IS_P2ALIGNED((char *)end - (char *)start, 8));
 
-	for (bonusp = db->db_data; bonusp < (uint64_t *)end; bonusp++) {
+	for (bonusp = start; bonusp < (uint64_t *)end; bonusp++) {
 		uint64_t token = ZTEST_BONUS_FILL_TOKEN(obj, dmu_objset_id(os),
-		    gen, bonusp - (uint64_t *)db->db_data);
+		    gen, bonusp - start);
 		*bonusp = token;
 	}
 }
@@ -1926,10 +1928,11 @@ ztest_verify_unused_bonus(dmu_buf_t *db, void *end, uint64_t obj,
     objset_t *os, uint64_t gen)
 {
 	uint64_t *bonusp;
+	uint64_t *start = abd_to_buf(db->db_abd);
 
-	for (bonusp = db->db_data; bonusp < (uint64_t *)end; bonusp++) {
+	for (bonusp = start; bonusp < (uint64_t *)end; bonusp++) {
 		uint64_t token = ZTEST_BONUS_FILL_TOKEN(obj, dmu_objset_id(os),
-		    gen, bonusp - (uint64_t *)db->db_data);
+		    gen, bonusp - start);
 		VERIFY3U(*bonusp, ==, token);
 	}
 }
@@ -2312,7 +2315,7 @@ ztest_replay_write(void *arg1, void *arg2, boolean_t byteswap)
 		dmu_write(os, lr->lr_foid, offset, length, data, tx,
 		    DMU_READ_PREFETCH);
 	} else {
-		memcpy(abuf->b_data, data, length);
+		abd_copy_from_buf(abuf->b_abd, data, length);
 		VERIFY0(dmu_assign_arcbuf_by_dbuf(db, offset, abuf, tx, 0));
 	}
 
@@ -5529,14 +5532,15 @@ ztest_dmu_read_write_zcopy(ztest_ds_t *zd, uint64_t id)
 		for (off = bigoff, j = 0; j < s; j++, off += chunksize) {
 			dmu_buf_t *dbt;
 			if (i != 5 || chunksize < (SPA_MINBLOCKSIZE * 2)) {
-				memcpy(bigbuf_arcbufs[j]->b_data,
+				abd_copy_from_buf(bigbuf_arcbufs[j]->b_abd,
 				    (caddr_t)bigbuf + (off - bigoff),
 				    chunksize);
 			} else {
-				memcpy(bigbuf_arcbufs[2 * j]->b_data,
+				abd_copy_from_buf(bigbuf_arcbufs[2 * j]->b_abd,
 				    (caddr_t)bigbuf + (off - bigoff),
 				    chunksize / 2);
-				memcpy(bigbuf_arcbufs[2 * j + 1]->b_data,
+				abd_copy_from_buf(
+				    bigbuf_arcbufs[2 * j + 1]->b_abd,
 				    (caddr_t)bigbuf + (off - bigoff) +
 				    chunksize / 2,
 				    chunksize / 2);

--- a/include/os/linux/spl/sys/uio.h
+++ b/include/os/linux/spl/sys/uio.h
@@ -98,6 +98,8 @@ typedef struct zfs_uio {
 #define	zfs_uio_soffset(u)		(u)->uio_soffset
 #define	zfs_uio_rlimit_fsize(z, u)	(0)
 #define	zfs_uio_fault_move(p, n, rw, u)	zfs_uiomove((p), (n), (rw), (u))
+#define	zfs_uio_fault_move_abd(p, o, n, rw, u)	\
+	zfs_uiomove_abd((p), (o), (n), (rw), (u))
 
 extern int zfs_uio_prefaultpages(ssize_t, zfs_uio_t *);
 
@@ -209,5 +211,12 @@ zfs_uio_iov_iter_init(zfs_uio_t *uio, struct iov_iter *iter, offset_t offset,
 #define	zfs_user_backed_iov_iter(iter) \
 	(zfs_uio_iov_iter_type((iter)) == ITER_IOVEC)
 #endif
+
+static inline boolean_t
+uio_is_user(zfs_uio_t *uio)
+{
+	return (uio->uio_segflg == UIO_ITER &&
+	    zfs_user_backed_iov_iter(uio->uio_iter));
+}
 
 #endif /* SPL_UIO_H */

--- a/include/sys/abd.h
+++ b/include/sys/abd.h
@@ -118,6 +118,8 @@ void abd_release_ownership_of_buf(abd_t *);
  */
 
 int abd_iterate_func(abd_t *, size_t, size_t, abd_iter_func_t *, void *);
+int abd_iterate_func_impl(abd_t *, size_t, size_t, abd_iter_func_t *, void *,
+    boolean_t);
 int abd_iterate_func2(abd_t *, abd_t *, size_t, size_t, size_t,
     abd_iter_func2_t *, void *);
 void abd_copy_off(abd_t *, abd_t *, size_t, size_t, size_t);

--- a/include/sys/abd_impl.h
+++ b/include/sys/abd_impl.h
@@ -108,6 +108,13 @@ void abd_iter_advance(struct abd_iter *, size_t);
 void abd_iter_map(struct abd_iter *);
 void abd_iter_unmap(struct abd_iter *);
 void abd_iter_page(struct abd_iter *);
+#if defined(__linux__) && defined(_KERNEL)
+void abd_iter_map_impl(struct abd_iter *, boolean_t);
+void abd_iter_unmap_impl(struct abd_iter *, boolean_t);
+#else
+#define	abd_iter_map_impl(aiter, x)	((void)x, abd_iter_map(aiter))
+#define	abd_iter_unmap_impl(aiter, x)	((void)x, abd_iter_unmap(aiter))
+#endif
 
 /*
  * Helper macros

--- a/include/sys/arc.h
+++ b/include/sys/arc.h
@@ -201,7 +201,7 @@ typedef enum arc_buf_flags {
 struct arc_buf {
 	arc_buf_hdr_t		*b_hdr;
 	arc_buf_t		*b_next;
-	void			*b_data;
+	abd_t			*b_abd;
 	arc_buf_flags_t		b_flags;
 };
 

--- a/include/sys/dbuf.h
+++ b/include/sys/dbuf.h
@@ -200,7 +200,7 @@ typedef struct dbuf_dirty_record {
 typedef struct dmu_buf_impl {
 	/*
 	 * The following members are immutable, with the exception of
-	 * db.db_data, which is protected by db_mtx.
+	 * db.db_abd, which is protected by db_mtx.
 	 */
 
 	/* the publicly visible structure */

--- a/include/sys/dbuf.h
+++ b/include/sys/dbuf.h
@@ -347,7 +347,8 @@ uint64_t dbuf_whichblock(const struct dnode *di, const int64_t level,
     const uint64_t offset);
 
 void dbuf_create_bonus(struct dnode *dn);
-int dbuf_spill_set_blksz(dmu_buf_t *db, uint64_t blksz, dmu_tx_t *tx);
+int dbuf_spill_set_blksz(dmu_buf_t *db, uint64_t blksz, boolean_t copy,
+    dmu_tx_t *tx);
 
 void dbuf_rm_spill(struct dnode *dn, dmu_tx_t *tx);
 
@@ -414,7 +415,7 @@ void dbuf_free_range(struct dnode *dn, uint64_t start, uint64_t end,
 void dbuf_evict_range(struct dnode *dn, uint64_t start_blkid,
     uint64_t end_blkid);
 
-void dbuf_new_size(dmu_buf_impl_t *db, int size, dmu_tx_t *tx);
+void dbuf_new_size(dmu_buf_impl_t *db, int size, boolean_t copy, dmu_tx_t *tx);
 
 void dbuf_stats_init(dbuf_hash_table_t *hash);
 void dbuf_stats_destroy(void);

--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -314,6 +314,14 @@ void zap_byteswap(void *buf, size_t size);
 void zfs_oldacl_byteswap(void *buf, size_t size);
 void zfs_acl_byteswap(void *buf, size_t size);
 void zfs_znode_byteswap(void *buf, size_t size);
+void abd_byteswap_uint64_array(abd_t *abd, size_t size);
+void abd_byteswap_uint32_array(abd_t *abd, size_t size);
+void abd_byteswap_uint16_array(abd_t *abd, size_t size);
+void abd_byteswap_uint8_array(abd_t *abd, size_t size);
+void abd_zap_byteswap(abd_t *abd, size_t size);
+void abd_zfs_oldacl_byteswap(abd_t *abd, size_t size);
+void abd_zfs_acl_byteswap(abd_t *abd, size_t size);
+void abd_zfs_znode_byteswap(abd_t *abd, size_t size);
 
 #define	DS_FIND_SNAPSHOTS	(1<<0)
 #define	DS_FIND_CHILDREN	(1<<1)
@@ -366,6 +374,7 @@ int dmu_objset_snapshot_one(const char *fsname, const char *snapname);
 int dmu_objset_find(const char *name, int func(const char *, void *), void *arg,
     int flags);
 void dmu_objset_byteswap(void *buf, size_t size);
+void abd_dmu_objset_byteswap(abd_t *abd, size_t size);
 int dsl_dataset_rename_snapshot(const char *fsname,
     const char *oldsnapname, const char *newsnapname, boolean_t recursive);
 
@@ -373,7 +382,7 @@ typedef struct dmu_buf {
 	uint64_t db_object;		/* object that this buffer is part of */
 	uint64_t db_offset;		/* byte offset in this object */
 	uint64_t db_size;		/* size of buffer in bytes */
-	void *db_data;			/* data in buffer */
+	abd_t *db_abd;			/* data, must be linear for metadata */
 } dmu_buf_t;
 
 /*
@@ -617,7 +626,7 @@ int dmu_spill_hold_existing(dmu_buf_t *bonus, const void *tag, dmu_buf_t **dbp);
  *
  * You must call dmu_buf_read, dmu_buf_will_dirty, or dmu_buf_will_fill
  * on the returned buffer before reading or writing the buffer's
- * db_data.  The comments for those routines describe what particular
+ * db_abd.  The comments for those routines describe what particular
  * operations are valid after calling them.
  *
  * The object number must be a valid, allocated object number.
@@ -818,7 +827,7 @@ void dmu_buf_user_evict_wait(void);
 struct blkptr *dmu_buf_get_blkptr(dmu_buf_t *db);
 
 /*
- * Indicate that you are going to modify the buffer's data (db_data).
+ * Indicate that you are going to modify the buffer's data (db_abd).
  *
  * The transaction (tx) must be assigned to a txg (ie. you've called
  * dmu_tx_assign()).  The buffer's object must be held in the tx
@@ -926,6 +935,8 @@ int dmu_read_by_dnode(dnode_t *dn, uint64_t offset, uint64_t size, void *buf,
     dmu_flags_t flags);
 void dmu_write(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
     const void *buf, dmu_tx_t *tx, dmu_flags_t flags);
+void dmu_write_abd(dnode_t *dn, uint64_t offset, uint64_t size,
+    abd_t *abd, dmu_tx_t *tx, dmu_flags_t flags);
 int dmu_write_by_dnode(dnode_t *dn, uint64_t offset, uint64_t size,
     const void *buf, dmu_tx_t *tx, dmu_flags_t flags);
 void dmu_prealloc(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
@@ -991,6 +1002,7 @@ typedef struct dmu_object_info {
 } dmu_object_info_t;
 
 typedef void (*const arc_byteswap_func_t)(void *buf, size_t size);
+typedef void (*const abd_byteswap_func_t)(abd_t *abd, size_t size);
 
 typedef struct dmu_object_type_info {
 	dmu_object_byteswap_t	ot_byteswap;
@@ -1002,6 +1014,7 @@ typedef struct dmu_object_type_info {
 
 typedef const struct dmu_object_byteswap_info {
 	arc_byteswap_func_t	 ob_func;
+	abd_byteswap_func_t	 ob_abd_func;
 	const char		*ob_name;
 } dmu_object_byteswap_info_t;
 

--- a/include/sys/dmu_impl.h
+++ b/include/sys/dmu_impl.h
@@ -269,7 +269,7 @@ void dmu_object_free_zapified(objset_t *, uint64_t, dmu_tx_t *);
 
 int dmu_write_direct(zio_t *, dmu_buf_impl_t *, abd_t *, dmu_tx_t *);
 int dmu_read_abd(dnode_t *, uint64_t, uint64_t, abd_t *, dmu_flags_t);
-int dmu_write_abd(dnode_t *, uint64_t, uint64_t, abd_t *, dmu_flags_t,
+int dmu_write_abd_direct(dnode_t *, uint64_t, uint64_t, abd_t *, dmu_flags_t,
     dmu_tx_t *);
 #if defined(_KERNEL)
 int dmu_read_uio_direct(dnode_t *, zfs_uio_t *, uint64_t, dmu_flags_t);

--- a/include/sys/dnode.h
+++ b/include/sys/dnode.h
@@ -290,7 +290,7 @@ struct dnode {
 	uint64_t dn_object;
 	struct dmu_buf_impl *dn_dbuf;
 	struct dnode_handle *dn_handle;
-	dnode_phys_t *dn_phys; /* pointer into dn->dn_dbuf->db.db_data */
+	dnode_phys_t *dn_phys; /* pointer into dn->dn_dbuf->db.db_abd */
 
 	/*
 	 * Copies of stuff in dn_phys.  They're valid in the open
@@ -441,6 +441,7 @@ void dnode_reallocate(dnode_t *dn, dmu_object_type_t ot, int blocksize,
 void dnode_free(dnode_t *dn, dmu_tx_t *tx);
 void dnode_byteswap(dnode_phys_t *dnp);
 void dnode_buf_byteswap(void *buf, size_t size);
+void abd_dnode_buf_byteswap(abd_t *abd, size_t size);
 void dnode_verify(dnode_t *dn);
 int dnode_set_nlevels(dnode_t *dn, int nlevels, dmu_tx_t *tx);
 int dnode_set_blksz(dnode_t *dn, uint64_t size, int ibs, dmu_tx_t *tx);

--- a/include/sys/dsl_dataset.h
+++ b/include/sys/dsl_dataset.h
@@ -282,7 +282,7 @@ typedef struct dsl_dataset {
 static inline dsl_dataset_phys_t *
 dsl_dataset_phys(dsl_dataset_t *ds)
 {
-	return ((dsl_dataset_phys_t *)ds->ds_dbuf->db_data);
+	return ((dsl_dataset_phys_t *)abd_to_buf(ds->ds_dbuf->db_abd));
 }
 
 typedef struct dsl_dataset_clone_arg_t {

--- a/include/sys/dsl_dir.h
+++ b/include/sys/dsl_dir.h
@@ -135,7 +135,7 @@ struct dsl_dir {
 static inline dsl_dir_phys_t *
 dsl_dir_phys(dsl_dir_t *dd)
 {
-	return (dd->dd_dbuf->db_data);
+	return (abd_to_buf(dd->dd_dbuf->db_abd));
 }
 
 void dsl_dir_rele(dsl_dir_t *dd, const void *tag);

--- a/include/sys/sa_impl.h
+++ b/include/sys/sa_impl.h
@@ -221,11 +221,10 @@ struct sa_handle {
 };
 
 #define	SA_GET_DB(hdl, type)	\
-	(dmu_buf_impl_t *)((type == SA_BONUS) ? hdl->sa_bonus : hdl->sa_spill)
+	((dmu_buf_impl_t *)((type == SA_BONUS) ? hdl->sa_bonus : hdl->sa_spill))
 
 #define	SA_GET_HDR(hdl, type) \
-	((sa_hdr_phys_t *)((dmu_buf_impl_t *)(SA_GET_DB(hdl, \
-	type))->db.db_data))
+	((sa_hdr_phys_t *)abd_to_buf(SA_GET_DB(hdl, type)->db.db_abd))
 
 #define	SA_IDX_TAB_GET(hdl, type) \
 	(type == SA_BONUS ? hdl->sa_bonus_tab : hdl->sa_spill_tab)

--- a/include/sys/uio_impl.h
+++ b/include/sys/uio_impl.h
@@ -43,8 +43,14 @@
 #include <sys/uio.h>
 #include <sys/sysmacros.h>
 
+struct abd;
+
 extern int zfs_uiomove(void *, size_t, zfs_uio_rw_t, zfs_uio_t *);
 extern int zfs_uiocopy(void *, size_t, zfs_uio_rw_t, zfs_uio_t *, size_t *);
+extern int zfs_uiomove_abd(struct abd *, size_t, size_t, zfs_uio_rw_t,
+    zfs_uio_t *);
+extern int zfs_uiocopy_abd(struct abd *, size_t, size_t, zfs_uio_rw_t,
+    zfs_uio_t *, size_t *);
 extern void zfs_uioskip(zfs_uio_t *, size_t);
 extern void zfs_uio_free_dio_pages(zfs_uio_t *, zfs_uio_rw_t);
 extern int zfs_uio_get_dio_pages_alloc(zfs_uio_t *, zfs_uio_rw_t);

--- a/include/sys/zap_impl.h
+++ b/include/sys/zap_impl.h
@@ -177,13 +177,13 @@ typedef struct zap {
 static inline zap_phys_t *
 zap_f_phys(zap_t *zap)
 {
-	return (zap->zap_dbuf->db_data);
+	return (abd_to_buf(zap->zap_dbuf->db_abd));
 }
 
 static inline mzap_phys_t *
 zap_m_phys(zap_t *zap)
 {
-	return (zap->zap_dbuf->db_data);
+	return (abd_to_buf(zap->zap_dbuf->db_abd));
 }
 
 /*

--- a/include/sys/zap_leaf.h
+++ b/include/sys/zap_leaf.h
@@ -171,7 +171,7 @@ typedef struct zap_leaf {
 static inline zap_leaf_phys_t *
 zap_leaf_phys(zap_leaf_t *l)
 {
-	return (l->l_dbuf->db_data);
+	return (abd_to_buf(l->l_dbuf->db_abd));
 }
 
 typedef struct zap_entry_handle {

--- a/include/sys/zio_checksum.h
+++ b/include/sys/zio_checksum.h
@@ -136,6 +136,9 @@ _SYS_ZIO_CHECKSUM_H zio_abd_checksum_func_t fletcher_4_abd_ops;
 extern zio_checksum_t abd_fletcher_4_native;
 extern zio_checksum_t abd_fletcher_4_byteswap;
 
+/* Fletcher 2 */
+extern zio_checksum_t abd_fletcher_2_native;
+
 extern int zio_checksum_equal(spa_t *, blkptr_t *, enum zio_checksum,
     void *, uint64_t, uint64_t, zio_bad_cksum_t *);
 extern void zio_checksum_compute(zio_t *, enum zio_checksum,

--- a/module/os/freebsd/spl/spl_uio.c
+++ b/module/os/freebsd/spl/spl_uio.c
@@ -67,6 +67,30 @@ zfs_uiomove(void *cp, size_t n, zfs_uio_rw_t dir, zfs_uio_t *uio)
 	return (uiomove(cp, (int)n, GET_UIO_STRUCT(uio)));
 }
 
+struct uiomove_arg {
+	zfs_uio_t *uio;
+	zfs_uio_rw_t rw;
+	int ret;
+};
+
+static int zfs_uiomove_abd_cb(void *buf, size_t size, void *private)
+{
+	struct uiomove_arg *arg = private;
+
+	arg->ret = zfs_uiomove(buf, size, arg->rw, arg->uio);
+
+	return (!!arg->ret);
+}
+
+int
+zfs_uiomove_abd(abd_t *abd, size_t off, size_t n, zfs_uio_rw_t rw,
+    zfs_uio_t *uio)
+{
+	struct uiomove_arg arg = { uio, rw, 0 };
+	(void) abd_iterate_func(abd, off, n, zfs_uiomove_abd_cb, &arg);
+	return (arg.ret);
+}
+
 /*
  * same as zfs_uiomove() but doesn't modify uio structure.
  * return in cbytes how many bytes were copied.
@@ -90,6 +114,32 @@ zfs_uiocopy(void *p, size_t n, zfs_uio_rw_t rw, zfs_uio_t *uio, size_t *cbytes)
 	}
 
 	error = vn_io_fault_uiomove(p, n, uio_clone);
+	*cbytes = zfs_uio_resid(uio) - uio_clone->uio_resid;
+	if (uio_clone != &small_uio_clone)
+		zfs_freeuio(uio_clone);
+	return (error);
+}
+
+int
+zfs_uiocopy_abd(abd_t *abd, size_t off, size_t n, zfs_uio_rw_t rw,
+    zfs_uio_t *uio, size_t *cbytes)
+{
+	struct iovec small_iovec[1];
+	struct uio small_uio_clone;
+	struct uio *uio_clone;
+	int error;
+
+	ASSERT3U(zfs_uio_rw(uio), ==, rw);
+	if (zfs_uio_iovcnt(uio) == 1) {
+		small_uio_clone = *(GET_UIO_STRUCT(uio));
+		small_iovec[0] = *(GET_UIO_STRUCT(uio)->uio_iov);
+		small_uio_clone.uio_iov = small_iovec;
+		uio_clone = &small_uio_clone;
+	} else {
+		uio_clone = cloneuio(GET_UIO_STRUCT(uio));
+	}
+
+	error = zfs_uiomove_abd(abd, off, n, rw, uio_clone);
 	*cbytes = zfs_uio_resid(uio) - uio_clone->uio_resid;
 	if (uio_clone != &small_uio_clone)
 		zfs_freeuio(uio_clone);

--- a/module/os/freebsd/zfs/dmu_os.c
+++ b/module/os/freebsd/zfs/dmu_os.c
@@ -111,8 +111,8 @@ dmu_write_pages(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
 			    db->db_offset + bufoff);
 			thiscpy = MIN(PAGESIZE, tocpy - copied);
 			va = zfs_map_page(*ma, &sf);
-			ASSERT(db->db_data != NULL);
-			memcpy((char *)db->db_data + bufoff, va, thiscpy);
+			ASSERT(db->db_abd != NULL);
+			abd_copy_from_buf_off(db->db_abd, va, bufoff, thiscpy);
 			zfs_unmap_page(sf);
 			ma += 1;
 			bufoff += PAGESIZE;
@@ -182,8 +182,8 @@ dmu_read_pages(objset_t *os, uint64_t object, vm_page_t *ma, int count,
 		ASSERT3U(db->db_size, >, PAGE_SIZE);
 		bufoff = IDX_TO_OFF(m->pindex) % db->db_size;
 		va = zfs_map_page(m, &sf);
-		ASSERT(db->db_data != NULL);
-		memcpy(va, (char *)db->db_data + bufoff, PAGESIZE);
+		ASSERT(db->db_abd != NULL);
+		abd_copy_to_buf_off(va, db->db_abd, bufoff, PAGESIZE);
 		zfs_unmap_page(sf);
 		vm_page_valid(m);
 		if ((m->busy_lock & VPB_BIT_WAITERS) != 0)
@@ -223,8 +223,9 @@ dmu_read_pages(objset_t *os, uint64_t object, vm_page_t *ma, int count,
 		tocpy = MIN(db->db_size - bufoff, PAGESIZE - pgoff);
 		ASSERT3S(tocpy, >=, 0);
 		if (m != bogus_page) {
-			ASSERT(db->db_data != NULL);
-			memcpy(va + pgoff, (char *)db->db_data + bufoff, tocpy);
+			ASSERT(db->db_abd != NULL);
+			abd_copy_to_buf_off(va + pgoff, db->db_abd, bufoff,
+			    tocpy);
 		}
 
 		pgoff += tocpy;
@@ -303,8 +304,8 @@ dmu_read_pages(objset_t *os, uint64_t object, vm_page_t *ma, int count,
 		bufoff = IDX_TO_OFF(m->pindex) % db->db_size;
 		tocpy = MIN(db->db_size - bufoff, PAGESIZE);
 		va = zfs_map_page(m, &sf);
-		ASSERT(db->db_data != NULL);
-		memcpy(va, (char *)db->db_data + bufoff, tocpy);
+		ASSERT(db->db_abd != NULL);
+		abd_copy_to_buf_off(va, db->db_abd, bufoff, tocpy);
 		if (tocpy < PAGESIZE) {
 			ASSERT3S(i, ==, *rahead - 1);
 			ASSERT3U((db->db_size & PAGE_MASK), !=, 0);

--- a/module/os/linux/zfs/abd_os.c
+++ b/module/os/linux/zfs/abd_os.c
@@ -901,7 +901,7 @@ abd_iter_advance(struct abd_iter *aiter, size_t amount)
  * has already exhausted, in which case this does nothing.
  */
 void
-abd_iter_map(struct abd_iter *aiter)
+abd_iter_map_impl(struct abd_iter *aiter, boolean_t nonatomic)
 {
 	void *paddr;
 	size_t offset = 0;
@@ -930,10 +930,22 @@ abd_iter_map(struct abd_iter *aiter)
 			aiter->iter_mapsize = MIN(aiter->iter_mapsize,
 			    PAGE_SIZE - offset);
 		}
-		paddr = zfs_kmap_local(page);
+#ifndef HAVE_KMAP_LOCAL_PAGE
+		if (nonatomic)
+			paddr = zfs_kmap(page);
+		else
+#endif
+			paddr = zfs_kmap_local(page);
+
 	}
 
 	aiter->iter_mapaddr = (char *)paddr + offset;
+}
+
+void
+abd_iter_map(struct abd_iter *aiter)
+{
+	return (abd_iter_map_impl(aiter, B_FALSE));
 }
 
 /*
@@ -941,7 +953,7 @@ abd_iter_map(struct abd_iter *aiter)
  * has already exhausted, in which case this does nothing.
  */
 void
-abd_iter_unmap(struct abd_iter *aiter)
+abd_iter_unmap_impl(struct abd_iter *aiter, boolean_t nonatomic)
 {
 	/* There's nothing left to unmap, so do nothing */
 	if (abd_iter_at_end(aiter))
@@ -955,7 +967,12 @@ abd_iter_unmap(struct abd_iter *aiter)
 			offset &= PAGE_SIZE - 1;
 
 		/* LINTED E_FUNC_SET_NOT_USED */
-		zfs_kunmap_local(aiter->iter_mapaddr - offset);
+#ifndef HAVE_KMAP_LOCAL_PAGE
+		if (nonatomic)
+			paddr = zfs_kunmap(page);
+		else
+#endif
+			zfs_kunmap_local(aiter->iter_mapaddr - offset);
 	}
 
 	ASSERT3P(aiter->iter_mapaddr, !=, NULL);
@@ -963,6 +980,12 @@ abd_iter_unmap(struct abd_iter *aiter)
 
 	aiter->iter_mapaddr = NULL;
 	aiter->iter_mapsize = 0;
+}
+
+void
+abd_iter_unmap(struct abd_iter *aiter)
+{
+	abd_iter_unmap_impl(aiter, B_FALSE);
 }
 
 void

--- a/module/os/linux/zfs/zfs_uio.c
+++ b/module/os/linux/zfs/zfs_uio.c
@@ -49,8 +49,7 @@
 #include <sys/uio_impl.h>
 #include <sys/sysmacros.h>
 #include <sys/string.h>
-#include <sys/zfs_refcount.h>
-#include <sys/zfs_debug.h>
+#include <sys/abd.h>
 #include <linux/kmap_compat.h>
 #include <linux/uaccess.h>
 #include <linux/pagemap.h>
@@ -280,6 +279,32 @@ zfs_uiomove(void *p, size_t n, zfs_uio_rw_t rw, zfs_uio_t *uio)
 }
 EXPORT_SYMBOL(zfs_uiomove);
 
+struct uiomove_arg {
+	zfs_uio_t *uio;
+	zfs_uio_rw_t rw;
+	int ret;
+};
+
+static int zfs_uiomove_abd_cb(void *buf, size_t size, void *private)
+{
+	struct uiomove_arg *arg = private;
+
+	arg->ret = zfs_uiomove(buf, size, arg->rw, arg->uio);
+
+	return (!!arg->ret);
+}
+
+int
+zfs_uiomove_abd(abd_t *abd, size_t off, size_t n, zfs_uio_rw_t rw,
+    zfs_uio_t *uio)
+{
+	struct uiomove_arg arg = { uio, rw, 0 };
+	(void) abd_iterate_func_impl(abd, off, n, zfs_uiomove_abd_cb, &arg,
+	    uio_is_user(uio));
+	return (arg.ret);
+}
+EXPORT_SYMBOL(zfs_uiomove_abd);
+
 /*
  * Fault in the pages of the first n bytes specified by the uio structure.
  * 1 byte in each page is touched and the uio struct is unmodified. Any
@@ -335,6 +360,26 @@ zfs_uiocopy(void *p, size_t n, zfs_uio_rw_t rw, zfs_uio_t *uio, size_t *cbytes)
 	return (ret);
 }
 EXPORT_SYMBOL(zfs_uiocopy);
+
+int
+zfs_uiocopy_abd(abd_t *abd, size_t off, size_t n, zfs_uio_rw_t rw,
+    zfs_uio_t *uio, size_t *cbytes)
+{
+	zfs_uio_t uio_copy;
+	int ret;
+
+	memcpy(&uio_copy, uio, sizeof (zfs_uio_t));
+
+	ret = zfs_uiomove_abd(abd, off, n, rw, &uio_copy);
+
+	*cbytes = uio->uio_resid - uio_copy.uio_resid;
+
+	if (uio->uio_segflg == UIO_ITER)
+		iov_iter_revert(uio->uio_iter, *cbytes);
+
+	return (ret);
+}
+EXPORT_SYMBOL(zfs_uiocopy_abd);
 
 /*
  * Drop the next n chars out of *uio.

--- a/module/os/linux/zfs/zfs_vnops_os.c
+++ b/module/os/linux/zfs/zfs_vnops_os.c
@@ -4287,12 +4287,12 @@ zfs_getpage(struct inode *ip, struct page *pp)
 	 * It is important to hold the rangelock here because it is possible
 	 * a Direct I/O write or block clone might be taking place at the same
 	 * time that a page is being faulted in through filemap_fault(). With
-	 * Direct I/O writes and block cloning db->db_data will be set to NULL
+	 * Direct I/O writes and block cloning db->db_abd will be set to NULL
 	 * with dbuf_clear_data() in dmu_buif_will_clone_or_dio(). If the
 	 * rangelock is not held, then there is a race between faulting in a
 	 * page and writing out a Direct I/O write or block cloning. Without
 	 * the rangelock a NULL pointer dereference can occur in
-	 * dmu_read_impl() for db->db_data during the mempcy operation when
+	 * dmu_read_impl() for db->db_abd during the mempcy operation when
 	 * zfs_fillpage() calls dmu_read().
 	 */
 	zfs_locked_range_t *lr = zfs_rangelock_tryenter(&zp->z_rangelock,

--- a/module/zfs/abd.c
+++ b/module/zfs/abd.c
@@ -794,6 +794,13 @@ int
 abd_iterate_func(abd_t *abd, size_t off, size_t size,
     abd_iter_func_t *func, void *private)
 {
+	return (abd_iterate_func_impl(abd, off, size, func, private, B_FALSE));
+}
+
+int
+abd_iterate_func_impl(abd_t *abd, size_t off, size_t size,
+    abd_iter_func_t *func, void *private, boolean_t nonatomic)
+{
 	struct abd_iter aiter;
 	int ret = 0;
 
@@ -808,14 +815,14 @@ abd_iterate_func(abd_t *abd, size_t off, size_t size,
 	while (size > 0) {
 		IMPLY(abd_is_gang(abd), c_abd != NULL);
 
-		abd_iter_map(&aiter);
+		abd_iter_map_impl(&aiter, nonatomic);
 
 		size_t len = MIN(aiter.iter_mapsize, size);
 		ASSERT3U(len, >, 0);
 
 		ret = func(aiter.iter_mapaddr, len, private);
 
-		abd_iter_unmap(&aiter);
+		abd_iter_unmap_impl(&aiter, nonatomic);
 
 		if (ret != 0)
 			break;

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -194,8 +194,8 @@
  *   | b_pabd    +-+           |b_next     +---->+-----------+
  *   +-----------+ |           |-----------|     |b_next     +-->NULL
  *                 |           |b_comp = T |     +-----------+
- *                 |           |b_data     +-+   |b_comp = F |
- *                 |           +-----------+ |   |b_data     +-+
+ *                 |           |b_abd      +-+   |b_comp = F |
+ *                 |           +-----------+ |   |b_abd      +-+
  *                 +->+------+               |   +-----------+ |
  *        compressed  |      |               |                 |
  *           data     |      |<--------------+                 | uncompressed
@@ -235,8 +235,8 @@
  *                |           |             |b_next   +---->+---------+
  *                |  b_pabd   +-+           |---------|     |b_next   +-->NULL
  *                +-----------+ |           |         |     +---------+
- *                              |           |b_data   +-+   |         |
- *                              |           +---------+ |   |b_data   +-+
+ *                              |           |b_abd    +-+   |         |
+ *                              |           +---------+ |   |b_abd    +-+
  *                              +->+------+             |   +---------+ |
  *                                 |      |             |               |
  *                   uncompressed  |      |             |               |
@@ -907,10 +907,8 @@ enum arc_hdr_alloc_flags {
 
 
 static abd_t *arc_get_data_abd(arc_buf_hdr_t *, uint64_t, const void *, int);
-static void *arc_get_data_buf(arc_buf_hdr_t *, uint64_t, const void *);
 static void arc_get_data_impl(arc_buf_hdr_t *, uint64_t, const void *, int);
 static void arc_free_data_abd(arc_buf_hdr_t *, abd_t *, uint64_t, const void *);
-static void arc_free_data_buf(arc_buf_hdr_t *, void *, uint64_t, const void *);
 static void arc_free_data_impl(arc_buf_hdr_t *hdr, uint64_t size,
     const void *tag);
 static void arc_hdr_free_abd(arc_buf_hdr_t *, boolean_t);
@@ -1420,10 +1418,9 @@ __maybe_unused
 static inline boolean_t
 arc_buf_is_shared(arc_buf_t *buf)
 {
-	boolean_t shared = (buf->b_data != NULL &&
+	boolean_t shared = (buf->b_abd != NULL &&
 	    buf->b_hdr->b_l1hdr.b_pabd != NULL &&
-	    abd_is_linear(buf->b_hdr->b_l1hdr.b_pabd) &&
-	    buf->b_data == abd_to_buf(buf->b_hdr->b_l1hdr.b_pabd));
+	    buf->b_abd == buf->b_hdr->b_l1hdr.b_pabd);
 	IMPLY(shared, HDR_SHARED_DATA(buf->b_hdr));
 	EQUIV(shared, ARC_BUF_SHARED(buf));
 	IMPLY(shared, ARC_BUF_COMPRESSED(buf) || ARC_BUF_LAST(buf));
@@ -1500,7 +1497,7 @@ arc_cksum_verify(arc_buf_t *buf)
 		return;
 	}
 
-	fletcher_2_native(buf->b_data, arc_buf_size(buf), NULL, &zc);
+	abd_fletcher_2_native(buf->b_abd, arc_buf_size(buf), NULL, &zc);
 	if (!ZIO_CHECKSUM_EQUAL(*hdr->b_l1hdr.b_freeze_cksum, zc))
 		panic("buffer modified while frozen!");
 	mutex_exit(&hdr->b_l1hdr.b_freeze_lock);
@@ -1561,7 +1558,7 @@ arc_cksum_compute(arc_buf_t *buf)
 	ASSERT(!ARC_BUF_COMPRESSED(buf));
 	hdr->b_l1hdr.b_freeze_cksum = kmem_alloc(sizeof (zio_cksum_t),
 	    KM_SLEEP);
-	fletcher_2_native(buf->b_data, arc_buf_size(buf), NULL,
+	abd_fletcher_2_native(buf->b_abd, arc_buf_size(buf), NULL,
 	    hdr->b_l1hdr.b_freeze_cksum);
 	mutex_exit(&hdr->b_l1hdr.b_freeze_lock);
 #endif
@@ -1575,6 +1572,13 @@ arc_buf_sigsegv(int sig, siginfo_t *si, void *unused)
 	(void) sig, (void) unused;
 	panic("Got SIGSEGV at address: 0x%lx\n", (long)si->si_addr);
 }
+
+static int
+arc_abd_watch(void *buf, size_t len, void *private)
+{
+	ASSERT0(mprotect(buf, len, *(int *)private));
+	return (0);
+}
 #endif
 
 static void
@@ -1582,8 +1586,9 @@ arc_buf_unwatch(arc_buf_t *buf)
 {
 #ifndef _KERNEL
 	if (arc_watch) {
-		ASSERT0(mprotect(buf->b_data, arc_buf_size(buf),
-		    PROT_READ | PROT_WRITE));
+		int prot = PROT_READ | PROT_WRITE;
+		abd_iterate_func(buf->b_abd, 0, arc_buf_size(buf),
+		    arc_abd_watch, &prot);
 	}
 #else
 	(void) buf;
@@ -1594,9 +1599,11 @@ static void
 arc_buf_watch(arc_buf_t *buf)
 {
 #ifndef _KERNEL
-	if (arc_watch)
-		ASSERT0(mprotect(buf->b_data, arc_buf_size(buf),
-		    PROT_READ));
+	if (arc_watch) {
+		int prot = PROT_READ;
+		abd_iterate_func(buf->b_abd, 0, arc_buf_size(buf),
+		    arc_abd_watch, &prot);
+	}
 #else
 	(void) buf;
 #endif
@@ -1733,7 +1740,7 @@ arc_buf_try_copy_decompressed_data(arc_buf_t *buf)
 	boolean_t copied = B_FALSE;
 
 	ASSERT(HDR_HAS_L1HDR(hdr));
-	ASSERT3P(buf->b_data, !=, NULL);
+	ASSERT3P(buf->b_abd, !=, NULL);
 	ASSERT(!ARC_BUF_COMPRESSED(buf));
 
 	for (arc_buf_t *from = hdr->b_l1hdr.b_buf; from != NULL;
@@ -1744,7 +1751,7 @@ arc_buf_try_copy_decompressed_data(arc_buf_t *buf)
 		}
 
 		if (!ARC_BUF_COMPRESSED(from)) {
-			memcpy(buf->b_data, from->b_data, arc_buf_size(buf));
+			abd_copy(buf->b_abd, from->b_abd, arc_buf_size(buf));
 			copied = B_TRUE;
 			break;
 		}
@@ -2017,7 +2024,7 @@ arc_buf_untransform_in_place(arc_buf_t *buf)
 	ASSERT(HDR_EMPTY_OR_LOCKED(hdr));
 	ASSERT3PF(hdr->b_l1hdr.b_pabd, !=, NULL, "hdr %px buf %px", hdr, buf);
 
-	zio_crypt_copy_dnode_bonus(hdr->b_l1hdr.b_pabd, buf->b_data,
+	zio_crypt_copy_dnode_bonus(hdr->b_l1hdr.b_pabd, abd_to_buf(buf->b_abd),
 	    arc_buf_size(buf));
 	buf->b_flags &= ~ARC_BUF_FLAG_ENCRYPTED;
 	buf->b_flags &= ~ARC_BUF_FLAG_COMPRESSED;
@@ -2049,7 +2056,7 @@ arc_buf_fill(arc_buf_t *buf, spa_t *spa, const zbookmark_phys_t *zb,
 	dmu_object_byteswap_t bswap = hdr->b_l1hdr.b_byteswap;
 	kmutex_t *hash_lock = (flags & ARC_FILL_LOCKED) ? NULL : HDR_LOCK(hdr);
 
-	ASSERT3P(buf->b_data, !=, NULL);
+	ASSERT3P(buf->b_abd, !=, NULL);
 	IMPLY(compressed, hdr_compressed || ARC_BUF_ENCRYPTED(buf));
 	IMPLY(compressed, ARC_BUF_COMPRESSED(buf));
 	IMPLY(encrypted, HDR_ENCRYPTED(hdr));
@@ -2064,7 +2071,7 @@ arc_buf_fill(arc_buf_t *buf, spa_t *spa, const zbookmark_phys_t *zb,
 	 */
 	if (encrypted) {
 		ASSERT(HDR_HAS_RABD(hdr));
-		abd_copy_to_buf(buf->b_data, hdr->b_crypt_hdr.b_rabd,
+		abd_copy(buf->b_abd, hdr->b_crypt_hdr.b_rabd,
 		    HDR_GET_PSIZE(hdr));
 		goto byteswap;
 	}
@@ -2096,7 +2103,7 @@ arc_buf_fill(arc_buf_t *buf, spa_t *spa, const zbookmark_phys_t *zb,
 	 * be decrypted in-place. This is necessary because there may
 	 * be many dnodes pointing into this buffer and there is
 	 * currently no method to synchronize replacing the backing
-	 * b_data buffer and updating all of the pointers. Here we use
+	 * b_abd buffer and updating all of the pointers. Here we use
 	 * the hash lock to ensure there are no races. If the need
 	 * arises for other types to be decrypted in-place, they must
 	 * add handling here as well.
@@ -2126,7 +2133,7 @@ arc_buf_fill(arc_buf_t *buf, spa_t *spa, const zbookmark_phys_t *zb,
 		if (ARC_BUF_SHARED(buf)) {
 			ASSERT(arc_buf_is_shared(buf));
 		} else {
-			abd_copy_to_buf(buf->b_data, hdr->b_l1hdr.b_pabd,
+			abd_copy(buf->b_abd, hdr->b_l1hdr.b_pabd,
 			    arc_buf_size(buf));
 		}
 	} else {
@@ -2141,10 +2148,11 @@ arc_buf_fill(arc_buf_t *buf, spa_t *spa, const zbookmark_phys_t *zb,
 			ASSERTF(ARC_BUF_COMPRESSED(buf),
 			"buf %p was uncompressed", buf);
 
-			/* We need to give the buf its own b_data */
+			/* We need to give the buf its own b_abd */
 			buf->b_flags &= ~ARC_BUF_FLAG_SHARED;
-			buf->b_data =
-			    arc_get_data_buf(hdr, HDR_GET_LSIZE(hdr), buf);
+			buf->b_abd =
+			    arc_get_data_abd(hdr, HDR_GET_LSIZE(hdr), buf,
+			    ARC_HDR_ALLOC_LINEAR);
 			arc_hdr_clear_flags(hdr, ARC_FLAG_SHARED_DATA);
 
 			/* Previously overhead was 0; just add new overhead */
@@ -2152,13 +2160,14 @@ arc_buf_fill(arc_buf_t *buf, spa_t *spa, const zbookmark_phys_t *zb,
 		} else if (ARC_BUF_COMPRESSED(buf)) {
 			ASSERT(!arc_buf_is_shared(buf));
 
-			/* We need to reallocate the buf's b_data */
-			arc_free_data_buf(hdr, buf->b_data, HDR_GET_PSIZE(hdr),
+			/* We need to reallocate the buf's b_abd */
+			arc_free_data_abd(hdr, buf->b_abd, HDR_GET_PSIZE(hdr),
 			    buf);
-			buf->b_data =
-			    arc_get_data_buf(hdr, HDR_GET_LSIZE(hdr), buf);
+			buf->b_abd =
+			    arc_get_data_abd(hdr, HDR_GET_LSIZE(hdr), buf,
+			    ARC_HDR_ALLOC_LINEAR);
 
-			/* We increased the size of b_data; update overhead */
+			/* We increased the size of b_abd; update overhead */
 			ARCSTAT_INCR(arcstat_overhead_size,
 			    HDR_GET_LSIZE(hdr) - HDR_GET_PSIZE(hdr));
 		}
@@ -2178,14 +2187,10 @@ arc_buf_fill(arc_buf_t *buf, spa_t *spa, const zbookmark_phys_t *zb,
 			/* Skip byteswapping and checksumming (already done) */
 			return (0);
 		} else {
-			abd_t dabd;
-			abd_get_from_buf_struct(&dabd, buf->b_data,
-			    HDR_GET_LSIZE(hdr));
 			error = zio_decompress_data(HDR_GET_COMPRESS(hdr),
-			    hdr->b_l1hdr.b_pabd, &dabd,
+			    hdr->b_l1hdr.b_pabd, buf->b_abd,
 			    HDR_GET_PSIZE(hdr), HDR_GET_LSIZE(hdr),
 			    &hdr->b_complevel);
-			abd_free(&dabd);
 
 			/*
 			 * Absent hardware errors or software bugs, this should
@@ -2211,7 +2216,8 @@ byteswap:
 	if (bswap != DMU_BSWAP_NUMFUNCS) {
 		ASSERT(!HDR_SHARED_DATA(hdr));
 		ASSERT3U(bswap, <, DMU_BSWAP_NUMFUNCS);
-		dmu_ot_byteswap[bswap].ob_func(buf->b_data, HDR_GET_LSIZE(hdr));
+		dmu_ot_byteswap[bswap].ob_abd_func(buf->b_abd,
+		    HDR_GET_LSIZE(hdr));
 	}
 
 	/* Compute the hdr's checksum if necessary */
@@ -2726,7 +2732,7 @@ arc_space_return(uint64_t space, arc_space_type_t type)
 }
 
 /*
- * Given a hdr and a buf, returns whether that buf can share its b_data buffer
+ * Given a hdr and a buf, returns whether that buf can share its b_abd buffer
  * with the hdr's b_pabd.
  */
 static boolean_t
@@ -2788,7 +2794,7 @@ arc_buf_alloc_impl(arc_buf_hdr_t *hdr, spa_t *spa, const zbookmark_phys_t *zb,
 
 	buf = *ret = kmem_cache_alloc(buf_cache, KM_PUSHPAGE);
 	buf->b_hdr = hdr;
-	buf->b_data = NULL;
+	buf->b_abd = NULL;
 	buf->b_next = hdr->b_l1hdr.b_buf;
 	buf->b_flags = 0;
 
@@ -2832,29 +2838,35 @@ arc_buf_alloc_impl(arc_buf_hdr_t *hdr, spa_t *spa, const zbookmark_phys_t *zb,
 	 * an arc_write() then the hdr's data buffer will be released when the
 	 * write completes, even though the L2ARC write might still be using it.
 	 * Second, the hdr's ABD must be linear so that the buf's user doesn't
-	 * need to be ABD-aware.  It must be allocated via
-	 * zio_[data_]buf_alloc(), not as a page, because we need to be able
-	 * to abd_release_ownership_of_buf(), which isn't allowed on "linear
-	 * page" buffers because the ABD code needs to handle freeing them
-	 * specially.
+	 * need to be ABD-aware. User data can be shared when non-linear.
 	 */
 	boolean_t can_share = arc_can_share(hdr, buf) &&
 	    !HDR_L2_WRITING(hdr) &&
 	    hdr->b_l1hdr.b_pabd != NULL &&
-	    abd_is_linear(hdr->b_l1hdr.b_pabd) &&
-	    !abd_is_linear_page(hdr->b_l1hdr.b_pabd);
+	    (abd_is_linear(hdr->b_l1hdr.b_pabd) ||
+	    hdr->b_type == ARC_BUFC_DATA);
 
-	/* Set up b_data and sharing */
+	/* Set up b_abd and sharing */
 	if (can_share) {
-		buf->b_data = abd_to_buf(hdr->b_l1hdr.b_pabd);
+		buf->b_abd = hdr->b_l1hdr.b_pabd;
 		buf->b_flags |= ARC_BUF_FLAG_SHARED;
 		arc_hdr_set_flags(hdr, ARC_FLAG_SHARED_DATA);
 	} else {
-		buf->b_data =
-		    arc_get_data_buf(hdr, arc_buf_size(buf), buf);
+		int alloc_flags;
+		/*
+		 * If we are data and !fill, we are most likely from write
+		 * path, allocating scatter will allow use to share buffer
+		 * if compress is off.
+		 */
+		if (hdr->b_type == ARC_BUFC_DATA && !fill)
+			alloc_flags = 0;
+		else
+			alloc_flags = ARC_HDR_ALLOC_LINEAR;
+		buf->b_abd =
+		    arc_get_data_abd(hdr, arc_buf_size(buf), buf, alloc_flags);
 		ARCSTAT_INCR(arcstat_overhead_size, arc_buf_size(buf));
 	}
-	VERIFY3P(buf->b_data, !=, NULL);
+	VERIFY3P(buf->b_abd, !=, NULL);
 
 	hdr->b_l1hdr.b_buf = buf;
 
@@ -2933,7 +2945,7 @@ arc_return_buf(arc_buf_t *buf, const void *tag)
 {
 	arc_buf_hdr_t *hdr = buf->b_hdr;
 
-	ASSERT3P(buf->b_data, !=, NULL);
+	ASSERT3P(buf->b_abd, !=, NULL);
 	ASSERT(HDR_HAS_L1HDR(hdr));
 	(void) zfs_refcount_add(&hdr->b_l1hdr.b_refcnt, tag);
 	(void) zfs_refcount_remove(&hdr->b_l1hdr.b_refcnt, arc_onloan_tag);
@@ -2947,7 +2959,7 @@ arc_loan_inuse_buf(arc_buf_t *buf, const void *tag)
 {
 	arc_buf_hdr_t *hdr = buf->b_hdr;
 
-	ASSERT3P(buf->b_data, !=, NULL);
+	ASSERT3P(buf->b_abd, !=, NULL);
 	ASSERT(HDR_HAS_L1HDR(hdr));
 	(void) zfs_refcount_add(&hdr->b_l1hdr.b_refcnt, arc_onloan_tag);
 	(void) zfs_refcount_remove(&hdr->b_l1hdr.b_refcnt, tag);
@@ -3025,9 +3037,7 @@ arc_share_buf(arc_buf_hdr_t *hdr, arc_buf_t *buf)
 	zfs_refcount_transfer_ownership_many(
 	    &hdr->b_l1hdr.b_state->arcs_size[arc_buf_type(hdr)],
 	    arc_hdr_size(hdr), buf, hdr);
-	hdr->b_l1hdr.b_pabd = abd_get_from_buf(buf->b_data, arc_buf_size(buf));
-	abd_take_ownership_of_buf(hdr->b_l1hdr.b_pabd,
-	    HDR_ISTYPE_METADATA(hdr));
+	hdr->b_l1hdr.b_pabd = buf->b_abd;
 	arc_hdr_set_flags(hdr, ARC_FLAG_SHARED_DATA);
 	buf->b_flags |= ARC_BUF_FLAG_SHARED;
 
@@ -3056,8 +3066,6 @@ arc_unshare_buf(arc_buf_hdr_t *hdr, arc_buf_t *buf)
 	    &hdr->b_l1hdr.b_state->arcs_size[arc_buf_type(hdr)],
 	    arc_hdr_size(hdr), hdr, buf);
 	arc_hdr_clear_flags(hdr, ARC_FLAG_SHARED_DATA);
-	abd_release_ownership_of_buf(hdr->b_l1hdr.b_pabd);
-	abd_free(hdr->b_l1hdr.b_pabd);
 	hdr->b_l1hdr.b_pabd = NULL;
 	buf->b_flags &= ~ARC_BUF_FLAG_SHARED;
 
@@ -3110,7 +3118,7 @@ arc_buf_remove(arc_buf_hdr_t *hdr, arc_buf_t *buf)
 }
 
 /*
- * Free up buf->b_data and pull the arc_buf_t off of the arc_buf_hdr_t's
+ * Free up buf->b_abd and pull the arc_buf_t off of the arc_buf_hdr_t's
  * list and free it.
  */
 static void
@@ -3123,7 +3131,7 @@ arc_buf_destroy_impl(arc_buf_t *buf)
 	 * sharing this with the hdr. If we are sharing it with the hdr, the
 	 * hdr is responsible for doing the free.
 	 */
-	if (buf->b_data != NULL) {
+	if (buf->b_abd != NULL) {
 		/*
 		 * We're about to change the hdr's b_flags. We must either
 		 * hold the hash_lock or be undiscoverable.
@@ -3138,10 +3146,10 @@ arc_buf_destroy_impl(arc_buf_t *buf)
 		} else {
 			ASSERT(!arc_buf_is_shared(buf));
 			uint64_t size = arc_buf_size(buf);
-			arc_free_data_buf(hdr, buf->b_data, size, buf);
+			arc_free_data_abd(hdr, buf->b_abd, size, buf);
 			ARCSTAT_INCR(arcstat_overhead_size, -size);
 		}
-		buf->b_data = NULL;
+		buf->b_abd = NULL;
 
 		/*
 		 * If we have no more encrypted buffers and we've already
@@ -3781,7 +3789,7 @@ arc_buf_destroy(arc_buf_t *buf, const void *tag)
 	ASSERT3P(hdr->b_l1hdr.b_buf, !=, NULL);
 	ASSERT3P(hash_lock, ==, HDR_LOCK(hdr));
 	ASSERT3P(hdr->b_l1hdr.b_state, !=, arc_anon);
-	ASSERT3P(buf->b_data, !=, NULL);
+	ASSERT3P(buf->b_abd, !=, NULL);
 
 	arc_buf_destroy_impl(buf);
 	(void) remove_reference(hdr, tag);
@@ -5170,20 +5178,6 @@ arc_get_data_abd(arc_buf_hdr_t *hdr, uint64_t size, const void *tag,
 		return (abd_alloc(size, type == ARC_BUFC_METADATA));
 }
 
-static void *
-arc_get_data_buf(arc_buf_hdr_t *hdr, uint64_t size, const void *tag)
-{
-	arc_buf_contents_t type = arc_buf_type(hdr);
-
-	arc_get_data_impl(hdr, size, tag, 0);
-	if (type == ARC_BUFC_METADATA) {
-		return (zio_buf_alloc(size));
-	} else {
-		ASSERT(type == ARC_BUFC_DATA);
-		return (zio_data_buf_alloc(size));
-	}
-}
-
 /*
  * Wait for the specified amount of data (in bytes) to be evicted from the
  * ARC, and for there to be sufficient free memory in the system.
@@ -5332,20 +5326,6 @@ arc_free_data_abd(arc_buf_hdr_t *hdr, abd_t *abd, uint64_t size,
 {
 	arc_free_data_impl(hdr, size, tag);
 	abd_free(abd);
-}
-
-static void
-arc_free_data_buf(arc_buf_hdr_t *hdr, void *buf, uint64_t size, const void *tag)
-{
-	arc_buf_contents_t type = arc_buf_type(hdr);
-
-	arc_free_data_impl(hdr, size, tag);
-	if (type == ARC_BUFC_METADATA) {
-		zio_buf_free(buf, size);
-	} else {
-		ASSERT(type == ARC_BUFC_DATA);
-		zio_data_buf_free(buf, size);
-	}
 }
 
 /*
@@ -5586,7 +5566,7 @@ arc_getbuf_func(zio_t *zio, const zbookmark_phys_t *zb, const blkptr_t *bp,
 	} else {
 		ASSERT(zio == NULL || zio->io_error == 0);
 		*bufp = buf;
-		ASSERT(buf->b_data != NULL);
+		ASSERT(buf->b_abd != NULL);
 	}
 }
 
@@ -6730,8 +6710,8 @@ arc_release(arc_buf_t *buf, const void *tag)
 					arc_share_buf(hdr, lastbuf);
 				} else {
 					arc_hdr_alloc_abd(hdr, 0);
-					abd_copy_from_buf(hdr->b_l1hdr.b_pabd,
-					    buf->b_data, psize);
+					abd_copy(hdr->b_l1hdr.b_pabd,
+					    buf->b_abd, psize);
 				}
 			} else if (HDR_SHARED_DATA(hdr)) {
 				/*
@@ -6812,7 +6792,7 @@ arc_release(arc_buf_t *buf, const void *tag)
 int
 arc_released(arc_buf_t *buf)
 {
-	return (buf->b_data != NULL &&
+	return (buf->b_abd != NULL &&
 	    buf->b_hdr->b_l1hdr.b_state == arc_anon);
 }
 
@@ -6949,7 +6929,8 @@ arc_write_ready(zio_t *zio)
 		    ARC_HDR_USE_RESERVE);
 		abd_copy(hdr->b_crypt_hdr.b_rabd, zio->io_abd, psize);
 	} else if (!(HDR_UNCACHED(hdr) ||
-	    abd_size_alloc_linear(arc_buf_size(buf))) ||
+	    abd_size_alloc_linear(arc_buf_size(buf)) ||
+	    !abd_is_linear(buf->b_abd) || abd_is_linear_page(buf->b_abd)) ||
 	    !arc_can_share(hdr, buf)) {
 		/*
 		 * Ideally, we would always copy the io_abd into b_pabd, but the
@@ -6969,11 +6950,11 @@ arc_write_ready(zio_t *zio)
 		} else {
 			ASSERT3U(zio->io_orig_size, ==, arc_hdr_size(hdr));
 			arc_hdr_alloc_abd(hdr, ARC_HDR_USE_RESERVE);
-			abd_copy_from_buf(hdr->b_l1hdr.b_pabd, buf->b_data,
+			abd_copy(hdr->b_l1hdr.b_pabd, buf->b_abd,
 			    arc_buf_size(buf));
 		}
 	} else {
-		ASSERT3P(buf->b_data, ==, abd_to_buf(zio->io_orig_abd));
+		ASSERT3P(buf->b_abd, ==, zio->io_orig_abd);
 		ASSERT3U(zio->io_orig_size, ==, arc_buf_size(buf));
 		ASSERT3P(hdr->b_l1hdr.b_buf, ==, buf);
 		ASSERT(ARC_BUF_LAST(buf));
@@ -7077,7 +7058,6 @@ arc_write_done(zio_t *zio)
 
 	callback->awcb_done(zio, buf, callback->awcb_private);
 
-	abd_free(zio->io_abd);
 	kmem_free(callback, sizeof (arc_write_callback_t));
 }
 
@@ -7157,7 +7137,7 @@ arc_write(zio_t *pio, spa_t *spa, uint64_t txg,
 			ASSERT(!arc_buf_is_shared(buf));
 			arc_hdr_free_abd(hdr, B_FALSE);
 		}
-		VERIFY3P(buf->b_data, !=, NULL);
+		VERIFY3P(buf->b_abd, !=, NULL);
 	}
 
 	if (HDR_HAS_RABD(hdr))
@@ -7170,7 +7150,7 @@ arc_write(zio_t *pio, spa_t *spa, uint64_t txg,
 	ASSERT0P(hdr->b_l1hdr.b_pabd);
 
 	zio = zio_write(pio, spa, txg, bp,
-	    abd_get_from_buf(buf->b_data, HDR_GET_LSIZE(hdr)),
+	    buf->b_abd,
 	    HDR_GET_LSIZE(hdr), arc_buf_size(buf), &localprop, arc_write_ready,
 	    (children_ready != NULL) ? arc_write_children_ready : NULL,
 	    arc_write_done, callback, priority, zio_flags, zb);

--- a/module/zfs/bpobj.c
+++ b/module/zfs/bpobj.c
@@ -131,7 +131,7 @@ bpobj_free(objset_t *os, uint64_t obj, dmu_tx_t *tx)
 		ASSERT3U(offset, >=, dbuf->db_offset);
 		ASSERT3U(offset, <, dbuf->db_offset + dbuf->db_size);
 
-		objarray = dbuf->db_data;
+		objarray = abd_to_buf(dbuf->db_abd);
 		bpobj_free(os, objarray[blkoff], tx);
 	}
 	if (dbuf) {
@@ -176,7 +176,7 @@ bpobj_open(bpobj_t *bpo, objset_t *os, uint64_t object)
 	bpo->bpo_havecomp = (doi.doi_bonus_size > BPOBJ_SIZE_V0);
 	bpo->bpo_havesubobj = (doi.doi_bonus_size > BPOBJ_SIZE_V1);
 	bpo->bpo_havefreed = (doi.doi_bonus_size > BPOBJ_SIZE_V2);
-	bpo->bpo_phys = bpo->bpo_dbuf->db_data;
+	bpo->bpo_phys = abd_to_buf(bpo->bpo_dbuf->db_abd);
 	return (0);
 }
 
@@ -318,7 +318,7 @@ bpobj_iterate_blkptrs(bpobj_info_t *bpi, bpobj_itor_t func, void *arg,
 		ASSERT3U(offset, >=, dbuf->db_offset);
 		ASSERT3U(offset, <, dbuf->db_offset + dbuf->db_size);
 
-		blkptr_t *bparray = dbuf->db_data;
+		blkptr_t *bparray = abd_to_buf(dbuf->db_abd);
 		blkptr_t *bp = &bparray[blkoff];
 
 		boolean_t bp_freed = BP_GET_FREE(bp);
@@ -752,7 +752,7 @@ bpobj_enqueue_subobj(bpobj_t *bpo, uint64_t subobj, dmu_tx_t *tx)
 		}
 		dmu_write(bpo->bpo_os, bpo->bpo_phys->bpo_subobjs,
 		    bpo->bpo_phys->bpo_num_subobjs * sizeof (subobj),
-		    numsubsub * sizeof (subobj), subdb->db_data, tx,
+		    numsubsub * sizeof (subobj), abd_to_buf(subdb->db_abd), tx,
 		    DMU_READ_NO_PREFETCH);
 		dmu_buf_rele(subdb, FTAG);
 		bpo->bpo_phys->bpo_num_subobjs += numsubsub;
@@ -778,7 +778,7 @@ bpobj_enqueue_subobj(bpobj_t *bpo, uint64_t subobj, dmu_tx_t *tx)
 		dmu_write(bpo->bpo_os, bpo->bpo_object,
 		    bpo->bpo_phys->bpo_num_blkptrs * sizeof (blkptr_t),
 		    numbps * sizeof (blkptr_t),
-		    bps->db_data, tx, DMU_READ_NO_PREFETCH);
+		    abd_to_buf(bps->db_abd), tx, DMU_READ_NO_PREFETCH);
 		dmu_buf_rele(bps, FTAG);
 		bpo->bpo_phys->bpo_num_blkptrs += numbps;
 
@@ -921,7 +921,7 @@ bpobj_enqueue(bpobj_t *bpo, const blkptr_t *bp, boolean_t bp_freed,
 	}
 
 	dmu_buf_will_dirty(bpo->bpo_cached_dbuf, tx);
-	bparray = bpo->bpo_cached_dbuf->db_data;
+	bparray = abd_to_buf(bpo->bpo_cached_dbuf->db_abd);
 	bparray[blkoff] = stored_bp;
 
 	dmu_buf_will_dirty(bpo->bpo_dbuf, tx);

--- a/module/zfs/bptree.c
+++ b/module/zfs/bptree.c
@@ -74,7 +74,7 @@ bptree_alloc(objset_t *os, dmu_tx_t *tx)
 	 */
 	VERIFY3U(0, ==, dmu_bonus_hold(os, obj, FTAG, &db));
 	dmu_buf_will_dirty(db, tx);
-	bt = db->db_data;
+	bt = abd_to_buf(db->db_abd);
 	bt->bt_begin = 0;
 	bt->bt_end = 0;
 	bt->bt_bytes = 0;
@@ -92,7 +92,7 @@ bptree_free(objset_t *os, uint64_t obj, dmu_tx_t *tx)
 	bptree_phys_t *bt;
 
 	VERIFY3U(0, ==, dmu_bonus_hold(os, obj, FTAG, &db));
-	bt = db->db_data;
+	bt = abd_to_buf(db->db_abd);
 	ASSERT3U(bt->bt_begin, ==, bt->bt_end);
 	ASSERT0(bt->bt_bytes);
 	ASSERT0(bt->bt_comp);
@@ -110,7 +110,7 @@ bptree_is_empty(objset_t *os, uint64_t obj)
 	boolean_t rv;
 
 	VERIFY0(dmu_bonus_hold(os, obj, FTAG, &db));
-	bt = db->db_data;
+	bt = abd_to_buf(db->db_abd);
 	rv = (bt->bt_begin == bt->bt_end);
 	dmu_buf_rele(db, FTAG);
 	return (rv);
@@ -132,7 +132,7 @@ bptree_add(objset_t *os, uint64_t obj, blkptr_t *bp, uint64_t birth_txg,
 	ASSERT(dmu_tx_is_syncing(tx));
 
 	VERIFY3U(0, ==, dmu_bonus_hold(os, obj, FTAG, &db));
-	bt = db->db_data;
+	bt = abd_to_buf(db->db_abd);
 
 	bte = kmem_zalloc(sizeof (*bte), KM_SLEEP);
 	bte->be_birth_txg = birth_txg;
@@ -205,7 +205,7 @@ bptree_iterate(objset_t *os, uint64_t obj, boolean_t free, bptree_itor_t func,
 	if (free)
 		dmu_buf_will_dirty(db, tx);
 
-	ba.ba_phys = db->db_data;
+	ba.ba_phys = abd_to_buf(db->db_abd);
 	ba.ba_free = free;
 	ba.ba_func = func;
 	ba.ba_arg = arg;

--- a/module/zfs/brt.c
+++ b/module/zfs/brt.c
@@ -564,7 +564,7 @@ brt_vdev_load(spa_t *spa, brt_vdev_t *brtvd)
 	if (error != 0)
 		return (error);
 
-	bvphys = db->db_data;
+	bvphys = abd_to_buf(db->db_abd);
 	if (spa->spa_brt_rangesize == 0) {
 		spa->spa_brt_rangesize = bvphys->bvp_rangesize;
 	} else {
@@ -823,7 +823,7 @@ brt_vdev_sync(spa_t *spa, brt_vdev_t *brtvd, dmu_tx_t *tx)
 	}
 
 	dmu_buf_will_dirty(db, tx);
-	bvphys = db->db_data;
+	bvphys = abd_to_buf(db->db_abd);
 	bvphys->bvp_mos_entries = brtvd->bv_mos_entries;
 	bvphys->bvp_size = brtvd->bv_size;
 	if (brtvd->bv_need_byteswap) {

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -529,7 +529,7 @@ dbuf_verify_user(dmu_buf_impl_t *db, dbvu_verify_type_t verify_type)
 	ASSERT0(db->db_level);
 
 	/* Clients must resolve a dbuf before attaching user data. */
-	ASSERT(db->db.db_data != NULL);
+	ASSERT(db->db.db_abd != NULL);
 	ASSERT3U(db->db_state, ==, DB_CACHED);
 
 	holds = zfs_refcount_count(&db->db_holds);
@@ -1114,6 +1114,19 @@ dbuf_fini(void)
  */
 
 #ifdef ZFS_DEBUG
+static int
+checkzero(void *p, size_t size, void *private)
+{
+	(void) private;
+	size_t i;
+	uint64_t *x = p;
+	for (i = 0; i < size >> 3; i++) {
+		if (x[i] != 0)
+			return (1);
+	}
+	return (0);
+}
+
 static void
 dbuf_verify(dmu_buf_impl_t *db)
 {
@@ -1196,13 +1209,13 @@ dbuf_verify(dmu_buf_impl_t *db)
 			ASSERT3U(db->db_parent->db.db_object, ==,
 			    db->db.db_object);
 			ASSERT3P(db->db_blkptr, ==,
-			    ((blkptr_t *)db->db_parent->db.db_data +
+			    ((blkptr_t *)abd_to_buf(db->db_parent->db.db_abd) +
 			    db->db_blkid % epb));
 		}
 	}
 	if ((db->db_blkptr == NULL || BP_IS_HOLE(db->db_blkptr)) &&
-	    (db->db_buf == NULL || db->db_buf->b_data) &&
-	    db->db.db_data && db->db_blkid != DMU_BONUS_BLKID &&
+	    (db->db_buf == NULL || db->db_buf->b_abd) &&
+	    db->db.db_abd && db->db_blkid != DMU_BONUS_BLKID &&
 	    db->db_state != DB_FILL && (dn == NULL || !dn->dn_free_txg)) {
 		/*
 		 * If the blkptr isn't set but they have nonzero data,
@@ -1217,14 +1230,10 @@ dbuf_verify(dmu_buf_impl_t *db)
 		 */
 		if (db->db_dirtycnt == 0) {
 			if (db->db_level == 0) {
-				uint64_t *buf = db->db.db_data;
-				int i;
-
-				for (i = 0; i < db->db.db_size >> 3; i++) {
-					ASSERT0(buf[i]);
-				}
+				ASSERT0(abd_iterate_func(db->db.db_abd, 0,
+				    db->db.db_size, checkzero, NULL));
 			} else {
-				blkptr_t *bps = db->db.db_data;
+				blkptr_t *bps = abd_to_buf(db->db.db_abd);
 				ASSERT3U(1 << DB_DNODE(db)->dn_indblkshift, ==,
 				    db->db.db_size);
 				/*
@@ -1262,7 +1271,7 @@ dbuf_clear_data(dmu_buf_impl_t *db)
 	ASSERT(MUTEX_HELD(&db->db_mtx));
 	dbuf_evict_user(db);
 	ASSERT0P(db->db_buf);
-	db->db.db_data = NULL;
+	db->db.db_abd = NULL;
 	if (db->db_state != DB_NOFILL) {
 		db->db_state = DB_UNCACHED;
 		DTRACE_SET_STATE(db, "clear data");
@@ -1276,8 +1285,8 @@ dbuf_set_data(dmu_buf_impl_t *db, arc_buf_t *buf)
 	ASSERT(buf != NULL);
 
 	db->db_buf = buf;
-	ASSERT(buf->b_data != NULL);
-	db->db.db_data = buf->b_data;
+	ASSERT(buf->b_abd != NULL);
+	db->db.db_abd = buf->b_abd;
 }
 
 static arc_buf_t *
@@ -1387,7 +1396,7 @@ dbuf_read_done(zio_t *zio, const zbookmark_phys_t *zb, const blkptr_t *bp,
 	 */
 	ASSERT(zfs_refcount_count(&db->db_holds) > 0);
 	ASSERT0P(db->db_buf);
-	ASSERT0P(db->db.db_data);
+	ASSERT0P(db->db.db_abd);
 	if (buf == NULL) {
 		/* i/o error */
 		ASSERT(zio == NULL || zio->io_error != 0);
@@ -1399,7 +1408,7 @@ dbuf_read_done(zio_t *zio, const zbookmark_phys_t *zb, const blkptr_t *bp,
 		/* freed in flight */
 		ASSERT(zio == NULL || zio->io_error == 0);
 		arc_release(buf, db);
-		memset(buf->b_data, 0, db->db.db_size);
+		abd_zero(buf->b_abd, db->db.db_size);
 		arc_buf_freeze(buf);
 		db->db_freed_in_flight = FALSE;
 		dbuf_set_data(db, buf);
@@ -1424,7 +1433,7 @@ dbuf_read_done(zio_t *zio, const zbookmark_phys_t *zb, const blkptr_t *bp,
 static int
 dbuf_read_bonus(dmu_buf_impl_t *db, dnode_t *dn)
 {
-	void* db_data;
+	abd_t *db_abd;
 	int bonuslen, max_bonuslen;
 
 	bonuslen = MIN(dn->dn_bonuslen, dn->dn_phys->dn_bonuslen);
@@ -1432,22 +1441,22 @@ dbuf_read_bonus(dmu_buf_impl_t *db, dnode_t *dn)
 	ASSERT(MUTEX_HELD(&db->db_mtx));
 	ASSERT(DB_DNODE_HELD(db));
 	ASSERT3U(bonuslen, <=, db->db.db_size);
-	db_data = kmem_alloc(max_bonuslen, KM_SLEEP);
+	db_abd = abd_alloc_linear(max_bonuslen, B_TRUE);
 	arc_space_consume(max_bonuslen, ARC_SPACE_BONUS);
 	if (bonuslen < max_bonuslen)
-		memset(db_data, 0, max_bonuslen);
+		abd_zero(db_abd, max_bonuslen);
 	if (bonuslen)
-		memcpy(db_data, DN_BONUS(dn->dn_phys), bonuslen);
-	db->db.db_data = db_data;
+		abd_copy_from_buf(db_abd, DN_BONUS(dn->dn_phys), bonuslen);
+	db->db.db_abd = db_abd;
 	db->db_state = DB_CACHED;
 	DTRACE_SET_STATE(db, "bonus buffer filled");
 	return (0);
 }
 
 static void
-dbuf_handle_indirect_hole(void *data, dnode_t *dn, blkptr_t *dbbp)
+dbuf_handle_indirect_hole(abd_t *data, dnode_t *dn, blkptr_t *dbbp)
 {
-	blkptr_t *bps = data;
+	blkptr_t *bps = abd_to_buf(data);
 	uint32_t indbs = 1ULL << dn->dn_indblkshift;
 	int n_bps = indbs >> SPA_BLKPTRSHIFT;
 
@@ -1498,11 +1507,11 @@ dbuf_read_hole(dmu_buf_impl_t *db, dnode_t *dn, blkptr_t *bp)
 
 	if (is_hole) {
 		db_data = dbuf_alloc_arcbuf(db);
-		memset(db_data->b_data, 0, db->db.db_size);
+		abd_zero(db_data->b_abd, db->db.db_size);
 
 		if (bp != NULL && db->db_level > 0 && BP_IS_HOLE(bp) &&
 		    BP_GET_LOGICAL_BIRTH(bp) != 0) {
-			dbuf_handle_indirect_hole(db_data->b_data, dn, bp);
+			dbuf_handle_indirect_hole(db_data->b_abd, dn, bp);
 		}
 		dbuf_set_data(db, db_data);
 		db->db_state = DB_CACHED;
@@ -1697,13 +1706,14 @@ dbuf_fix_old_data(dmu_buf_impl_t *db, uint64_t txg)
 	dbuf_dirty_record_t *dr = list_head(&db->db_dirty_records);
 
 	ASSERT(MUTEX_HELD(&db->db_mtx));
-	ASSERT(db->db.db_data != NULL);
+	ASSERT(db->db.db_abd != NULL);
 	ASSERT0(db->db_level);
 	ASSERT(db->db.db_object != DMU_META_DNODE_OBJECT);
 
 	if (dr == NULL ||
 	    (dr->dt.dl.dr_data !=
-	    ((db->db_blkid  == DMU_BONUS_BLKID) ? db->db.db_data : db->db_buf)))
+	    ((db->db_blkid  == DMU_BONUS_BLKID) ?
+	    abd_to_buf(db->db.db_abd) : db->db_buf)))
 		return;
 
 	/*
@@ -1711,7 +1721,7 @@ dbuf_fix_old_data(dmu_buf_impl_t *db, uint64_t txg)
 	 * and its referencing the dbuf data, either:
 	 *	reset the reference to point to a new copy,
 	 * or (if there a no active holders)
-	 *	just null out the current db_data pointer.
+	 *	just null out the current db_abd pointer.
 	 */
 	ASSERT3U(dr->dr_txg, >=, txg - 2);
 	if (db->db_blkid == DMU_BONUS_BLKID) {
@@ -1719,7 +1729,7 @@ dbuf_fix_old_data(dmu_buf_impl_t *db, uint64_t txg)
 		int bonuslen = DN_SLOTS_TO_BONUSLEN(dn->dn_num_slots);
 		dr->dt.dl.dr_data = kmem_alloc(bonuslen, KM_SLEEP);
 		arc_space_consume(bonuslen, ARC_SPACE_BONUS);
-		memcpy(dr->dt.dl.dr_data, db->db.db_data, bonuslen);
+		abd_copy_to_buf(dr->dt.dl.dr_data, db->db.db_abd, bonuslen);
 	} else if (zfs_refcount_count(&db->db_holds) > db->db_dirtycnt) {
 		dnode_t *dn = DB_DNODE(db);
 		int size = arc_buf_size(db->db_buf);
@@ -1749,7 +1759,7 @@ dbuf_fix_old_data(dmu_buf_impl_t *db, uint64_t txg)
 		} else {
 			dr->dt.dl.dr_data = arc_alloc_buf(spa, db, type, size);
 		}
-		memcpy(dr->dt.dl.dr_data->b_data, db->db.db_data, size);
+		abd_copy(dr->dt.dl.dr_data->b_abd, db->db.db_abd, size);
 	} else {
 		db->db_buf = NULL;
 		dbuf_clear_data(db);
@@ -1918,7 +1928,7 @@ dbuf_noread(dmu_buf_impl_t *db, dmu_flags_t flags)
 		cv_wait(&db->db_changed, &db->db_mtx);
 	if (db->db_state == DB_UNCACHED) {
 		ASSERT0P(db->db_buf);
-		ASSERT0P(db->db.db_data);
+		ASSERT0P(db->db.db_abd);
 		dbuf_set_data(db, dbuf_alloc_arcbuf(db));
 		db->db_state = DB_FILL;
 		DTRACE_SET_STATE(db, "assigning filled buffer");
@@ -2033,7 +2043,7 @@ dbuf_free_range(dnode_t *dn, uint64_t start_blkid, uint64_t end_blkid,
 		if (db->db_state == DB_UNCACHED ||
 		    db->db_state == DB_NOFILL ||
 		    db->db_state == DB_EVICTING) {
-			ASSERT0P(db->db.db_data);
+			ASSERT0P(db->db.db_abd);
 			mutex_exit(&db->db_mtx);
 			continue;
 		}
@@ -2074,10 +2084,10 @@ dbuf_free_range(dnode_t *dn, uint64_t start_blkid, uint64_t end_blkid,
 		}
 		/* clear the contents if its cached */
 		if (db->db_state == DB_CACHED) {
-			ASSERT(db->db.db_data != NULL);
+			ASSERT(db->db.db_abd != NULL);
 			arc_release(db->db_buf, db);
 			rw_enter(&db->db_rwlock, RW_WRITER);
-			memset(db->db.db_data, 0, db->db.db_size);
+			abd_zero(db->db.db_abd, db->db.db_size);
 			rw_exit(&db->db_rwlock);
 			arc_buf_freeze(db->db_buf);
 		}
@@ -2177,10 +2187,10 @@ dbuf_new_size(dmu_buf_impl_t *db, int size, boolean_t copy, dmu_tx_t *tx)
 	if (copy) {
 		ASSERT(arc_get_compression(old_buf) == ZIO_COMPRESS_OFF);
 		/* copy old block data to the new block */
-		memcpy(buf->b_data, old_buf->b_data, MIN(osize, size));
+		abd_copy(buf->b_abd, old_buf->b_abd, MIN(osize, size));
 		/* zero the remainder */
 		if (size > osize)
-			memset((uint8_t *)buf->b_data + osize, 0, size - osize);
+			abd_zero_off(buf->b_abd, osize, size - osize);
 	}
 
 	mutex_enter(&db->db_mtx);
@@ -2433,7 +2443,7 @@ dbuf_dirty(dmu_buf_impl_t *db, dmu_tx_t *tx)
 		if (db->db_state != DB_NOFILL) {
 			if (db->db_blkid == DMU_BONUS_BLKID) {
 				dbuf_fix_old_data(db, tx->tx_txg);
-				data_old = db->db.db_data;
+				data_old = abd_to_buf(db->db.db_abd);
 			} else if (db->db.db_object != DMU_META_DNODE_OBJECT) {
 				/*
 				 * Release the data buffer from the cache so
@@ -2594,7 +2604,7 @@ dbuf_undirty_bonus(dbuf_dirty_record_t *dr)
 	dmu_buf_impl_t *db = dr->dr_dbuf;
 
 	ASSERT(MUTEX_HELD(&db->db_mtx));
-	if (dr->dt.dl.dr_data != db->db.db_data) {
+	if (dr->dt.dl.dr_data != abd_to_buf(db->db.db_abd)) {
 		struct dnode *dn = dr->dr_dnode;
 		int max_bonuslen = DN_SLOTS_TO_BONUSLEN(dn->dn_num_slots);
 
@@ -2969,7 +2979,7 @@ dmu_buf_will_clone_or_dio(dmu_buf_t *db_fake, dmu_tx_t *tx)
 	}
 
 	ASSERT0P(db->db_buf);
-	ASSERT0P(db->db.db_data);
+	ASSERT0P(db->db.db_abd);
 
 	db->db_state = DB_NOFILL;
 	DTRACE_SET_STATE(db,
@@ -3115,7 +3125,7 @@ dmu_buf_fill_done(dmu_buf_t *dbuf, dmu_tx_t *tx, boolean_t failed)
 			ASSERT(db->db_blkid != DMU_BONUS_BLKID);
 			/* we were freed while filling */
 			/* XXX dbuf_undirty? */
-			memset(db->db.db_data, 0, db->db.db_size);
+			abd_zero(db->db.db_abd, db->db.db_size);
 			db->db_freed_in_flight = FALSE;
 			db->db_state = DB_CACHED;
 			DTRACE_SET_STATE(db,
@@ -3247,7 +3257,7 @@ dbuf_assign_arcbuf(dmu_buf_impl_t *db, arc_buf_t *buf, dmu_tx_t *tx,
 		ASSERT(!arc_is_encrypted(buf));
 		mutex_exit(&db->db_mtx);
 		(void) dbuf_dirty(db, tx);
-		memcpy(db->db.db_data, buf->b_data, db->db.db_size);
+		abd_copy(db->db.db_abd, buf->b_abd, db->db.db_size);
 		arc_buf_destroy(buf, db);
 		return;
 	}
@@ -3308,8 +3318,8 @@ dbuf_destroy(dmu_buf_impl_t *db)
 	if (db->db_blkid == DMU_BONUS_BLKID) {
 		int slots = DB_DNODE(db)->dn_num_slots;
 		int bonuslen = DN_SLOTS_TO_BONUSLEN(slots);
-		if (db->db.db_data != NULL) {
-			kmem_free(db->db.db_data, bonuslen);
+		if (db->db.db_abd != NULL) {
+			abd_free(db->db.db_abd);
 			arc_space_return(bonuslen, ARC_SPACE_BONUS);
 			db->db_state = DB_UNCACHED;
 			DTRACE_SET_STATE(db, "buffer cleared");
@@ -3394,7 +3404,7 @@ dbuf_destroy(dmu_buf_impl_t *db)
 	db->db_parent = NULL;
 
 	ASSERT0P(db->db_buf);
-	ASSERT0P(db->db.db_data);
+	ASSERT0P(db->db.db_abd);
 	ASSERT0P(db->db_hash_next);
 	ASSERT0P(db->db_blkptr);
 	ASSERT0P(db->db_data_pending);
@@ -3490,7 +3500,7 @@ dbuf_findbp(dnode_t *dn, int level, uint64_t blkid, int fail_sparse,
 			*parentp = NULL;
 			return (err);
 		}
-		*bpp = ((blkptr_t *)(*parentp)->db.db_data) +
+		*bpp = ((blkptr_t *)abd_to_buf((*parentp)->db.db_abd)) +
 		    (blkid & ((1ULL << epbs) - 1));
 		return (0);
 	} else {
@@ -3757,7 +3767,7 @@ dbuf_prefetch_indirect_done(zio_t *zio, const zbookmark_phys_t *zb,
 	dpa->dpa_curlevel--;
 	uint64_t nextblkid = dpa->dpa_zb.zb_blkid >>
 	    (dpa->dpa_epbs * (dpa->dpa_curlevel - dpa->dpa_zb.zb_level));
-	blkptr_t *bp = ((blkptr_t *)abuf->b_data) +
+	blkptr_t *bp = ((blkptr_t *)abd_to_buf(abuf->b_abd)) +
 	    P2PHASE(nextblkid, 1ULL << dpa->dpa_epbs);
 
 	ASSERT(!BP_IS_REDACTED(bp) || dpa->dpa_dnode == NULL ||
@@ -3862,7 +3872,7 @@ dbuf_prefetch_impl(dnode_t *dn, int64_t level, uint64_t blkid,
 
 		if (dbuf_hold_impl(dn, parent_level, parent_blkid,
 		    FALSE, TRUE, FTAG, &db) == 0) {
-			blkptr_t *bpp = db->db_buf->b_data;
+			blkptr_t *bpp = abd_to_buf(db->db_buf->b_abd);
 			bp = bpp[P2PHASE(curblkid, 1 << epbs)];
 			dbuf_rele(db, FTAG);
 			break;
@@ -3980,7 +3990,7 @@ dbuf_hold_copy(dnode_t *dn, dmu_buf_impl_t *db)
 		db_data = arc_alloc_buf(dn->dn_objset->os_spa, db,
 		    DBUF_GET_BUFC_TYPE(db), db->db.db_size);
 	}
-	memcpy(db_data->b_data, data->b_data, arc_buf_size(data));
+	abd_copy(db_data->b_abd, data->b_abd, arc_buf_size(data));
 
 	dbuf_set_data(db, db_data);
 }
@@ -4045,14 +4055,14 @@ dbuf_hold_impl(dnode_t *dn, uint8_t level, uint64_t blkid,
 	if (db->db_buf != NULL) {
 		arc_buf_access(db->db_buf);
 		ASSERT(MUTEX_HELD(&db->db_mtx));
-		ASSERT3P(db->db.db_data, ==, db->db_buf->b_data);
+		ASSERT3P(db->db.db_abd, ==, db->db_buf->b_abd);
 	}
 
 	ASSERT(db->db_buf == NULL || arc_referenced(db->db_buf));
 
 	/*
 	 * If this buffer is currently syncing out, and we are
-	 * still referencing it from db_data, we need to make a copy
+	 * still referencing it from db_abd, we need to make a copy
 	 * of it in case we decide we want to dirty it again in this txg.
 	 */
 	if (db->db_level == 0 && db->db_blkid != DMU_BONUS_BLKID &&
@@ -4496,7 +4506,7 @@ dbuf_check_blkptr(dnode_t *dn, dmu_buf_impl_t *db)
 			mutex_enter(&db->db_mtx);
 			db->db_parent = parent;
 		}
-		db->db_blkptr = (blkptr_t *)parent->db.db_data +
+		db->db_blkptr = (blkptr_t *)abd_to_buf(parent->db.db_abd) +
 		    (db->db_blkid & ((1ULL << epbs) - 1));
 		DBUF_VERIFY(db);
 	}
@@ -4670,7 +4680,7 @@ dbuf_lightweight_bp(dbuf_dirty_record_t *dr)
 		VERIFY3U(parent_db->db_level, ==, 1);
 		VERIFY3P(DB_DNODE(parent_db), ==, dn);
 		VERIFY3U(dr->dt.dll.dr_blkid >> epbs, ==, parent_db->db_blkid);
-		blkptr_t *bp = parent_db->db.db_data;
+		blkptr_t *bp = abd_to_buf(parent_db->db.db_abd);
 		return (&bp[dr->dt.dll.dr_blkid & ((1 << epbs) - 1)]);
 	}
 }
@@ -4801,10 +4811,11 @@ dbuf_sync_leaf(dbuf_dirty_record_t *dr, dmu_tx_t *tx)
 	 */
 	if (db->db_state == DB_UNCACHED) {
 		/* This buffer has been freed since it was dirtied */
-		ASSERT0P(db->db.db_data);
+		ASSERT0P(db->db.db_abd);
 	} else if (db->db_state == DB_FILL) {
 		/* This buffer was freed and is now being re-filled */
-		ASSERT(db->db.db_data != dr->dt.dl.dr_data);
+		ASSERT(!abd_is_linear(db->db.db_abd) ||
+		    abd_to_buf(db->db.db_abd) != dr->dt.dl.dr_data);
 	} else if (db->db_state == DB_READ) {
 		/*
 		 * This buffer was either cloned or had a Direct I/O write
@@ -4819,7 +4830,7 @@ dbuf_sync_leaf(dbuf_dirty_record_t *dr, dmu_tx_t *tx)
 		dbuf_dirty_record_t *dr_head =
 		    list_head(&db->db_dirty_records);
 		ASSERT0P(db->db_buf);
-		ASSERT0P(db->db.db_data);
+		ASSERT0P(db->db.db_abd);
 		ASSERT0P(dr_head->dt.dl.dr_data);
 		ASSERT3U(dr_head->dt.dl.dr_override_state, ==, DR_OVERRIDDEN);
 	} else {
@@ -4896,7 +4907,7 @@ dbuf_sync_leaf(dbuf_dirty_record_t *dr, dmu_tx_t *tx)
 	    zfs_refcount_count(&db->db_holds) > 1) {
 		/*
 		 * If this buffer is currently "in use" (i.e., there
-		 * are active holds and db_data still references it),
+		 * are active holds and db_abd still references it),
 		 * then make a copy before we start the write so that
 		 * any modifications from the open txg will not leak
 		 * into this write.
@@ -4929,7 +4940,7 @@ dbuf_sync_leaf(dbuf_dirty_record_t *dr, dmu_tx_t *tx)
 		} else {
 			*datap = arc_alloc_buf(os->os_spa, db, type, psize);
 		}
-		memcpy((*datap)->b_data, db->db.db_data, psize);
+		abd_copy((*datap)->b_abd, db->db.db_abd, psize);
 	}
 	db->db_data_pending = dr;
 
@@ -5036,8 +5047,8 @@ dbuf_write_ready(zio_t *zio, arc_buf_t *buf, void *vdb)
 		if (dn->dn_type == DMU_OT_DNODE) {
 			i = 0;
 			while (i < db->db.db_size) {
-				dnode_phys_t *dnp =
-				    (void *)(((char *)db->db.db_data) + i);
+				dnode_phys_t *dnp = (void *)
+				    (((char *)abd_to_buf(db->db.db_abd)) + i);
 
 				i += DNODE_MIN_SIZE;
 				if (dnp->dn_type != DMU_OT_NONE) {
@@ -5068,7 +5079,7 @@ dbuf_write_ready(zio_t *zio, arc_buf_t *buf, void *vdb)
 			}
 		}
 	} else {
-		blkptr_t *ibp = db->db.db_data;
+		blkptr_t *ibp = abd_to_buf(db->db.db_abd);
 		ASSERT3U(db->db.db_size, ==, 1<<dn->dn_phys->dn_indblkshift);
 		for (i = db->db.db_size >> SPA_BLKPTRSHIFT; i > 0; i--, ibp++) {
 			if (BP_IS_HOLE(ibp))
@@ -5112,7 +5123,8 @@ dbuf_write_children_ready(zio_t *zio, arc_buf_t *buf, void *vdb)
 	ASSERT3U(epbs, <, 31);
 
 	/* Determine if all our children are holes */
-	for (i = 0, bp = db->db.db_data; i < 1ULL << epbs; i++, bp++) {
+	bp = abd_to_buf(db->db.db_abd);
+	for (i = 0; i < 1ULL << epbs; i++, bp++) {
 		if (!BP_IS_HOLE(bp))
 			break;
 	}
@@ -5128,7 +5140,7 @@ dbuf_write_children_ready(zio_t *zio, arc_buf_t *buf, void *vdb)
 		 * zero out.
 		 */
 		rw_enter(&db->db_rwlock, RW_WRITER);
-		memset(db->db.db_data, 0, db->db.db_size);
+		abd_zero(db->db.db_abd, db->db.db_size);
 		rw_exit(&db->db_rwlock);
 	}
 }
@@ -5252,9 +5264,6 @@ dbuf_write_override_done(zio_t *zio)
 	mutex_exit(&db->db_mtx);
 
 	dbuf_write_done(zio, NULL, db);
-
-	if (zio->io_abd != NULL)
-		abd_free(zio->io_abd);
 }
 
 typedef struct dbuf_remap_impl_callback_arg {
@@ -5346,12 +5355,12 @@ dbuf_remap(dnode_t *dn, dmu_buf_impl_t *db, dmu_tx_t *tx)
 		return;
 
 	if (db->db_level > 0) {
-		blkptr_t *bp = db->db.db_data;
+		blkptr_t *bp = abd_to_buf(db->db.db_abd);
 		for (int i = 0; i < db->db.db_size >> SPA_BLKPTRSHIFT; i++) {
 			dbuf_remap_impl(dn, &bp[i], &db->db_rwlock, tx);
 		}
 	} else if (db->db.db_object == DMU_META_DNODE_OBJECT) {
-		dnode_phys_t *dnp = db->db.db_data;
+		dnode_phys_t *dnp = abd_to_buf(db->db.db_abd);
 		ASSERT3U(dn->dn_type, ==, DMU_OT_DNODE);
 		for (int i = 0; i < db->db.db_size >> DNODE_SHIFT;
 		    i += dnp[i].dn_extra_slots + 1) {
@@ -5408,7 +5417,7 @@ dbuf_write(dbuf_dirty_record_t *dr, arc_buf_t *data, dmu_tx_t *tx)
 		/* Our parent's buffer is one level closer to the dnode. */
 		ASSERT(db->db_level == parent->db_level-1);
 		/*
-		 * We're about to modify our parent's db_data by modifying
+		 * We're about to modify our parent's db_abd by modifying
 		 * our block pointer, so the parent must be released.
 		 */
 		ASSERT(arc_released(parent->db_buf));
@@ -5471,8 +5480,7 @@ dbuf_write(dbuf_dirty_record_t *dr, arc_buf_t *data, dmu_tx_t *tx)
 		 * (by dmu_sync(), dmu_write_direct(),
 		 *  or dmu_buf_write_embedded()).
 		 */
-		abd_t *contents = (data != NULL) ?
-		    abd_get_from_buf(data->b_data, arc_buf_size(data)) : NULL;
+		abd_t *contents = (data != NULL) ? data->b_abd : NULL;
 
 		dr->dr_zio = zio_write(pio, os->os_spa, txg, &dr->dr_bp_copy,
 		    contents, db->db.db_size, db->db.db_size, &zp,

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -2149,7 +2149,7 @@ dbuf_evict_range(dnode_t *dn, uint64_t start_blkid, uint64_t end_blkid)
 }
 
 void
-dbuf_new_size(dmu_buf_impl_t *db, int size, dmu_tx_t *tx)
+dbuf_new_size(dmu_buf_impl_t *db, int size, boolean_t copy, dmu_tx_t *tx)
 {
 	arc_buf_t *buf, *old_buf;
 	dbuf_dirty_record_t *dr;
@@ -2173,12 +2173,15 @@ dbuf_new_size(dmu_buf_impl_t *db, int size, dmu_tx_t *tx)
 	/* create the data buffer for the new block */
 	buf = arc_alloc_buf(dn->dn_objset->os_spa, db, type, size);
 
-	/* copy old block data to the new block */
 	old_buf = db->db_buf;
-	memcpy(buf->b_data, old_buf->b_data, MIN(osize, size));
-	/* zero the remainder */
-	if (size > osize)
-		memset((uint8_t *)buf->b_data + osize, 0, size - osize);
+	if (copy) {
+		ASSERT(arc_get_compression(old_buf) == ZIO_COMPRESS_OFF);
+		/* copy old block data to the new block */
+		memcpy(buf->b_data, old_buf->b_data, MIN(osize, size));
+		/* zero the remainder */
+		if (size > osize)
+			memset((uint8_t *)buf->b_data + osize, 0, size - osize);
+	}
 
 	mutex_enter(&db->db_mtx);
 	dbuf_set_data(db, buf);
@@ -4129,7 +4132,8 @@ dbuf_create_bonus(dnode_t *dn)
 }
 
 int
-dbuf_spill_set_blksz(dmu_buf_t *db_fake, uint64_t blksz, dmu_tx_t *tx)
+dbuf_spill_set_blksz(dmu_buf_t *db_fake, uint64_t blksz, boolean_t copy,
+    dmu_tx_t *tx)
 {
 	dmu_buf_impl_t *db = (dmu_buf_impl_t *)db_fake;
 
@@ -4140,7 +4144,7 @@ dbuf_spill_set_blksz(dmu_buf_t *db_fake, uint64_t blksz, dmu_tx_t *tx)
 	ASSERT3U(blksz, <=, spa_maxblocksize(dmu_objset_spa(db->db_objset)));
 	blksz = P2ROUNDUP(blksz, SPA_MINBLOCKSIZE);
 
-	dbuf_new_size(db, blksz, tx);
+	dbuf_new_size(db, blksz, copy, tx);
 
 	return (0);
 }

--- a/module/zfs/ddt_log.c
+++ b/module/zfs/ddt_log.c
@@ -102,7 +102,7 @@ ddt_log_update_header(ddt_t *ddt, ddt_log_t *ddl, dmu_tx_t *tx)
 	VERIFY0(dmu_bonus_hold(ddt->ddt_os, ddl->ddl_object, FTAG, &db));
 	dmu_buf_will_dirty(db, tx);
 
-	ddt_log_header_t *hdr = (ddt_log_header_t *)db->db_data;
+	ddt_log_header_t *hdr = (ddt_log_header_t *)abd_to_buf(db->db_abd);
 	DLH_SET_VERSION(hdr, 1);
 	DLH_SET_FLAGS(hdr, ddl->ddl_flags);
 	hdr->dlh_length = ddl->ddl_length;
@@ -306,11 +306,11 @@ ddt_log_entry(ddt_t *ddt, ddt_lightweight_entry_t *ddlwe, ddt_log_update_t *dlu)
 	if (dlu->dlu_offset == 0) {
 		dmu_buf_will_fill_flags(db, dlu->dlu_tx, B_FALSE,
 		    DMU_UNCACHEDIO);
-		memset(db->db_data, 0, db->db_size);
+		abd_zero(db->db_abd, db->db_size);
 	}
 
 	/* Create the log record directly in the buffer */
-	ddt_log_record_t *dlr = (db->db_data + dlu->dlu_offset);
+	ddt_log_record_t *dlr = abd_to_buf(db->db_abd) + dlu->dlu_offset;
 	DLR_SET_TYPE(dlr, DLR_ENTRY);
 	DLR_SET_RECLEN(dlr, dlu->dlu_reclen);
 	DLR_SET_ENTRY_TYPE(dlr, ddlwe->ddlwe_type);
@@ -582,7 +582,7 @@ ddt_log_load_one(ddt_t *ddt, uint_t n)
 		dnode_rele(dn, FTAG);
 		return (err);
 	}
-	memcpy(&hdr, db->db_data, sizeof (ddt_log_header_t));
+	abd_copy_to_buf(&hdr, db->db_abd, sizeof (ddt_log_header_t));
 	dmu_buf_rele(db, FTAG);
 
 	if (DLH_GET_VERSION(&hdr) != 1) {
@@ -619,7 +619,7 @@ ddt_log_load_one(ddt_t *ddt, uint_t n)
 			uint64_t boffset = 0;
 			while (boffset < db->db_size) {
 				ddt_log_record_t *dlr =
-				    (ddt_log_record_t *)(db->db_data + boffset);
+				    abd_to_buf(db->db_abd) + boffset;
 
 				/* Partially-filled block, skip the rest */
 				if (DLR_GET_TYPE(dlr) == DLR_INVALID)

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -160,17 +160,19 @@ const dmu_object_type_info_t dmu_ot[DMU_OT_NUMTYPES] = {
 	{DMU_BSWAP_UINT64, TRUE,  FALSE, FALSE, "bpobj subobj"		}
 };
 
+#define	OB_FUNC(func)	func, abd_##func
+
 dmu_object_byteswap_info_t dmu_ot_byteswap[DMU_BSWAP_NUMFUNCS] = {
-	{	byteswap_uint8_array,	"uint8"		},
-	{	byteswap_uint16_array,	"uint16"	},
-	{	byteswap_uint32_array,	"uint32"	},
-	{	byteswap_uint64_array,	"uint64"	},
-	{	zap_byteswap,		"zap"		},
-	{	dnode_buf_byteswap,	"dnode"		},
-	{	dmu_objset_byteswap,	"objset"	},
-	{	zfs_znode_byteswap,	"znode"		},
-	{	zfs_oldacl_byteswap,	"oldacl"	},
-	{	zfs_acl_byteswap,	"acl"		}
+	{	OB_FUNC(byteswap_uint8_array),	"uint8"		},
+	{	OB_FUNC(byteswap_uint16_array),	"uint16"	},
+	{	OB_FUNC(byteswap_uint32_array),	"uint32"	},
+	{	OB_FUNC(byteswap_uint64_array),	"uint64"	},
+	{	OB_FUNC(zap_byteswap),		"zap"		},
+	{	OB_FUNC(dnode_buf_byteswap),	"dnode"		},
+	{	OB_FUNC(dmu_objset_byteswap),	"objset"	},
+	{	OB_FUNC(zfs_znode_byteswap),	"znode"		},
+	{	OB_FUNC(zfs_oldacl_byteswap),	"oldacl"	},
+	{	OB_FUNC(zfs_acl_byteswap),	"acl"		}
 };
 
 int
@@ -1422,8 +1424,8 @@ dmu_read_impl(dnode_t *dn, uint64_t offset, uint64_t size,
 			bufoff = offset - db->db_offset;
 			tocpy = MIN(db->db_size - bufoff, size);
 
-			ASSERT(db->db_data != NULL);
-			(void) memcpy(buf, (char *)db->db_data + bufoff, tocpy);
+			ASSERT(db->db_abd != NULL);
+			abd_copy_to_buf_off(buf, db->db_abd, bufoff, tocpy);
 
 			offset += tocpy;
 			size -= tocpy;
@@ -1487,8 +1489,8 @@ dmu_write_impl(dmu_buf_t **dbp, int numbufs, uint64_t offset, uint64_t size,
 			dmu_buf_will_dirty_flags(db, tx, flags);
 		}
 
-		ASSERT(db->db_data != NULL);
-		(void) memcpy((char *)db->db_data + bufoff, buf, tocpy);
+		ASSERT(db->db_abd != NULL);
+		abd_copy_from_buf_off(db->db_abd, buf, bufoff, tocpy);
 
 		if (tocpy == db->db_size)
 			dmu_buf_fill_done(db, tx, B_FALSE);
@@ -1515,6 +1517,65 @@ dmu_write(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
 	dmu_buf_rele_array(dbp, numbufs, FTAG);
 }
 
+static void
+dmu_write_abd_impl(dmu_buf_t **dbp, int numbufs, uint64_t offset, uint64_t size,
+    abd_t *abd, dmu_tx_t *tx, dmu_flags_t flags)
+{
+	int i;
+	int64_t soff = 0;
+
+	for (i = 0; i < numbufs; i++) {
+		uint64_t tocpy;
+		int64_t bufoff;
+		dmu_buf_t *db = dbp[i];
+
+		ASSERT(size > 0);
+
+		bufoff = offset - db->db_offset;
+		tocpy = MIN(db->db_size - bufoff, size);
+
+		ASSERT(i == 0 || i == numbufs-1 || tocpy == db->db_size);
+
+		if (tocpy == db->db_size) {
+			dmu_buf_will_fill_flags(db, tx, B_FALSE, flags);
+		} else {
+			if (i == numbufs - 1 && bufoff + tocpy < db->db_size) {
+				if (bufoff == 0)
+					flags |= DMU_PARTIAL_FIRST;
+				else
+					flags |= DMU_PARTIAL_MORE;
+			}
+			dmu_buf_will_dirty_flags(db, tx, flags);
+		}
+
+		ASSERT(db->db_abd != NULL);
+		abd_copy_off(db->db_abd, abd, bufoff, soff, tocpy);
+
+		if (tocpy == db->db_size)
+			dmu_buf_fill_done(db, tx, B_FALSE);
+
+		offset += tocpy;
+		size -= tocpy;
+		soff += tocpy;
+	}
+}
+
+void
+dmu_write_abd(dnode_t *dn, uint64_t offset, uint64_t size, abd_t *abd,
+    dmu_tx_t *tx, dmu_flags_t flags)
+{
+	dmu_buf_t **dbp;
+	int numbufs;
+
+	if (size == 0)
+		return;
+
+	VERIFY0(dmu_buf_hold_array_by_dnode(dn, offset, size,
+	    FALSE, FTAG, &numbufs, &dbp, flags));
+	dmu_write_abd_impl(dbp, numbufs, offset, size, abd, tx, flags);
+	dmu_buf_rele_array(dbp, numbufs, FTAG);
+}
+
 int
 dmu_write_by_dnode(dnode_t *dn, uint64_t offset, uint64_t size,
     const void *buf, dmu_tx_t *tx, dmu_flags_t flags)
@@ -1530,7 +1591,7 @@ dmu_write_by_dnode(dnode_t *dn, uint64_t offset, uint64_t size,
 	if ((flags & DMU_DIRECTIO) && zfs_dio_page_aligned((void *)buf) &&
 	    zfs_dio_aligned(offset, size, dn->dn_datablksz)) {
 		abd_t *data = abd_get_from_buf((void *)buf, size);
-		error = dmu_write_abd(dn, offset, size, data, flags, tx);
+		error = dmu_write_abd_direct(dn, offset, size, data, flags, tx);
 		abd_free(data);
 		return (error);
 	}
@@ -1628,8 +1689,8 @@ dmu_read_uio_dnode(dnode_t *dn, zfs_uio_t *uio, uint64_t size,
 		bufoff = zfs_uio_offset(uio) - db->db_offset;
 		tocpy = MIN(db->db_size - bufoff, size);
 
-		ASSERT(db->db_data != NULL);
-		err = zfs_uio_fault_move((char *)db->db_data + bufoff, tocpy,
+		ASSERT(db->db_abd != NULL);
+		err = zfs_uio_fault_move_abd(db->db_abd, bufoff, tocpy,
 		    UIO_READ, uio);
 
 		if (err)
@@ -1766,8 +1827,8 @@ top:
 			dmu_buf_will_dirty_flags(db, tx, flags);
 		}
 
-		ASSERT(db->db_data != NULL);
-		err = zfs_uio_fault_move((char *)db->db_data + bufoff,
+		ASSERT(db->db_abd != NULL);
+		err = zfs_uio_fault_move_abd(db->db_abd, bufoff,
 		    tocpy, UIO_WRITE, uio);
 
 		if (tocpy == db->db_size && dmu_buf_fill_done(db, tx, err)) {
@@ -1942,8 +2003,8 @@ dmu_object_cached_size(objset_t *os, uint64_t object,
 
 		err = dbuf_read(db, NULL, DB_RF_CANFAIL);
 		if (err == 0) {
-			dmu_cached_bps(dmu_objset_spa(os), db->db.db_data,
-			    nbps, l1sz, l2sz);
+			dmu_cached_bps(dmu_objset_spa(os),
+			    abd_to_buf(db->db.db_abd), nbps, l1sz, l2sz);
 		}
 		/*
 		 * error may be ignored, and we continue
@@ -2039,7 +2100,7 @@ dmu_assign_arcbuf_by_dnode(dnode_t *dn, uint64_t offset, arc_buf_t *buf,
 		ASSERT(!(buf->b_flags & ARC_BUF_FLAG_COMPRESSED));
 
 		dbuf_rele(db, FTAG);
-		dmu_write_by_dnode(dn, offset, blksz, buf->b_data, tx, flags);
+		dmu_write_abd(dn, offset, blksz, buf->b_abd, tx, flags);
 		dmu_return_arcbuf(buf);
 	}
 
@@ -2186,7 +2247,6 @@ dmu_sync_late_arrival_done(zio_t *zio)
 
 	dsa->dsa_done(dsa->dsa_zgd, zio->io_error);
 
-	abd_free(zio->io_abd);
 	kmem_free(dsa, sizeof (*dsa));
 }
 
@@ -2254,7 +2314,7 @@ dmu_sync_late_arrival(zio_t *pio, objset_t *os, dmu_sync_cb_t *done, zgd_t *zgd,
 	zp->zp_nopwrite = B_FALSE;
 
 	zio_nowait(zio_write(pio, os->os_spa, dmu_tx_get_txg(tx), zgd->zgd_bp,
-	    abd_get_from_buf(zgd->zgd_db->db_data, zgd->zgd_db->db_size),
+	    zgd->zgd_db->db_abd,
 	    zgd->zgd_db->db_size, zgd->zgd_db->db_size, zp,
 	    dmu_sync_late_arrival_ready, NULL, dmu_sync_late_arrival_done,
 	    dsa, ZIO_PRIORITY_SYNC_WRITE, ZIO_FLAG_CANFAIL, zb));
@@ -3066,9 +3126,10 @@ dmu_object_dnsize_from_db(dmu_buf_t *db_fake, int *dnsize)
 	DB_DNODE_EXIT(db);
 }
 
-void
-byteswap_uint64_array(void *vbuf, size_t size)
+static int
+byteswap_uint64_array_func(void *vbuf, size_t size, void *priv)
 {
+	(void) priv;
 	uint64_t *buf = vbuf;
 	size_t count = size >> 3;
 	int i;
@@ -3077,11 +3138,25 @@ byteswap_uint64_array(void *vbuf, size_t size)
 
 	for (i = 0; i < count; i++)
 		buf[i] = BSWAP_64(buf[i]);
+	return (0);
 }
 
 void
-byteswap_uint32_array(void *vbuf, size_t size)
+byteswap_uint64_array(void *vbuf, size_t size)
 {
+	byteswap_uint64_array_func(vbuf, size, NULL);
+}
+
+void
+abd_byteswap_uint64_array(abd_t *abd, size_t size)
+{
+	abd_iterate_func(abd, 0, size, byteswap_uint64_array_func, NULL);
+}
+
+static int
+byteswap_uint32_array_func(void *vbuf, size_t size, void *priv)
+{
+	(void) priv;
 	uint32_t *buf = vbuf;
 	size_t count = size >> 2;
 	int i;
@@ -3090,11 +3165,25 @@ byteswap_uint32_array(void *vbuf, size_t size)
 
 	for (i = 0; i < count; i++)
 		buf[i] = BSWAP_32(buf[i]);
+	return (0);
 }
 
 void
-byteswap_uint16_array(void *vbuf, size_t size)
+byteswap_uint32_array(void *vbuf, size_t size)
 {
+	byteswap_uint32_array_func(vbuf, size, NULL);
+}
+
+void
+abd_byteswap_uint32_array(abd_t *abd, size_t size)
+{
+	abd_iterate_func(abd, 0, size, byteswap_uint32_array_func, NULL);
+}
+
+static int
+byteswap_uint16_array_func(void *vbuf, size_t size, void *priv)
+{
+	(void) priv;
 	uint16_t *buf = vbuf;
 	size_t count = size >> 1;
 	int i;
@@ -3103,12 +3192,31 @@ byteswap_uint16_array(void *vbuf, size_t size)
 
 	for (i = 0; i < count; i++)
 		buf[i] = BSWAP_16(buf[i]);
+	return (0);
+}
+
+void
+byteswap_uint16_array(void *vbuf, size_t size)
+{
+	byteswap_uint16_array_func(vbuf, size, NULL);
+}
+
+void
+abd_byteswap_uint16_array(abd_t *abd, size_t size)
+{
+	abd_iterate_func(abd, 0, size, byteswap_uint16_array_func, NULL);
 }
 
 void
 byteswap_uint8_array(void *vbuf, size_t size)
 {
 	(void) vbuf, (void) size;
+}
+
+void
+abd_byteswap_uint8_array(abd_t *abd, size_t size)
+{
+	(void) abd, (void) size;
 }
 
 void

--- a/module/zfs/dmu_diff.c
+++ b/module/zfs/dmu_diff.c
@@ -147,7 +147,7 @@ diff_cb(spa_t *spa, zilog_t *zilog, const blkptr_t *bp,
 		    ZIO_PRIORITY_ASYNC_READ, zio_flags, &aflags, zb) != 0)
 			return (SET_ERROR(EIO));
 
-		blk = abuf->b_data;
+		blk = abd_to_buf(abuf->b_abd);
 		for (i = 0; i < epb; i += blk[i].dn_extra_slots + 1) {
 			uint64_t dnobj = (zb->zb_blkid <<
 			    (DNODE_BLOCK_SHIFT - DNODE_SHIFT)) + i;

--- a/module/zfs/dmu_direct.c
+++ b/module/zfs/dmu_direct.c
@@ -98,7 +98,7 @@ dmu_write_direct_done(zio_t *zio)
 	mutex_enter(&db->db_mtx);
 	ASSERT0P(db->db_buf);
 	ASSERT0P(dr->dt.dl.dr_data);
-	ASSERT0P(db->db.db_data);
+	ASSERT0P(db->db.db_abd);
 	db->db_state = DB_UNCACHED;
 	mutex_exit(&db->db_mtx);
 
@@ -213,7 +213,7 @@ dmu_write_direct(zio_t *pio, dmu_buf_impl_t *db, abd_t *data, dmu_tx_t *tx)
 }
 
 int
-dmu_write_abd(dnode_t *dn, uint64_t offset, uint64_t size,
+dmu_write_abd_direct(dnode_t *dn, uint64_t offset, uint64_t size,
     abd_t *data, dmu_flags_t flags, dmu_tx_t *tx)
 {
 	dmu_buf_t **dbp;
@@ -312,8 +312,8 @@ dmu_read_abd(dnode_t *dn, uint64_t offset, uint64_t size,
 				 */
 				err = dmu_buf_untransform_direct(db, spa);
 				ASSERT0(err);
-				abd_copy_from_buf_off(data,
-				    (char *)db->db.db_data + boff, aoff, len);
+				abd_copy_off(data, db->db.db_abd, aoff, boff,
+				    len);
 			} else {
 				abd_zero_off(data, aoff, len);
 			}
@@ -391,7 +391,7 @@ dmu_write_uio_direct(dnode_t *dn, zfs_uio_t *uio, uint64_t size,
 
 	abd_t *data = abd_alloc_from_pages(&uio->uio_dio.pages[page_index],
 	    offset & (PAGESIZE - 1), size);
-	err = dmu_write_abd(dn, offset, size, data, flags, tx);
+	err = dmu_write_abd_direct(dn, offset, size, data, flags, tx);
 	abd_free(data);
 
 	if (err == 0)

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -401,6 +401,12 @@ dmu_objset_byteswap(void *buf, size_t size)
 	}
 }
 
+void
+abd_dmu_objset_byteswap(abd_t *abd, size_t size)
+{
+	dmu_objset_byteswap(abd_to_buf(abd), size);
+}
+
 /*
  * Runs cityhash on the objset_t pointer and the object number.
  */
@@ -530,21 +536,21 @@ dmu_objset_open_impl(spa_t *spa, dsl_dataset_t *ds, blkptr_t *bp,
 		if (arc_buf_size(os->os_phys_buf) < size) {
 			arc_buf_t *buf = arc_alloc_buf(spa, &os->os_phys_buf,
 			    ARC_BUFC_METADATA, size);
-			memset(buf->b_data, 0, size);
-			memcpy(buf->b_data, os->os_phys_buf->b_data,
+			abd_zero(buf->b_abd, size);
+			abd_copy(buf->b_abd, os->os_phys_buf->b_abd,
 			    arc_buf_size(os->os_phys_buf));
 			arc_buf_destroy(os->os_phys_buf, &os->os_phys_buf);
 			os->os_phys_buf = buf;
 		}
 
-		os->os_phys = os->os_phys_buf->b_data;
+		os->os_phys = abd_to_buf(os->os_phys_buf->b_abd);
 		os->os_flags = os->os_phys->os_flags;
 	} else {
 		int size = spa_version(spa) >= SPA_VERSION_USERSPACE ?
 		    sizeof (objset_phys_t) : OBJSET_PHYS_SIZE_V1;
 		os->os_phys_buf = arc_alloc_buf(spa, &os->os_phys_buf,
 		    ARC_BUFC_METADATA, size);
-		os->os_phys = os->os_phys_buf->b_data;
+		os->os_phys = abd_to_buf(os->os_phys_buf->b_abd);
 		memset(os->os_phys, 0, size);
 	}
 	/*
@@ -2169,7 +2175,7 @@ dmu_objset_userquota_find_data(dmu_buf_impl_t *db, dmu_tx_t *tx)
 
 	if (db->db_dirtycnt == 0) {
 		ASSERT(MUTEX_HELD(&db->db_mtx));
-		return (db->db.db_data);  /* Nothing is changing */
+		return (abd_to_buf(db->db.db_abd));  /* Nothing is changing */
 	}
 
 	dr = dbuf_find_dirty_eq(db, tx->tx_txg);
@@ -2179,7 +2185,7 @@ dmu_objset_userquota_find_data(dmu_buf_impl_t *db, dmu_tx_t *tx)
 	} else {
 		if (dr->dr_dnode->dn_bonuslen == 0 &&
 		    dr->dr_dbuf->db_blkid == DMU_SPILL_BLKID)
-			data = dr->dt.dl.dr_data->b_data;
+			data = abd_to_buf(dr->dt.dl.dr_data->b_abd);
 		else
 			data = dr->dt.dl.dr_data;
 	}
@@ -2235,7 +2241,7 @@ dmu_objset_userquota_get_ids(dnode_t *dn, boolean_t before, dmu_tx_t *tx)
 			    FTAG, (dmu_buf_t **)&db);
 			ASSERT0(error);
 			mutex_enter(&db->db_mtx);
-			data = (before) ? db->db.db_data :
+			data = (before) ? abd_to_buf(db->db.db_abd) :
 			    dmu_objset_userquota_find_data(db, tx);
 			have_spill = B_TRUE;
 	} else {

--- a/module/zfs/dmu_recv.c
+++ b/module/zfs/dmu_recv.c
@@ -1722,8 +1722,8 @@ receive_object_is_same_generation(objset_t *os, uint64_t object,
 	err = dmu_bonus_hold(os, object, FTAG, &old_bonus_dbuf);
 	if (err != 0)
 		return (err);
-	err = dmu_get_file_info(os, old_bonus_type, old_bonus_dbuf->db_data,
-	    &zoi);
+	err = dmu_get_file_info(os, old_bonus_type,
+	    abd_to_buf(old_bonus_dbuf->db_abd), &zoi);
 	dmu_buf_rele(old_bonus_dbuf, FTAG);
 	if (err != 0)
 		return (err);
@@ -3059,7 +3059,8 @@ receive_object(struct receive_writer_arg *rwa, struct drr_object *drro,
 		dmu_buf_will_dirty(db, tx);
 
 		ASSERT3U(db->db_size, >=, drro->drr_bonuslen);
-		memcpy(db->db_data, data, DRR_OBJECT_PAYLOAD_SIZE(drro));
+		abd_copy_from_buf(db->db_abd, data,
+		    DRR_OBJECT_PAYLOAD_SIZE(drro));
 
 		/*
 		 * Raw bonus buffers have their byteorder determined by the
@@ -3068,7 +3069,7 @@ receive_object(struct receive_writer_arg *rwa, struct drr_object *drro,
 		if (rwa->byteswap && !rwa->raw) {
 			dmu_object_byteswap_t byteswap =
 			    DMU_OT_BYTESWAP(drro->drr_bonustype);
-			dmu_ot_byteswap[byteswap].ob_func(db->db_data,
+			dmu_ot_byteswap[byteswap].ob_abd_func(db->db_abd,
 			    DRR_OBJECT_PAYLOAD_SIZE(drro));
 		}
 		dmu_buf_rele(db, FTAG);
@@ -3547,7 +3548,7 @@ receive_spill(struct receive_writer_arg *rwa, struct drr_spill *drrs,
 		}
 	}
 
-	memcpy(abuf->b_data, abd_to_buf(abd), DRR_SPILL_PAYLOAD_SIZE(drrs));
+	abd_copy(abuf->b_abd, abd, DRR_SPILL_PAYLOAD_SIZE(drrs));
 	abd_free(abd);
 	dbuf_assign_arcbuf((dmu_buf_impl_t *)db_spill, abuf, tx,
 	    DMU_UNCACHEDIO);

--- a/module/zfs/dmu_recv.c
+++ b/module/zfs/dmu_recv.c
@@ -3521,7 +3521,7 @@ receive_spill(struct receive_writer_arg *rwa, struct drr_spill *drrs,
 	if (db_spill->db_size != drrs->drr_length) {
 		dmu_buf_will_fill(db_spill, tx, B_FALSE);
 		VERIFY0(dbuf_spill_set_blksz(db_spill,
-		    drrs->drr_length, tx));
+		    drrs->drr_length, B_FALSE, tx));
 	}
 
 	arc_buf_t *abuf;

--- a/module/zfs/dmu_send.c
+++ b/module/zfs/dmu_send.c
@@ -874,6 +874,17 @@ send_do_embed(const blkptr_t *bp, uint64_t featureflags)
 	return (B_FALSE);
 }
 
+static int
+fillbadblock(void *p, size_t size, void *private)
+{
+	(void) private;
+	int i;
+	uint64_t *x = p;
+	for (i = 0; i < size >> 3; i++)
+		x[i] = 0x2f5baddb10cULL;
+	return (0);
+}
+
 /*
  * This function actually handles figuring out what kind of record needs to be
  * dumped, and calling the appropriate helper function.  In most cases,
@@ -946,11 +957,8 @@ do_dump(dmu_send_cookie_t *dscp, struct send_range *range)
 				 */
 				srdp->abuf = arc_alloc_buf(spa, &srdp->abuf,
 				    ARC_BUFC_DATA, srdp->datablksz);
-				uint64_t *ptr;
-				for (ptr = srdp->abuf->b_data;
-				    (char *)ptr < (char *)srdp->abuf->b_data +
-				    srdp->datablksz; ptr++)
-					*ptr = 0x2f5baddb10cULL;
+				abd_iterate_func(srdp->abuf->b_abd, 0,
+				    srdp->datablksz, fillbadblock, NULL);
 			} else {
 				return (SET_ERROR(EIO));
 			}
@@ -959,17 +967,26 @@ do_dump(dmu_send_cookie_t *dscp, struct send_range *range)
 		ASSERT(dscp->dsc_dso->dso_dryrun ||
 		    srdp->abuf != NULL || srdp->abd != NULL);
 
-		char *data = NULL;
+		abd_t *data = NULL;
 		if (srdp->abd != NULL) {
-			data = abd_to_buf(srdp->abd);
+			data = srdp->abd;
 			ASSERT0P(srdp->abuf);
 		} else if (srdp->abuf != NULL) {
-			data = srdp->abuf->b_data;
+			data = srdp->abuf->b_abd;
+		}
+
+		void *dump_buf = NULL;
+		if (data) {
+			ASSERT(data->abd_size == srdp->datablksz ||
+			    data->abd_size == srdp->datasz);
+			dump_buf = abd_borrow_buf_copy(data, data->abd_size);
 		}
 
 		if (BP_GET_TYPE(bp) == DMU_OT_SA) {
 			ASSERT3U(range->start_blkid, ==, DMU_SPILL_BLKID);
-			err = dump_spill(dscp, bp, range->object, data);
+			err = dump_spill(dscp, bp, range->object, dump_buf);
+			if (data)
+				abd_return_buf(data, dump_buf, data->abd_size);
 			return (err);
 		}
 
@@ -983,28 +1000,31 @@ do_dump(dmu_send_cookie_t *dscp, struct send_range *range)
 		if (srdp->datablksz > SPA_OLD_MAXBLOCKSIZE &&
 		    !(dscp->dsc_featureflags &
 		    DMU_BACKUP_FEATURE_LARGE_BLOCKS)) {
+			void *tmp = dump_buf;
 			while (srdp->datablksz > 0 && err == 0) {
 				int n = MIN(srdp->datablksz,
 				    SPA_OLD_MAXBLOCKSIZE);
 				err = dmu_dump_write(dscp, srdp->obj_type,
 				    range->object, offset, n, n, NULL, B_FALSE,
-				    data);
+				    tmp);
 				offset += n;
 				/*
 				 * When doing dry run, data==NULL is used as a
 				 * sentinel value by
 				 * dmu_dump_write()->dump_record().
 				 */
-				if (data != NULL)
-					data += n;
+				if (tmp != NULL)
+					tmp += n;
 				srdp->datablksz -= n;
 			}
 		} else {
 			err = dmu_dump_write(dscp, srdp->obj_type,
 			    range->object, offset,
 			    srdp->datablksz, srdp->datasz, bp,
-			    srdp->io_compressed, data);
+			    srdp->io_compressed, dump_buf);
 		}
+		if (data)
+			abd_return_buf(data, dump_buf, data->abd_size);
 		return (err);
 	}
 	case HOLE: {

--- a/module/zfs/dmu_traverse.c
+++ b/module/zfs/dmu_traverse.c
@@ -341,6 +341,7 @@ traverse_visitbp(traverse_data_t *td, const dnode_phys_t *dnp,
 		ptidx = 0;
 		pidx = 1;
 		prefetchlimit = zfs_traverse_indirect_prefetch_limit;
+		blkptr_t *bps = abd_to_buf(buf->b_abd);
 		for (i = 0; i < epb; i++) {
 			if (prefetchlimit && i == ptidx) {
 				ASSERT3S(ptidx, <=, pidx);
@@ -350,8 +351,7 @@ traverse_visitbp(traverse_data_t *td, const dnode_phys_t *dnp,
 					    zb->zb_object, zb->zb_level - 1,
 					    zb->zb_blkid * epb + pidx);
 					if (traverse_prefetch_metadata(td, dnp,
-					    &((blkptr_t *)buf->b_data)[pidx],
-					    czb) == B_TRUE) {
+					    &bps[pidx], czb) == B_TRUE) {
 						prefetched++;
 						if (prefetched ==
 						    MAX(prefetchlimit / 2, 1))
@@ -364,8 +364,7 @@ traverse_visitbp(traverse_data_t *td, const dnode_phys_t *dnp,
 			SET_BOOKMARK(czb, zb->zb_objset, zb->zb_object,
 			    zb->zb_level - 1,
 			    zb->zb_blkid * epb + i);
-			err = traverse_visitbp(td, dnp,
-			    &((blkptr_t *)buf->b_data)[i], czb);
+			err = traverse_visitbp(td, dnp, &bps[i], czb);
 			if (err != 0)
 				break;
 		}
@@ -391,7 +390,7 @@ traverse_visitbp(traverse_data_t *td, const dnode_phys_t *dnp,
 		if (err != 0)
 			goto post;
 
-		child_dnp = buf->b_data;
+		child_dnp = abd_to_buf(buf->b_abd);
 
 		for (i = 0; i < epb; i += child_dnp[i].dn_extra_slots + 1) {
 			prefetch_dnode_metadata(td, &child_dnp[i],
@@ -418,7 +417,7 @@ traverse_visitbp(traverse_data_t *td, const dnode_phys_t *dnp,
 		if (err != 0)
 			goto post;
 
-		osp = buf->b_data;
+		osp = abd_to_buf(buf->b_abd);
 		prefetch_dnode_metadata(td, &osp->os_meta_dnode, zb->zb_objset,
 		    DMU_META_DNODE_OBJECT);
 		/*
@@ -699,7 +698,7 @@ traverse_impl(spa_t *spa, dsl_dataset_t *ds, uint64_t objset, blkptr_t *rootbp,
 			    !(td->td_flags & TRAVERSE_PRE))
 				goto out;
 		} else {
-			osp = buf->b_data;
+			osp = abd_to_buf(buf->b_abd);
 			traverse_zil(td, &osp->os_zil_header);
 			arc_buf_destroy(buf, &buf);
 		}

--- a/module/zfs/dnode.c
+++ b/module/zfs/dnode.c
@@ -1978,7 +1978,7 @@ dnode_set_blksz(dnode_t *dn, uint64_t size, int ibs, dmu_tx_t *tx)
 		/* resize the old block */
 		err = dbuf_hold_impl(dn, 0, 0, TRUE, FALSE, FTAG, &db);
 		if (err == 0) {
-			dbuf_new_size(db, size, tx);
+			dbuf_new_size(db, size, B_TRUE, tx);
 		} else if (err != ENOENT) {
 			goto fail;
 		}

--- a/module/zfs/dnode.c
+++ b/module/zfs/dnode.c
@@ -447,7 +447,7 @@ dnode_verify(dnode_t *dn)
 	ASSERT(DMU_OBJECT_IS_SPECIAL(dn->dn_object) || dn->dn_dbuf != NULL);
 	if (dn->dn_dbuf != NULL) {
 		ASSERT3P(dn->dn_phys, ==,
-		    (dnode_phys_t *)dn->dn_dbuf->db.db_data +
+		    (dnode_phys_t *)abd_to_buf(dn->dn_dbuf->db.db_abd) +
 		    (dn->dn_object % (dn->dn_dbuf->db.db_size >> DNODE_SHIFT)));
 	}
 	if (drop_struct_lock)
@@ -518,6 +518,12 @@ dnode_buf_byteswap(void *vbuf, size_t size)
 }
 
 void
+abd_dnode_buf_byteswap(abd_t *abd, size_t size)
+{
+	dnode_buf_byteswap(abd_to_buf(abd), size);
+}
+
+void
 dnode_setbonuslen(dnode_t *dn, int newsize, dmu_tx_t *tx)
 {
 	ASSERT3U(zfs_refcount_count(&dn->dn_holds), >=, 1);
@@ -530,8 +536,7 @@ dnode_setbonuslen(dnode_t *dn, int newsize, dmu_tx_t *tx)
 	if (newsize < dn->dn_bonuslen) {
 		/* clear any data after the end of the new size */
 		size_t diff = dn->dn_bonuslen - newsize;
-		char *data_end = ((char *)dn->dn_bonus->db.db_data) + newsize;
-		memset(data_end, 0, diff);
+		abd_zero_off(dn->dn_bonus->db.db_abd, newsize, diff);
 	}
 
 	dn->dn_bonuslen = newsize;
@@ -1529,7 +1534,7 @@ dnode_hold_impl(objset_t *os, uint64_t object, int flag, int slots,
 	epb = db->db.db_size >> DNODE_SHIFT;
 
 	idx = object & (epb - 1);
-	dn_block = (dnode_phys_t *)db->db.db_data;
+	dn_block = (dnode_phys_t *)abd_to_buf(db->db.db_abd);
 
 	ASSERT(DB_DNODE(db)->dn_type == DMU_OT_DNODE);
 	dnc = dmu_buf_get_user(&db->db);
@@ -2236,11 +2241,8 @@ dnode_partial_zero(dnode_t *dn, uint64_t off, uint64_t blkoff, uint64_t len,
 		    (db->db_blkptr && !BP_IS_HOLE(db->db_blkptr));
 		dmu_buf_unlock_parent(db, dblt, FTAG);
 		if (dirty) {
-			caddr_t data;
-
 			dmu_buf_will_dirty(&db->db, tx);
-			data = db->db.db_data;
-			memset(data + blkoff, 0, len);
+			abd_zero_off(db->db.db_abd, blkoff, len);
 		}
 		dbuf_rele(db, FTAG);
 	}
@@ -2597,7 +2599,7 @@ dnode_next_offset_level(dnode_t *dn, int flags, int lvl, uint64_t blkid,
 			dbuf_rele(db, FTAG);
 			return (error);
 		}
-		data = db->db.db_data;
+		data = abd_to_buf(db->db.db_abd);
 		rw_enter(&db->db_rwlock, RW_READER);
 	}
 

--- a/module/zfs/dnode_sync.c
+++ b/module/zfs/dnode_sync.c
@@ -80,10 +80,10 @@ dnode_increase_indirection(dnode_t *dn, dmu_tx_t *tx)
 	if (dn->dn_dbuf != NULL)
 		rw_enter(&dn->dn_dbuf->db_rwlock, RW_WRITER);
 	rw_enter(&db->db_rwlock, RW_WRITER);
-	ASSERT(db->db.db_data);
+	ASSERT(db->db.db_abd);
 	ASSERT(arc_released(db->db_buf));
 	ASSERT3U(sizeof (blkptr_t) * nblkptr, <=, db->db.db_size);
-	memcpy(db->db.db_data, dn->dn_phys->dn_blkptr,
+	abd_copy_from_buf(db->db.db_abd, dn->dn_phys->dn_blkptr,
 	    sizeof (blkptr_t) * nblkptr);
 	arc_buf_freeze(db->db_buf);
 
@@ -110,8 +110,9 @@ dnode_increase_indirection(dnode_t *dn, dmu_tx_t *tx)
 
 		child->db_parent = db;
 		dbuf_add_ref(db, child);
-		if (db->db.db_data)
-			child->db_blkptr = (blkptr_t *)db->db.db_data + i;
+		if (db->db.db_abd)
+			child->db_blkptr =
+			    (blkptr_t *)abd_to_buf(db->db.db_abd) + i;
 		else
 			child->db_blkptr = NULL;
 		dprintf_dbuf_bp(child, child->db_blkptr,
@@ -173,10 +174,23 @@ free_blocks(dnode_t *dn, blkptr_t *bp, int num, dmu_tx_t *tx)
 }
 
 #ifdef ZFS_DEBUG
+static int
+checkzero(void *p, size_t size, void *private)
+{
+	(void) private;
+	size_t i;
+	uint64_t *x = p;
+	for (i = 0; i < size >> 3; i++) {
+		if (x[i] != 0)
+			return (1);
+	}
+	return (0);
+}
+
 static void
 free_verify(dmu_buf_impl_t *db, uint64_t start, uint64_t end, dmu_tx_t *tx)
 {
-	uint64_t off, num, i, j;
+	uint64_t off, num, i;
 	unsigned int epbs;
 	int err;
 	uint64_t txg = tx->tx_txg;
@@ -197,7 +211,7 @@ free_verify(dmu_buf_impl_t *db, uint64_t start, uint64_t end, dmu_tx_t *tx)
 	ASSERT(db->db_blkptr != NULL);
 
 	for (i = off; i < off+num; i++) {
-		uint64_t *buf;
+		abd_t *buf;
 		dmu_buf_impl_t *child;
 		dbuf_dirty_record_t *dr;
 
@@ -215,37 +229,33 @@ free_verify(dmu_buf_impl_t *db, uint64_t start, uint64_t end, dmu_tx_t *tx)
 
 		/* data_old better be zeroed */
 		if (dr) {
-			buf = dr->dt.dl.dr_data->b_data;
-			for (j = 0; j < child->db.db_size >> 3; j++) {
-				if (buf[j] != 0) {
-					panic("freed data not zero: "
-					    "child=%p i=%llu off=%llu "
-					    "num=%llu\n",
-					    (void *)child, (u_longlong_t)i,
-					    (u_longlong_t)off,
-					    (u_longlong_t)num);
-				}
-			}
+			buf = dr->dt.dl.dr_data->b_abd;
+			if (abd_iterate_func(buf, 0, child->db.db_size,
+			    checkzero, NULL) != 0)
+				panic("freed data not zero: "
+				    "child=%p i=%llu off=%llu "
+				    "num=%llu\n",
+				    (void *)child, (u_longlong_t)i,
+				    (u_longlong_t)off,
+				    (u_longlong_t)num);
 		}
 
 		/*
-		 * db_data better be zeroed unless it's dirty in a
+		 * db_abd better be zeroed unless it's dirty in a
 		 * future txg.
 		 */
 		mutex_enter(&child->db_mtx);
-		buf = child->db.db_data;
+		buf = child->db.db_abd;
 		if (buf != NULL && child->db_state != DB_FILL &&
 		    list_is_empty(&child->db_dirty_records)) {
-			for (j = 0; j < child->db.db_size >> 3; j++) {
-				if (buf[j] != 0) {
-					panic("freed data not zero: "
-					    "child=%p i=%llu off=%llu "
-					    "num=%llu\n",
-					    (void *)child, (u_longlong_t)i,
-					    (u_longlong_t)off,
-					    (u_longlong_t)num);
-				}
-			}
+			if (abd_iterate_func(buf, 0, child->db.db_size,
+			    checkzero, NULL) != 0)
+				panic("freed data not zero: "
+				    "child=%p i=%llu off=%llu "
+				    "num=%llu\n",
+				    (void *)child, (u_longlong_t)i,
+				    (u_longlong_t)off,
+				    (u_longlong_t)num);
 		}
 		mutex_exit(&child->db_mtx);
 
@@ -313,7 +323,7 @@ free_children(dmu_buf_impl_t *db, uint64_t blkid, uint64_t nblks,
 	}
 
 	dbuf_release_bp(db);
-	bp = db->db.db_data;
+	bp = abd_to_buf(db->db.db_abd);
 
 	DB_DNODE_ENTER(db);
 	dn = DB_DNODE(db);
@@ -356,9 +366,10 @@ free_children(dmu_buf_impl_t *db, uint64_t blkid, uint64_t nblks,
 
 	if (free_indirects) {
 		rw_enter(&db->db_rwlock, RW_WRITER);
-		for (i = 0, bp = db->db.db_data; i < 1 << epbs; i++, bp++)
+		bp = abd_to_buf(db->db.db_abd);
+		for (i = 0; i < 1 << epbs; i++, bp++)
 			ASSERT(BP_IS_HOLE(bp));
-		memset(db->db.db_data, 0, db->db.db_size);
+		abd_zero(db->db.db_abd, db->db.db_size);
 		free_blocks(dn, db->db_blkptr, 1, tx);
 		rw_exit(&db->db_rwlock);
 	}

--- a/module/zfs/dsl_bookmark.c
+++ b/module/zfs/dsl_bookmark.c
@@ -494,7 +494,7 @@ dsl_bookmark_create_sync_impl_snap(const char *bookmark, const char *snapshot,
 			dmu_buf_will_fill(db, tx, B_FALSE);
 			VERIFY0(dbuf_spill_set_blksz(db, P2ROUNDUP(bonuslen,
 			    SPA_MINBLOCKSIZE), B_TRUE, tx));
-			local_rl->rl_phys = db->db_data;
+			local_rl->rl_phys = abd_to_buf(db->db_abd);
 			local_rl->rl_dbuf = db;
 		}
 		memcpy(local_rl->rl_phys->rlp_snaps, redact_snaps,
@@ -1277,7 +1277,7 @@ dsl_redaction_list_hold_obj(dsl_pool_t *dp, uint64_t rlobj, const void *tag,
 			rl->rl_dbuf = dbuf;
 		}
 		rl->rl_object = rlobj;
-		rl->rl_phys = rl->rl_dbuf->db_data;
+		rl->rl_phys = abd_to_buf(rl->rl_dbuf->db_abd);
 		rl->rl_mos = dp->dp_meta_objset;
 		zfs_refcount_create(&rl->rl_longholds);
 		dmu_buf_init_user(&rl->rl_dbu, redaction_list_evict_sync, NULL,

--- a/module/zfs/dsl_bookmark.c
+++ b/module/zfs/dsl_bookmark.c
@@ -493,7 +493,7 @@ dsl_bookmark_create_sync_impl_snap(const char *bookmark, const char *snapshot,
 			    DB_RF_MUST_SUCCEED, tag, &db));
 			dmu_buf_will_fill(db, tx, B_FALSE);
 			VERIFY0(dbuf_spill_set_blksz(db, P2ROUNDUP(bonuslen,
-			    SPA_MINBLOCKSIZE), tx));
+			    SPA_MINBLOCKSIZE), B_TRUE, tx));
 			local_rl->rl_phys = db->db_data;
 			local_rl->rl_dbuf = db;
 		}

--- a/module/zfs/dsl_dataset.c
+++ b/module/zfs/dsl_dataset.c
@@ -520,7 +520,7 @@ dsl_dataset_get_snapname(dsl_dataset_t *ds)
 	    FTAG, &headdbuf);
 	if (err != 0)
 		return (err);
-	headphys = headdbuf->db_data;
+	headphys = abd_to_buf(headdbuf->db_abd);
 	err = zap_value_search(dp->dp_meta_objset,
 	    headphys->ds_snapnames_zapobj, ds->ds_object, 0, ds->ds_snapname,
 	    sizeof (ds->ds_snapname));
@@ -770,7 +770,7 @@ after_dsl_bookmark_fini:
 	}
 
 	ASSERT3P(ds->ds_dbuf, ==, dbuf);
-	ASSERT3P(dsl_dataset_phys(ds), ==, dbuf->db_data);
+	ASSERT3P(dsl_dataset_phys(ds), ==, abd_to_buf(dbuf->db_abd));
 	ASSERT(dsl_dataset_phys(ds)->ds_prev_snap_obj != 0 ||
 	    spa_version(dp->dp_spa) < SPA_VERSION_ORIGIN ||
 	    dp->dp_origin_snap == NULL || ds == dp->dp_origin_snap);
@@ -1195,7 +1195,7 @@ dsl_dataset_create_sync_dd(dsl_dir_t *dd, dsl_dataset_t *origin,
 	    DMU_OT_DSL_DATASET, sizeof (dsl_dataset_phys_t), tx);
 	VERIFY0(dmu_bonus_hold(mos, dsobj, FTAG, &dbuf));
 	dmu_buf_will_dirty(dbuf, tx);
-	dsphys = dbuf->db_data;
+	dsphys = abd_to_buf(dbuf->db_abd);
 	memset(dsphys, 0, sizeof (dsl_dataset_phys_t));
 	dsphys->ds_dir_obj = dd->dd_object;
 	dsphys->ds_flags = flags;
@@ -1761,7 +1761,7 @@ dsl_dataset_snapshot_sync_impl(dsl_dataset_t *ds, const char *snapname,
 	    DMU_OT_DSL_DATASET, sizeof (dsl_dataset_phys_t), tx);
 	VERIFY0(dmu_bonus_hold(mos, dsobj, FTAG, &dbuf));
 	dmu_buf_will_dirty(dbuf, tx);
-	dsphys = dbuf->db_data;
+	dsphys = abd_to_buf(dbuf->db_abd);
 	memset(dsphys, 0, sizeof (dsl_dataset_phys_t));
 	dsphys->ds_dir_obj = ds->ds_dir->dd_object;
 	dsphys->ds_fsid_guid = unique_create();

--- a/module/zfs/dsl_deadlist.c
+++ b/module/zfs/dsl_deadlist.c
@@ -323,7 +323,7 @@ dsl_deadlist_open(dsl_deadlist_t *dl, objset_t *os, uint64_t object)
 	}
 
 	dl->dl_oldfmt = B_FALSE;
-	dl->dl_phys = dl->dl_dbuf->db_data;
+	dl->dl_phys = abd_to_buf(dl->dl_dbuf->db_abd);
 	dl->dl_havetree = B_FALSE;
 	dl->dl_havecache = B_FALSE;
 	return (0);
@@ -917,7 +917,7 @@ dsl_deadlist_merge(dsl_deadlist_t *dl, uint64_t obj, dmu_tx_t *tx)
 	zap_cursor_fini(&pzc);
 
 	VERIFY0(dmu_bonus_hold(dl->dl_os, obj, FTAG, &bonus));
-	dlp = bonus->db_data;
+	dlp = abd_to_buf(bonus->db_abd);
 	dmu_buf_will_dirty(bonus, tx);
 	memset(dlp, 0, sizeof (*dlp));
 	dmu_buf_rele(bonus, FTAG);

--- a/module/zfs/dsl_dir.c
+++ b/module/zfs/dsl_dir.c
@@ -265,7 +265,7 @@ dsl_dir_hold_obj(dsl_pool_t *dp, uint64_t ddobj,
 			    &origin_bonus);
 			if (err != 0)
 				goto errout;
-			origin_phys = origin_bonus->db_data;
+			origin_phys = abd_to_buf(origin_bonus->db_abd);
 			dd->dd_origin_txg =
 			    origin_phys->ds_creation_txg;
 			dmu_buf_rele(origin_bonus, FTAG);
@@ -969,7 +969,7 @@ dsl_dir_create_sync(dsl_pool_t *dp, dsl_dir_t *pds, const char *name,
 	}
 	VERIFY0(dmu_bonus_hold(mos, ddobj, FTAG, &dbuf));
 	dmu_buf_will_dirty(dbuf, tx);
-	ddphys = dbuf->db_data;
+	ddphys = abd_to_buf(dbuf->db_abd);
 
 	ddphys->dd_creation_time = gethrestime_sec();
 	if (pds) {

--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -2161,7 +2161,8 @@ dsl_scan_prefetch_cb(zio_t *zio, const zbookmark_phys_t *zb, const blkptr_t *bp,
 		int epb = BP_GET_LSIZE(bp) >> SPA_BLKPTRSHIFT;
 		zbookmark_phys_t czb;
 
-		for (i = 0, cbp = buf->b_data; i < epb; i++, cbp++) {
+		cbp = abd_to_buf(buf->b_abd);
+		for (i = 0; i < epb; i++, cbp++) {
 			SET_BOOKMARK(&czb, zb->zb_objset, zb->zb_object,
 			    zb->zb_level - 1, zb->zb_blkid * epb + i);
 			dsl_scan_prefetch(spc, cbp, &czb);
@@ -2171,14 +2172,15 @@ dsl_scan_prefetch_cb(zio_t *zio, const zbookmark_phys_t *zb, const blkptr_t *bp,
 		int i;
 		int epb = BP_GET_LSIZE(bp) >> DNODE_SHIFT;
 
-		for (i = 0, cdnp = buf->b_data; i < epb;
+		cdnp = abd_to_buf(buf->b_abd);
+		for (i = 0; i < epb;
 		    i += cdnp->dn_extra_slots + 1,
 		    cdnp += cdnp->dn_extra_slots + 1) {
 			dsl_scan_prefetch_dnode(scn, cdnp,
 			    zb->zb_objset, zb->zb_blkid * epb + i);
 		}
 	} else if (BP_GET_TYPE(bp) == DMU_OT_OBJSET) {
-		objset_phys_t *osp = buf->b_data;
+		objset_phys_t *osp = abd_to_buf(buf->b_abd);
 
 		dsl_scan_prefetch_dnode(scn, &osp->os_meta_dnode,
 		    zb->zb_objset, DMU_META_DNODE_OBJECT);
@@ -2360,7 +2362,8 @@ dsl_scan_recurse(dsl_scan_t *scn, dsl_dataset_t *ds, dmu_objset_type_t ostype,
 			scn->scn_phys.scn_errors++;
 			return (err);
 		}
-		for (i = 0, cbp = buf->b_data; i < epb; i++, cbp++) {
+		cbp = abd_to_buf(buf->b_abd);
+		for (i = 0; i < epb; i++, cbp++) {
 			zbookmark_phys_t czb;
 
 			SET_BOOKMARK(&czb, zb->zb_objset, zb->zb_object,
@@ -2388,7 +2391,8 @@ dsl_scan_recurse(dsl_scan_t *scn, dsl_dataset_t *ds, dmu_objset_type_t ostype,
 			scn->scn_phys.scn_errors++;
 			return (err);
 		}
-		for (i = 0, cdnp = buf->b_data; i < epb;
+		cdnp = abd_to_buf(buf->b_abd);
+		for (i = 0; i < epb;
 		    i += cdnp->dn_extra_slots + 1,
 		    cdnp += cdnp->dn_extra_slots + 1) {
 			dsl_scan_visitdnode(scn, ds, ostype,
@@ -2408,7 +2412,7 @@ dsl_scan_recurse(dsl_scan_t *scn, dsl_dataset_t *ds, dmu_objset_type_t ostype,
 			return (err);
 		}
 
-		osp = buf->b_data;
+		osp = abd_to_buf(buf->b_abd);
 
 		dsl_scan_visitdnode(scn, ds, osp->os_type,
 		    &osp->os_meta_dnode, DMU_META_DNODE_OBJECT, tx);

--- a/module/zfs/sa.c
+++ b/module/zfs/sa.c
@@ -504,7 +504,7 @@ sa_resize_spill(sa_handle_t *hdl, uint32_t size, dmu_tx_t *tx)
 		blocksize = P2ROUNDUP_TYPED(size, SPA_MINBLOCKSIZE, uint32_t);
 	}
 
-	error = dbuf_spill_set_blksz(hdl->sa_spill, blocksize, tx);
+	error = dbuf_spill_set_blksz(hdl->sa_spill, blocksize, B_TRUE, tx);
 	ASSERT0(error);
 	return (error);
 }

--- a/module/zfs/sa.c
+++ b/module/zfs/sa.c
@@ -722,8 +722,9 @@ sa_build_layouts(sa_handle_t *hdl, sa_bulk_attr_t *attr_desc, int attr_count,
 	}
 
 	/* setup starting pointers to lay down data */
-	data_start = (void *)((uintptr_t)hdl->sa_bonus->db_data + hdrsize);
-	sahdr = (sa_hdr_phys_t *)hdl->sa_bonus->db_data;
+	data_start =
+	    (void *)((uintptr_t)abd_to_buf(hdl->sa_bonus->db_abd) + hdrsize);
+	sahdr = (sa_hdr_phys_t *)abd_to_buf(hdl->sa_bonus->db_abd);
 	buftype = SA_BONUS;
 
 	attrs_start = attrs = kmem_alloc(sizeof (sa_attr_type_t) * attr_count,
@@ -751,7 +752,8 @@ sa_build_layouts(sa_handle_t *hdl, sa_bulk_attr_t *attr_desc, int attr_count,
 			hash = -1ULL;
 			len_idx = 0;
 
-			sahdr = (sa_hdr_phys_t *)hdl->sa_spill->db_data;
+			sahdr = (sa_hdr_phys_t *)
+			    abd_to_buf(hdl->sa_spill->db_abd);
 			sahdr->sa_magic = SA_MAGIC;
 			data_start = (void *)((uintptr_t)sahdr +
 			    spillhdrsize);
@@ -1727,9 +1729,8 @@ sa_add_projid(sa_handle_t *hdl, dmu_tx_t *tx, uint64_t projid)
 		    &xattr, 8);
 
 	if (zp->z_pflags & ZFS_BONUS_SCANSTAMP) {
-		memcpy(scanstamp,
-		    (caddr_t)db->db_data + ZFS_OLD_ZNODE_PHYS_SIZE,
-		    AV_SCANSTAMP_SZ);
+		abd_copy_to_buf_off(scanstamp, db->db_abd,
+		    ZFS_OLD_ZNODE_PHYS_SIZE, AV_SCANSTAMP_SZ);
 		SA_ADD_BULK_ATTR(attrs, count, SA_ZPL_SCANSTAMP(zfsvfs), NULL,
 		    scanstamp, AV_SCANSTAMP_SZ);
 		zp->z_pflags &= ~ZFS_BONUS_SCANSTAMP;
@@ -1942,7 +1943,7 @@ sa_modify_attrs(sa_handle_t *hdl, sa_attr_type_t newattr,
 	if (DB_DNODE(db)->dn_bonuslen != 0) {
 		bonus_data_size = hdl->sa_bonus->db_size;
 		old_data[0] = kmem_alloc(bonus_data_size, KM_SLEEP);
-		memcpy(old_data[0], hdl->sa_bonus->db_data,
+		abd_copy_to_buf(old_data[0], hdl->sa_bonus->db_abd,
 		    hdl->sa_bonus->db_size);
 		bonus_attr_count = hdl->sa_bonus_tab->sa_layout->lot_attr_count;
 	} else {
@@ -1955,7 +1956,7 @@ sa_modify_attrs(sa_handle_t *hdl, sa_attr_type_t newattr,
 	if ((error = sa_get_spill(hdl)) == 0) {
 		spill_data_size = hdl->sa_spill->db_size;
 		old_data[1] = vmem_alloc(spill_data_size, KM_SLEEP);
-		memcpy(old_data[1], hdl->sa_spill->db_data,
+		abd_copy_to_buf(old_data[1], hdl->sa_spill->db_abd,
 		    hdl->sa_spill->db_size);
 		spill_attr_count =
 		    hdl->sa_spill_tab->sa_layout->lot_attr_count;

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -2774,7 +2774,7 @@ load_nvlist(spa_t *spa, uint64_t obj, nvlist_t **value)
 	if (error)
 		return (error);
 
-	nvsize = *(uint64_t *)db->db_data;
+	nvsize = *(uint64_t *)abd_to_buf(db->db_abd);
 	dmu_buf_rele(db, FTAG);
 
 	packed = vmem_alloc(nvsize, KM_SLEEP);
@@ -10203,7 +10203,7 @@ spa_sync_nvlist(spa_t *spa, uint64_t obj, nvlist_t *nv, dmu_tx_t *tx)
 
 	VERIFY0(dmu_bonus_hold(spa->spa_meta_objset, obj, FTAG, &db));
 	dmu_buf_will_dirty(db, tx);
-	*(uint64_t *)db->db_data = nvsize;
+	*(uint64_t *)abd_to_buf(db->db_abd) = nvsize;
 	dmu_buf_rele(db, FTAG);
 }
 

--- a/module/zfs/spa_history.c
+++ b/module/zfs/spa_history.c
@@ -103,7 +103,7 @@ spa_history_create_obj(spa_t *spa, dmu_tx_t *tx)
 	VERIFY0(dmu_bonus_hold(mos, spa->spa_history, FTAG, &dbp));
 	ASSERT3U(dbp->db_size, >=, sizeof (spa_history_phys_t));
 
-	shpp = dbp->db_data;
+	shpp = abd_to_buf(dbp->db_abd);
 	dmu_buf_will_dirty(dbp, tx);
 
 	/*
@@ -277,7 +277,7 @@ spa_history_log_sync(void *arg, dmu_tx_t *tx)
 	 * Update the offset when the write completes.
 	 */
 	VERIFY0(dmu_bonus_hold(mos, spa->spa_history, FTAG, &dbp));
-	shpp = dbp->db_data;
+	shpp = abd_to_buf(dbp->db_abd);
 
 	dmu_buf_will_dirty(dbp, tx);
 
@@ -446,7 +446,7 @@ spa_history_get(spa_t *spa, uint64_t *offp, uint64_t *len, char *buf)
 
 	if ((err = dmu_bonus_hold(mos, spa->spa_history, FTAG, &dbp)) != 0)
 		return (err);
-	shpp = dbp->db_data;
+	shpp = abd_to_buf(dbp->db_abd);
 
 #ifdef ZFS_DEBUG
 	{

--- a/module/zfs/space_map.c
+++ b/module/zfs/space_map.c
@@ -104,7 +104,7 @@ space_map_iterate(space_map_t *sm, uint64_t end, sm_cb_t callback, void *arg)
 		if (error != 0)
 			return (error);
 
-		uint64_t *block_start = db->db_data;
+		uint64_t *block_start = abd_to_buf(db->db_abd);
 		uint64_t block_length = MIN(end - block_base, blksz);
 		uint64_t *block_end = block_start +
 		    (block_length / sizeof (uint64_t));
@@ -222,7 +222,7 @@ space_map_reversed_last_block_entries(space_map_t *sm, uint64_t *buf,
 	ASSERT3U(bufsz, >=, db->db_size);
 	ASSERT(nwords != NULL);
 
-	uint64_t *words = db->db_data;
+	uint64_t *words = abd_to_buf(db->db_abd);
 	*nwords =
 	    (sm->sm_phys->smp_length - db->db_offset) / sizeof (uint64_t);
 
@@ -568,7 +568,7 @@ space_map_write_seg(space_map_t *sm, uint64_t rstart, uint64_t rend,
 	dmu_buf_t *db = *dbp;
 	ASSERT3U(db->db_size, ==, sm->sm_blksz);
 
-	uint64_t *block_base = db->db_data;
+	uint64_t *block_base = abd_to_buf(db->db_abd);
 	uint64_t *block_end = block_base + (sm->sm_blksz / sizeof (uint64_t));
 	uint64_t *block_cursor = block_base +
 	    (sm->sm_phys->smp_length - db->db_offset) / sizeof (uint64_t);
@@ -605,7 +605,7 @@ space_map_write_seg(space_map_t *sm, uint64_t rstart, uint64_t rend,
 
 			ASSERT3U(db->db_size, ==, sm->sm_blksz);
 
-			block_base = db->db_data;
+			block_base = abd_to_buf(db->db_abd);
 			block_cursor = block_base;
 			block_end = block_base +
 			    (db->db_size / sizeof (uint64_t));
@@ -805,7 +805,7 @@ space_map_open_impl(space_map_t *sm)
 		return (error);
 
 	dmu_object_size_from_db(sm->sm_dbuf, &sm->sm_blksz, &blocks);
-	sm->sm_phys = sm->sm_dbuf->db_data;
+	sm->sm_phys = abd_to_buf(sm->sm_dbuf->db_abd);
 	return (0);
 }
 

--- a/module/zfs/vdev_indirect_births.c
+++ b/module/zfs/vdev_indirect_births.c
@@ -107,7 +107,7 @@ vdev_indirect_births_open(objset_t *os, uint64_t births_object)
 	vib->vib_object = births_object;
 
 	VERIFY0(dmu_bonus_hold(os, vib->vib_object, vib, &vib->vib_dbuf));
-	vib->vib_phys = vib->vib_dbuf->db_data;
+	vib->vib_phys = abd_to_buf(vib->vib_dbuf->db_abd);
 
 	if (vib->vib_phys->vib_count > 0) {
 		uint64_t births_size = vdev_indirect_births_size_impl(vib);

--- a/module/zfs/vdev_indirect_mapping.c
+++ b/module/zfs/vdev_indirect_mapping.c
@@ -329,7 +329,7 @@ vdev_indirect_mapping_alloc(objset_t *os, dmu_tx_t *tx)
 
 		VERIFY0(dmu_bonus_hold(os, object, FTAG, &dbuf));
 		dmu_buf_will_dirty(dbuf, tx);
-		vimp = dbuf->db_data;
+		vimp = abd_to_buf(dbuf->db_abd);
 		vimp->vimp_counts_object = dmu_object_alloc(os,
 		    DMU_OTN_UINT32_METADATA, SPA_OLD_MAXBLOCKSIZE,
 		    DMU_OT_NONE, 0, tx);
@@ -353,7 +353,7 @@ vdev_indirect_mapping_open(objset_t *os, uint64_t mapping_object)
 
 	VERIFY0(dmu_bonus_hold(os, vim->vim_object, vim,
 	    &vim->vim_dbuf));
-	vim->vim_phys = vim->vim_dbuf->db_data;
+	vim->vim_phys = abd_to_buf(vim->vim_dbuf->db_abd);
 
 	vim->vim_havecounts =
 	    (doi.doi_bonus_size > VDEV_INDIRECT_MAPPING_SIZE_V0);

--- a/module/zfs/zap_fat.c
+++ b/module/zfs/zap_fat.c
@@ -124,7 +124,7 @@ fzap_upgrade(zap_t *zap, dmu_tx_t *tx, zap_flags_t flags)
 	 * explicitly zero it since it might be coming from an
 	 * initialized microzap
 	 */
-	memset(zap->zap_dbuf->db_data, 0, zap->zap_dbuf->db_size);
+	abd_zero(zap->zap_dbuf->db_abd, zap->zap_dbuf->db_size);
 	zp->zap_block_type = ZBT_HEADER;
 	zp->zap_magic = ZAP_MAGIC;
 
@@ -203,15 +203,16 @@ zap_table_grow(zap_t *zap, zap_table_phys_t *tbl,
 	VERIFY0(dmu_buf_hold_by_dnode(zap->zap_dnode,
 	    (newblk + 2*b+0) << bs, FTAG, &db_new, DMU_READ_NO_PREFETCH));
 	dmu_buf_will_dirty(db_new, tx);
-	transfer_func(db_old->db_data, db_new->db_data, hepb);
+	transfer_func(abd_to_buf(db_old->db_abd), abd_to_buf(db_new->db_abd),
+	    hepb);
 	dmu_buf_rele(db_new, FTAG);
 
 	/* second half of entries in old[b] go to new[2*b+1] */
 	VERIFY0(dmu_buf_hold_by_dnode(zap->zap_dnode,
 	    (newblk + 2*b+1) << bs, FTAG, &db_new, DMU_READ_NO_PREFETCH));
 	dmu_buf_will_dirty(db_new, tx);
-	transfer_func((uint64_t *)db_old->db_data + hepb,
-	    db_new->db_data, hepb);
+	transfer_func((uint64_t *)abd_to_buf(db_old->db_abd) + hepb,
+	    abd_to_buf(db_new->db_abd), hepb);
 	dmu_buf_rele(db_new, FTAG);
 
 	dmu_buf_rele(db_old, FTAG);
@@ -275,12 +276,12 @@ zap_table_store(zap_t *zap, zap_table_phys_t *tbl, uint64_t idx, uint64_t val,
 			return (err);
 		}
 		dmu_buf_will_dirty(db2, tx);
-		((uint64_t *)db2->db_data)[off2] = val;
-		((uint64_t *)db2->db_data)[off2+1] = val;
+		((uint64_t *)abd_to_buf(db2->db_abd))[off2] = val;
+		((uint64_t *)abd_to_buf(db2->db_abd))[off2+1] = val;
 		dmu_buf_rele(db2, FTAG);
 	}
 
-	((uint64_t *)db->db_data)[off] = val;
+	((uint64_t *)abd_to_buf(db->db_abd))[off] = val;
 	dmu_buf_rele(db, FTAG);
 
 	return (0);
@@ -301,7 +302,7 @@ zap_table_load(zap_t *zap, zap_table_phys_t *tbl, uint64_t idx, uint64_t *valp)
 	    (tbl->zt_blk + blk) << bs, FTAG, &db, DMU_READ_NO_PREFETCH);
 	if (err != 0)
 		return (err);
-	*valp = ((uint64_t *)db->db_data)[off];
+	*valp = ((uint64_t *)abd_to_buf(db->db_abd))[off];
 	dmu_buf_rele(db, FTAG);
 
 	if (tbl->zt_nextblk != 0) {
@@ -366,7 +367,8 @@ zap_grow_ptrtbl(zap_t *zap, dmu_tx_t *tx)
 			return (err);
 		dmu_buf_will_dirty(db_new, tx);
 		zap_ptrtbl_transfer(&ZAP_EMBEDDED_PTRTBL_ENT(zap, 0),
-		    db_new->db_data, 1 << ZAP_EMBEDDED_PTRTBL_SHIFT(zap));
+		    abd_to_buf(db_new->db_abd),
+		    1 << ZAP_EMBEDDED_PTRTBL_SHIFT(zap));
 		dmu_buf_rele(db_new, FTAG);
 
 		zap_f_phys(zap)->zap_ptrtbl.zt_blk = newblk;
@@ -675,7 +677,7 @@ zap_deref_leaf(zap_t *zap, uint64_t h, dmu_tx_t *tx, krw_t lt, zap_leaf_t **lp)
 	uint64_t blk;
 
 	ASSERT(zap->zap_dbuf == NULL ||
-	    zap_f_phys(zap) == zap->zap_dbuf->db_data);
+	    zap_f_phys(zap) == abd_to_buf(zap->zap_dbuf->db_abd));
 
 	/* Reality check for corrupt zap objects (leaf or header). */
 	if ((zap_f_phys(zap)->zap_block_type != ZBT_LEAF &&
@@ -1219,7 +1221,7 @@ fzap_get_stats(zap_t *zap, zap_stats_t *zs)
 			    (zap_f_phys(zap)->zap_ptrtbl.zt_blk + b) << bs,
 			    FTAG, &db, DMU_READ_NO_PREFETCH);
 			if (err == 0) {
-				zap_stats_ptrtbl(zap, db->db_data,
+				zap_stats_ptrtbl(zap, abd_to_buf(db->db_abd),
 				    1<<(bs-3), zs);
 				dmu_buf_rele(db, FTAG);
 			}

--- a/module/zfs/zap_impl.c
+++ b/module/zfs/zap_impl.c
@@ -519,6 +519,12 @@ zap_byteswap(void *buf, size_t size)
 	}
 }
 
+void
+abd_zap_byteswap(abd_t *abd, size_t size)
+{
+	zap_byteswap(abd_to_buf(abd), size);
+}
+
 /*
  * Cursor attribute allocator/free. Part of the public interface in zap.h,
  * in this file to get access to the kmem caches.

--- a/module/zfs/zap_leaf.c
+++ b/module/zfs/zap_leaf.c
@@ -99,7 +99,7 @@ zap_leaf_byteswap(zap_leaf_phys_t *buf, size_t size)
 	zap_leaf_t l;
 	dmu_buf_t l_dbuf;
 
-	l_dbuf.db_data = buf;
+	l_dbuf.db_abd = abd_get_from_buf(buf, size);
 	l.l_bs = highbit64(size) - 1;
 	l.l_dbuf = &l_dbuf;
 
@@ -146,6 +146,7 @@ zap_leaf_byteswap(zap_leaf_phys_t *buf, size_t size)
 			    lc->l_free.lf_type);
 		}
 	}
+	abd_free(l_dbuf.db_abd);
 }
 
 void

--- a/module/zfs/zap_micro.c
+++ b/module/zfs/zap_micro.c
@@ -229,7 +229,7 @@ zap_t *
 mzap_open(dmu_buf_t *db)
 {
 	zap_t *winner;
-	uint64_t *zap_hdr = (uint64_t *)db->db_data;
+	uint64_t *zap_hdr = (uint64_t *)abd_to_buf(db->db_abd);
 	uint64_t zap_block_type = zap_hdr[0];
 	uint64_t zap_magic = zap_hdr[1];
 
@@ -333,7 +333,7 @@ mzap_upgrade(zap_t **zapp, dmu_tx_t *tx, zap_flags_t flags)
 
 	int sz = zap->zap_dbuf->db_size;
 	mzap_phys_t *mzp = vmem_alloc(sz, KM_SLEEP);
-	memcpy(mzp, zap->zap_dbuf->db_data, sz);
+	abd_copy_to_buf(mzp, zap->zap_dbuf->db_abd, sz);
 	int nchunks = zap->zap_m.zap_num_chunks;
 
 	if (!flags) {
@@ -395,7 +395,7 @@ mzap_create_impl(dnode_t *dn, int normflags, zap_flags_t flags, dmu_tx_t *tx)
 	VERIFY0(dmu_buf_hold_by_dnode(dn, 0, FTAG, &db, DMU_READ_NO_PREFETCH));
 
 	dmu_buf_will_dirty(db, tx);
-	mzap_phys_t *zp = db->db_data;
+	mzap_phys_t *zp = abd_to_buf(db->db_abd);
 	zp->mz_block_type = ZBT_MICRO;
 	zp->mz_salt =
 	    ((uintptr_t)db ^ (uintptr_t)tx ^ (dn->dn_object << 1)) | 1ULL;

--- a/module/zfs/zfs_byteswap.c
+++ b/module/zfs/zfs_byteswap.c
@@ -196,6 +196,24 @@ zfs_znode_byteswap(void *buf, size_t size)
 	}
 }
 
+void
+abd_zfs_oldacl_byteswap(abd_t *abd, size_t size)
+{
+	zfs_oldacl_byteswap(abd_to_buf(abd), size);
+}
+
+void
+abd_zfs_acl_byteswap(abd_t *abd, size_t size)
+{
+	zfs_acl_byteswap(abd_to_buf(abd), size);
+}
+
+void
+abd_zfs_znode_byteswap(abd_t *abd, size_t size)
+{
+	zfs_znode_byteswap(abd_to_buf(abd), size);
+}
+
 #if defined(_KERNEL)
 EXPORT_SYMBOL(zfs_oldacl_byteswap);
 EXPORT_SYMBOL(zfs_acl_byteswap);

--- a/module/zfs/zfs_fuid.c
+++ b/module/zfs/zfs_fuid.c
@@ -110,7 +110,7 @@ zfs_fuid_table_load(objset_t *os, uint64_t fuid_obj, avl_tree_t *idx_tree,
 
 	ASSERT(fuid_obj != 0);
 	VERIFY0(dmu_bonus_hold(os, fuid_obj, FTAG, &db));
-	fuid_size = *(uint64_t *)db->db_data;
+	fuid_size = *(uint64_t *)abd_to_buf(db->db_abd);
 	dmu_buf_rele(db, FTAG);
 
 	if (fuid_size)  {
@@ -269,7 +269,7 @@ zfs_fuid_sync(zfsvfs_t *zfsvfs, dmu_tx_t *tx)
 	kmem_free(packed, zfsvfs->z_fuid_size);
 	VERIFY0(dmu_bonus_hold(zfsvfs->z_os, zfsvfs->z_fuid_obj, FTAG, &db));
 	dmu_buf_will_dirty(db, tx);
-	*(uint64_t *)db->db_data = zfsvfs->z_fuid_size;
+	*(uint64_t *)abd_to_buf(db->db_abd) = zfsvfs->z_fuid_size;
 	dmu_buf_rele(db, FTAG);
 
 	zfsvfs->z_fuid_dirty = B_FALSE;

--- a/module/zfs/zfs_sa.c
+++ b/module/zfs/zfs_sa.c
@@ -85,14 +85,13 @@ zfs_sa_readlink(znode_t *zp, zfs_uio_t *uio)
 
 	bufsz = zp->z_size;
 	if (bufsz + ZFS_OLD_ZNODE_PHYS_SIZE <= db->db_size) {
-		error = zfs_uiomove((caddr_t)db->db_data +
-		    ZFS_OLD_ZNODE_PHYS_SIZE,
+		error = zfs_uiomove_abd(db->db_abd, ZFS_OLD_ZNODE_PHYS_SIZE,
 		    MIN((size_t)bufsz, zfs_uio_resid(uio)), UIO_READ, uio);
 	} else {
 		dmu_buf_t *dbp;
 		if ((error = dmu_buf_hold(ZTOZSB(zp)->z_os, zp->z_id,
 		    0, FTAG, &dbp, DMU_READ_NO_PREFETCH)) == 0) {
-			error = zfs_uiomove(dbp->db_data,
+			error = zfs_uiomove_abd(dbp->db_abd, 0,
 			    MIN((size_t)bufsz, zfs_uio_resid(uio)), UIO_READ,
 			    uio);
 			dmu_buf_rele(dbp, FTAG);
@@ -109,8 +108,8 @@ zfs_sa_symlink(znode_t *zp, char *link, int len, dmu_tx_t *tx)
 	if (ZFS_OLD_ZNODE_PHYS_SIZE + len <= dmu_bonus_max()) {
 		VERIFY0(dmu_set_bonus(db, len + ZFS_OLD_ZNODE_PHYS_SIZE, tx));
 		if (len) {
-			memcpy((caddr_t)db->db_data +
-			    ZFS_OLD_ZNODE_PHYS_SIZE, link, len);
+			abd_copy_from_buf_off(db->db_abd, link,
+			    ZFS_OLD_ZNODE_PHYS_SIZE, len);
 		}
 	} else {
 		dmu_buf_t *dbp;
@@ -122,7 +121,7 @@ zfs_sa_symlink(znode_t *zp, char *link, int len, dmu_tx_t *tx)
 		dmu_buf_will_dirty(dbp, tx);
 
 		ASSERT3U(len, <=, dbp->db_size);
-		memcpy(dbp->db_data, link, len);
+		abd_copy_from_buf(dbp->db_abd, link, len);
 		dmu_buf_rele(dbp, FTAG);
 	}
 }
@@ -153,8 +152,8 @@ zfs_sa_get_scanstamp(znode_t *zp, xvattr_t *xvap)
 		    ZFS_OLD_ZNODE_PHYS_SIZE;
 
 		if (len <= doi.doi_bonus_size) {
-			(void) memcpy(xoap->xoa_av_scanstamp,
-			    (caddr_t)db->db_data + ZFS_OLD_ZNODE_PHYS_SIZE,
+			abd_copy_to_buf_off(xoap->xoa_av_scanstamp,
+			    db->db_abd, ZFS_OLD_ZNODE_PHYS_SIZE,
 			    sizeof (xoap->xoa_av_scanstamp));
 		}
 	}
@@ -183,8 +182,8 @@ zfs_sa_set_scanstamp(znode_t *zp, xvattr_t *xvap, dmu_tx_t *tx)
 		    ZFS_OLD_ZNODE_PHYS_SIZE;
 		if (len > doi.doi_bonus_size)
 			VERIFY0(dmu_set_bonus(db, len, tx));
-		(void) memcpy((caddr_t)db->db_data + ZFS_OLD_ZNODE_PHYS_SIZE,
-		    xoap->xoa_av_scanstamp, sizeof (xoap->xoa_av_scanstamp));
+		abd_copy_from_buf_off(db->db_abd, xoap->xoa_av_scanstamp,
+		    ZFS_OLD_ZNODE_PHYS_SIZE, sizeof (xoap->xoa_av_scanstamp));
 
 		zp->z_pflags |= ZFS_BONUS_SCANSTAMP;
 		VERIFY0(sa_update(zp->z_sa_hdl, SA_ZPL_FLAGS(zfsvfs),
@@ -422,9 +421,8 @@ zfs_sa_upgrade(sa_handle_t *hdl, dmu_tx_t *tx)
 	/* if scanstamp then add scanstamp */
 
 	if (zp->z_pflags & ZFS_BONUS_SCANSTAMP) {
-		memcpy(scanstamp,
-		    (caddr_t)db->db_data + ZFS_OLD_ZNODE_PHYS_SIZE,
-		    AV_SCANSTAMP_SZ);
+		abd_copy_to_buf_off(scanstamp, db->db_abd,
+		    ZFS_OLD_ZNODE_PHYS_SIZE, AV_SCANSTAMP_SZ);
 		SA_ADD_BULK_ATTR(sa_attrs, count, SA_ZPL_SCANSTAMP(zfsvfs),
 		    NULL, scanstamp, AV_SCANSTAMP_SZ);
 		zp->z_pflags &= ~ZFS_BONUS_SCANSTAMP;

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -834,7 +834,7 @@ zfs_write(znode_t *zp, zfs_uio_t *uio, int ioflag, cred_t *cr)
 			    blksz);
 			ASSERT(abuf != NULL);
 			ASSERT(arc_buf_size(abuf) == blksz);
-			if ((error = zfs_uiocopy(abuf->b_data, blksz,
+			if ((error = zfs_uiocopy_abd(abuf->b_abd, 0, blksz,
 			    UIO_WRITE, uio, &nbytes))) {
 				dmu_return_arcbuf(abuf);
 				break;

--- a/module/zfs/zil.c
+++ b/module/zfs/zil.c
@@ -283,7 +283,7 @@ zil_read_log_block(zilog_t *zilog, boolean_t decrypt, const blkptr_t *bp,
 
 		uint64_t size = BP_GET_LSIZE(bp);
 		if (BP_GET_CHECKSUM(bp) == ZIO_CHECKSUM_ZILOG2) {
-			zil_chain_t *zilc = (*abuf)->b_data;
+			zil_chain_t *zilc = abd_to_buf((*abuf)->b_abd);
 			char *lr = (char *)(zilc + 1);
 
 			if (memcmp(&cksum, &zilc->zc_next_blk.blk_cksum,
@@ -297,7 +297,7 @@ zil_read_log_block(zilog_t *zilog, boolean_t decrypt, const blkptr_t *bp,
 				*nbp = zilc->zc_next_blk;
 			}
 		} else {
-			char *lr = (*abuf)->b_data;
+			char *lr = abd_to_buf((*abuf)->b_abd);
 			zil_chain_t *zilc = (zil_chain_t *)(lr + size) - 1;
 
 			if (memcmp(&cksum, &zilc->zc_next_blk.blk_cksum,
@@ -354,7 +354,7 @@ zil_read_log_data(zilog_t *zilog, const lr_write_t *lr, void *wbuf)
 
 	if (error == 0) {
 		if (wbuf != NULL)
-			memcpy(wbuf, abuf->b_data, arc_buf_size(abuf));
+			abd_copy_to_buf(wbuf, abuf->b_abd, arc_buf_size(abuf));
 		arc_buf_destroy(abuf, &abuf);
 	}
 

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -3677,8 +3677,7 @@ zio_ddt_collision(zio_t *zio, ddt_t *ddt, ddt_entry_t *dde)
 			    &aflags, &zio->io_bookmark);
 
 			if (error == 0) {
-				if (abd_cmp_buf(zio->io_orig_abd, abuf->b_data,
-				    zio->io_orig_size) != 0)
+				if (abd_cmp(zio->io_orig_abd, abuf->b_abd) != 0)
 					error = SET_ERROR(ENOENT);
 				arc_buf_destroy(abuf, &abuf);
 			}

--- a/module/zfs/zio_checksum.c
+++ b/module/zfs/zio_checksum.c
@@ -100,7 +100,7 @@ abd_checksum_off(abd_t *abd, uint64_t size,
 	ZIO_SET_CHECKSUM(zcp, 0, 0, 0, 0);
 }
 
-static void
+void
 abd_fletcher_2_native(abd_t *abd, uint64_t size,
     const void *ctx_template, zio_cksum_t *zcp)
 {

--- a/tests/unit/mock_dmu.c
+++ b/tests/unit/mock_dmu.c
@@ -74,7 +74,8 @@ mock_dnode_block_alloc(mock_dnode_t *mdn, uint64_t blkid)
 	mdb->mdb_db.db_object = mdn->mdn_dn.dn_object;
 	mdb->mdb_db.db_offset = blkid * mdn->mdn_blksize;
 	mdb->mdb_db.db_size   = mdn->mdn_blksize;
-	mdb->mdb_db.db_data   = mdb->mdb_data;
+	mdb->mdb_db.db_abd    = abd_get_from_buf(mdb->mdb_data,
+	    mdn->mdn_blksize);
 	mdb->mdb_owner = mdn;
 
 	return (mdb);
@@ -136,6 +137,7 @@ mock_dnode_destroy(mock_dnode_t *mdn)
 		    mdb->mdb_user->dbu_evict_func_sync != NULL)
 			mdb->mdb_user->dbu_evict_func_sync(mdb->mdb_user);
 
+		abd_free(mdb->mdb_db.db_abd);
 		kmem_free(mdb->mdb_data, mdb->mdb_db.db_size);
 		kmem_free(mdb, sizeof (mock_dbuf_t));
 	}
@@ -156,7 +158,7 @@ mock_dnode_block_data(mock_dnode_t *mdn, uint64_t blkid)
 {
 	if (blkid >= mdn->mdn_nblocks)
 		return (NULL);
-	return (mdn->mdn_blocks[blkid]->mdb_db.db_data);
+	return (abd_to_buf(mdn->mdn_blocks[blkid]->mdb_db.db_abd));
 }
 
 uint64_t
@@ -254,11 +256,12 @@ dmu_object_set_blocksize(objset_t *os, uint64_t object, uint64_t size,
 	void *new_data = kmem_zalloc(size, KM_SLEEP);
 	memcpy(new_data, mdb->mdb_data,
 	    MIN(size, (size_t)mdb->mdb_db.db_size));
+	abd_free(mdb->mdb_db.db_abd);
 	kmem_free(mdb->mdb_data, mdb->mdb_db.db_size);
 
 	mdb->mdb_data = new_data;
 	mdb->mdb_db.db_size = size;
-	mdb->mdb_db.db_data = new_data;
+	mdb->mdb_db.db_abd = abd_get_from_buf(new_data, size);
 	mdn->mdn_blksize = size;
 
 	return (0);
@@ -406,4 +409,38 @@ dmu_prefetch_wait(objset_t *os, uint64_t object, uint64_t offset,
 {
 	(void) os; (void) object; (void) offset; (void) len;
 	return (EIO);
+}
+
+abd_t *
+abd_get_from_buf(void *buf, size_t size)
+{
+	abd_t *abd = kmem_zalloc(sizeof (abd_t), KM_SLEEP);
+	abd->abd_flags = ABD_FLAG_ALLOCD | ABD_FLAG_LINEAR;
+	abd->abd_size = size;
+	abd->abd_u.abd_linear.abd_buf = buf;
+	return (abd);
+}
+
+void *
+abd_to_buf(abd_t *abd)
+{
+	return (abd->abd_u.abd_linear.abd_buf);
+}
+
+void
+abd_zero_off(abd_t *abd, size_t off, size_t size)
+{
+	memset(abd_to_buf(abd) + off, 0, size);
+}
+
+void
+abd_copy_to_buf_off(void *buf, abd_t *abd, size_t off, size_t size)
+{
+	memcpy(buf, abd_to_buf(abd) + off, size);
+}
+
+void
+abd_free(abd_t *abd)
+{
+	kmem_free(abd, sizeof (abd_t));
 }


### PR DESCRIPTION
For uncompressed block, we were supposed to allow buffer sharing between hdr->b_pabd and arc_buf->b_data. However, we can only do so for linear buffer as arc_buf and dbuf doesn't work with abd. And in practice, b_pabd will almost always be scatter type abd except for small buffer, so buffer sharing almost never happens.

In this change we make arc_buf and dbuf use abd instead of raw buf, and make them use scatter abd for user data. This allows us to share the abd between b_pabd, arc_buf and dbuf for data. This reduces memory copy needed for both read and write, which can be a bottleneck for high performance setup.

For metadata, we only use linear abd, so the user of metadata dbuf will need to use abd_to_buf to access the data, but otherwise it's pretty much the same as before.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
