### PR TITLE
mmp: do not require writes to mirror legs the config marks absent

### DIFF
--- a/module/zfs/mmp.c
+++ b/module/zfs/mmp.c
@@ -560,8 +560,8 @@ mmp_claim_uberblock_sync_done(zio_t *zio)
 
 /*
  * Write the uberblock to the first label of all leaves of the specified vdev.
- * Two writes required for each mirror, one for a singleton, and parity+1 for
- * raidz or draid vdevs.
+ * One write per mirror leg the config still expects present, one for a
+ * singleton, and parity+1 for raidz or draid vdevs.
  */
 static void
 mmp_claim_uberblock_sync(zio_t *zio, uint64_t *good_writes,
@@ -580,8 +580,32 @@ mmp_claim_uberblock_sync(zio_t *zio, uint64_t *good_writes,
 			if (nparity) {
 				*req_writes += nparity + 1;
 			} else {
-				*req_writes +=
-				    MIN(MAX(cvd->vdev_children, 1), 2);
+				/*
+				 * Mirror: any single leg is enough for a
+				 * remote host to see the claim, so require a
+				 * write to every leg the pool config still
+				 * expects to be present.  A leg taken out of
+				 * service is recorded persistently in the
+				 * config (offline, faulted, or removed) and
+				 * is seen the same way by every host, so it
+				 * is not required and a degraded mirror can
+				 * still be claimed.  A leg merely unreachable
+				 * from this host has none of those states and
+				 * stays required, so a host which can see
+				 * only some of the legs of an otherwise
+				 * healthy mirror still fails the claim and
+				 * cannot split the pool.
+				 */
+				uint64_t present = 0;
+				for (uint64_t l = 0; l < cvd->vdev_children;
+				    l++) {
+					vdev_t *lvd = cvd->vdev_child[l];
+					if (!lvd->vdev_offline &&
+					    !lvd->vdev_faulted &&
+					    !lvd->vdev_removed)
+						present++;
+				}
+				*req_writes += MAX(present, 1);
 			}
 		}
 

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -165,6 +165,7 @@ tags = ['functional', 'mmap']
 [tests/functional/mmp:Linux]
 tests = ['mmp_on_thread', 'mmp_on_uberblocks', 'mmp_on_off', 'mmp_interval',
     'mmp_active_import', 'mmp_inactive_import', 'mmp_exported_import',
+    'mmp_degraded_import',
     'mmp_write_uberblocks', 'mmp_reset_interval', 'multihost_history',
     'mmp_on_zdb', 'mmp_write_distribution', 'mmp_hostid', 'mmp_write_slow_disk',
     'mmp_concurrent_import']

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1816,6 +1816,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/mmp/cleanup.ksh \
 	functional/mmp/mmp_active_import.ksh \
 	functional/mmp/mmp_concurrent_import.ksh \
+	functional/mmp/mmp_degraded_import.ksh \
 	functional/mmp/mmp_exported_import.ksh \
 	functional/mmp/mmp_hostid.ksh \
 	functional/mmp/mmp_inactive_import.ksh \

--- a/tests/zfs-tests/tests/functional/mmp/mmp_degraded_import.ksh
+++ b/tests/zfs-tests/tests/functional/mmp/mmp_degraded_import.ksh
@@ -1,0 +1,163 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2026 by Michael Heller.
+#
+
+# DESCRIPTION:
+#	Verify the MMP uberblock claim requires a write only to those mirror
+#	legs the pool configuration still expects to be present.
+#
+# STRATEGY:
+#	1. Create a mirrored pool with multihost=on and export it without
+#	   updating the labels, so it still appears imported and the next
+#	   import runs an activity check and an uberblock claim.
+#	2. A healthy mirror is claimed and imported.
+#	3. A mirror with an offlined leg is claimed and imported degraded.
+#	   The offline state is recorded in the configuration, so that leg
+#	   is not required and a degraded pool can still fail over.
+#	4. A mirror with a leg this host cannot open, and which the
+#	   configuration does not mark absent, is refused.  Requiring that
+#	   leg is what prevents two hosts which each see one leg from
+#	   importing the same pool.
+#	5. The same two cases on a three-way mirror, where the number of legs
+#	   the configuration expects and the number this host can reach come
+#	   apart.  A claim which stopped at two writes would accept the last
+#	   case, since two of the three legs are readable.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/mmp/mmp.cfg
+. $STF_SUITE/tests/functional/mmp/mmp.kshlib
+
+verify_runnable "both"
+
+#
+# A leg moved out of the search directory entirely.  Renaming it in place
+# would not do: the devices are matched by the labels they carry rather than by
+# name, so a renamed leg is still found and opened.
+#
+typeset HIDDEN_LEG=$TEST_BASE_DIR/mmp_degraded_hidden_leg
+
+function cleanup
+{
+	mmp_pool_destroy $MMP_POOL $MMP_DIR
+	log_must rm -f $HIDDEN_LEG
+	log_must mmp_clear_hostid
+}
+
+log_assert "mmp claim requires only the mirror legs the config expects"
+log_onexit cleanup
+
+#
+# Leave the pool looking imported by exporting it without updating the
+# labels, then take on a different identity.  The next import therefore
+# runs an activity check and an uberblock claim, as it would after the
+# original host failed.
+#
+function crash_export_as_other_host
+{
+	log_must zpool export -F $MMP_POOL
+	log_must mmp_clear_hostid
+	log_must mmp_set_hostid $HOSTID2
+}
+
+# 1. A healthy mirror is claimed and imported
+log_note "Verify a healthy mirror is claimed and imported"
+mmp_pool_create_simple $MMP_POOL $MMP_DIR
+crash_export_as_other_host
+log_must zpool import -d $MMP_DIR -f $MMP_POOL
+log_must check_state $MMP_POOL "" "ONLINE"
+mmp_pool_destroy $MMP_POOL $MMP_DIR
+
+# 2. A mirror with an offlined leg is claimed and imported degraded
+log_note "Verify a mirror with an offlined leg is claimed and imported"
+mmp_pool_create_simple $MMP_POOL $MMP_DIR
+log_must zpool offline $MMP_POOL $MMP_DIR/vdev2
+log_must check_state $MMP_POOL $MMP_DIR/vdev2 "OFFLINE"
+crash_export_as_other_host
+log_must zpool import -d $MMP_DIR -f $MMP_POOL
+log_must check_state $MMP_POOL "" "DEGRADED"
+log_must check_state $MMP_POOL $MMP_DIR/vdev2 "OFFLINE"
+mmp_pool_destroy $MMP_POOL $MMP_DIR
+
+# 3. A mirror with a leg which is unreadable, and not marked absent by
+#    the configuration, is refused
+log_note "Verify a mirror with an unreachable leg is refused"
+mmp_pool_create_simple $MMP_POOL $MMP_DIR
+crash_export_as_other_host
+log_must mv $MMP_DIR/vdev2 $HIDDEN_LEG
+
+typeset out
+if out=$(zpool import -d $MMP_DIR -f $MMP_POOL 2>&1); then
+	log_fail "Imported a mirror while a required leg was unreadable"
+fi
+if ! echo "$out" | grep -q "pool is imported on host"; then
+	log_fail "Import refused for an unexpected reason: $out"
+fi
+
+#
+# The cases above use a two-way mirror, where "every present leg" and "two
+# legs" are the same number.  A three-way mirror separates them.
+#
+function mmp_pool_create_3way
+{
+	log_must mkdir -p $MMP_DIR
+	log_must rm -f $MMP_DIR/*
+	log_must truncate -s $MINVDEVSIZE $MMP_DIR/vdev1 $MMP_DIR/vdev2 \
+	    $MMP_DIR/vdev3
+	log_must mmp_clear_hostid
+	log_must mmp_set_hostid $HOSTID1
+	log_must zpool create -f -o cachefile=$MMP_CACHE $MMP_POOL \
+	    mirror $MMP_DIR/vdev1 $MMP_DIR/vdev2 $MMP_DIR/vdev3
+	log_must zpool set multihost=on $MMP_POOL
+}
+
+log_must rm -f $HIDDEN_LEG
+
+# 4. A three-way mirror with an offlined leg is claimed and imported degraded
+log_note "Verify a three-way mirror with an offlined leg is claimed"
+mmp_pool_create_3way
+log_must zpool offline $MMP_POOL $MMP_DIR/vdev3
+log_must check_state $MMP_POOL $MMP_DIR/vdev3 "OFFLINE"
+crash_export_as_other_host
+log_must zpool import -d $MMP_DIR -f $MMP_POOL
+log_must check_state $MMP_POOL "" "DEGRADED"
+log_must check_state $MMP_POOL $MMP_DIR/vdev3 "OFFLINE"
+mmp_pool_destroy $MMP_POOL $MMP_DIR
+
+#
+# 5. A three-way mirror with one leg this host cannot open, and which the
+#    configuration does not mark absent, is refused.  Two of the three legs
+#    are readable here, so a claim which required only two writes would let
+#    this import while another host holding the third leg could do the same.
+#
+log_note "Verify a three-way mirror with an unreachable leg is refused"
+mmp_pool_create_3way
+crash_export_as_other_host
+log_must mv $MMP_DIR/vdev3 $HIDDEN_LEG
+
+if out=$(zpool import -d $MMP_DIR -f $MMP_POOL 2>&1); then
+	log_fail "Imported a three-way mirror while a required leg was" \
+	    "unreadable"
+fi
+if ! echo "$out" | grep -q "pool is imported on host"; then
+	log_fail "Import refused for an unexpected reason: $out"
+fi
+
+log_pass "mmp claim requires only the mirror legs the config expects"


### PR DESCRIPTION
Opening this as a draft while @arturpzol's testing on real HA hardware is
outstanding. The design question this started with has been settled by
@behlendorf below.

This is the degraded-mirror facet of #18823, found by @arturpzol, which
@behlendorf said should be its own PR. #18835 fixed the neighbouring case, top-level
vdevs carrying no writeable device at all (holes and indirect vdevs left
by removal, plus log, spare and l2arc). Here every leaf is real, but one leg of
a mirror is out of service.

## The problem

`mmp_claim_uberblock_sync()` requires two good writes for every mirror, so a
mirror with one leg offline can never satisfy the claim: `req_writes=2`,
`good_writes=1`. The import is refused as active on another host (hostid 0),
and `-f` does not help, so a pool which lost a leg before its host died cannot
be brought up on the surviving node. That is the failover case multihost exists
for.

```
mmp.c:638: claiming uberblock ... req_writes=2 good_writes=1
mmp: uberblock claim failed, error=5
```

The requirement is deliberate. Two legs are needed so that a host which can see
only leg A and a host which can see only leg B cannot both claim the pool and
split it. Dropping to one leg unconditionally would trade this bug for a far
worse one.

## The approach

Count only those legs the pool configuration still expects to be present, which
is the config-based direction you suggested first, @behlendorf, before the
`vdev_state` sketch. The distinction is what keeps the partition protection:

- A leg taken out of service with `zpool offline`, or faulted, or removed, is
  recorded persistently in the configuration and every host reads it the same
  way. It is not required, so a degraded pool can still fail over.
- A leg merely unreachable from this host carries none of those states, so it
  stays required. A host seeing one leg of an otherwise healthy mirror still
  fails the claim and cannot split the pool.

On a two-way mirror, forced import after a simulated crash:

| pool state | req / good | result |
| --- | --- | --- |
| healthy | 2 / 2 | imports, unchanged |
| one leg `zpool offline` | 1 / 1 | imports degraded |
| one leg pulled, not offlined | 2 / 1 | refused |

## The rule

A mirror requires a good write to every leg the pool config still expects
present, `MAX(present, 1)`.

I first had this capped at two, matching the current code, and @behlendorf
settled it in the discussion below: the design intent is that enough leaf
labels are updated that at least one must be visible to a remote host, and for
a mirror that means all present legs. The cap existed because requiring every
child was too strict for wide mirrors, particularly where a leg is deliberately
left offline for long periods as part of a backup strategy. Consulting the
config covers that case directly, so the cap is no longer needed.

It matters beyond tidiness. On a three-way mirror with one leg unreachable and
not marked absent, two of the three legs are readable, so a claim which stopped
at two writes accepts it while another host holding the third leg could accept
it as well. Requiring all three refuses it.

Two-way mirrors are unchanged in every state, since "every present leg" and
"two legs" are the same number there.

The remaining loose end is a genuine simultaneous host and device failure, which
lands in the last row of the table and cannot import at all today: `-f` maps to
`ZFS_IMPORT_ANY_HOST`, which never leaves userland and so cannot relax the
claim, and while `ZFS_IMPORT_SKIP_MMP` exists it cannot be set from `zpool
import`. Per the discussion the answer there is not an import flag but a `zhack`
operation which forces the pool through the full MMP check so it can rewrite its
config, after which a normal import succeeds. That is a follow-up rather than
part of this change.

## Testing

New ZTS test `mmp_degraded_import`, five cases: a healthy mirror is claimed and
imported; a mirror with an offlined leg is claimed and imported degraded; a
mirror with a leg this host cannot open, which the config does not mark absent,
is refused; and the last two repeat the degraded and unreachable cases on a
three-way mirror, where the number of legs the config expects and the number
this host can reach come apart.

Ubuntu 24.04, debug build, on `466d90e15`, unloading the module between runs and
reading `/sys/module/zfs/version` back per run so each result is definitely the
tree under test:

| build | `mmp_degraded_import` |
| --- | --- |
| this branch | 3/3 pass |
| stock master | 3/3 fail, at the offlined-leg case |
| this branch with the cap put back | 2/2 fail, at the three-way case only |

The third row is there because stock master fails at the second case and never
reaches the three-way ones, so it cannot show whether they carry their weight.
The capped variant passes cases 1 to 4 and fails only on the three-way
unreachable leg, which is the case the rule change is about.

Full `mmp` group 18/18.

Coverage is single-host so far, so it does not reach a real two-host partition.
@arturpzol has offered to test this on HA hardware including a genuine two-node
partition, and I would like to take him up on that before this leaves draft.
