### PR TITLE
arc: fix race between arc_release() and arc_read_done()

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -6634,12 +6634,18 @@ arc_release(arc_buf_t *buf, const void *tag)
 
 	ASSERT(HDR_HAS_L1HDR(hdr));
 
+	kmutex_t *hash_lock = HDR_LOCK(hdr);
+	mutex_enter(hash_lock);
+
 	/*
-	 * We don't grab the hash lock prior to this check, because if
-	 * the buffer's header is in the arc_anon state, it won't be
-	 * linked into the hash table.
+	 * Grab hash lock before this check to avoid races with arc_read_done()
+	 * which can transition hdr to arc_anon state on error, and we don't
+	 * want to miss it.
 	 */
 	if (hdr->b_l1hdr.b_state == arc_anon) {
+
+		mutex_exit(hash_lock);
+
 		ASSERT(!HDR_IO_IN_PROGRESS(hdr));
 		ASSERT(!HDR_IN_HASH_TABLE(hdr));
 		ASSERT(!HDR_HAS_L2HDR(hdr));
@@ -6660,9 +6666,6 @@ arc_release(arc_buf_t *buf, const void *tag)
 
 		return;
 	}
-
-	kmutex_t *hash_lock = HDR_LOCK(hdr);
-	mutex_enter(hash_lock);
 
 	/*
 	 * This assignment is only valid as long as the hash_lock is


### PR DESCRIPTION
Currently, if `arc_release()` is executed in parallel with `arc_read_done()`, and if the latter transition `hdr` to `arc_anon` state, it is possible that `arc_release()` would miss this transition since the check for hdr's state is not protected by any lock and it can read a stale cached value.

Solution: take the hash lock a bit earlier in `arc_release()`, before the check for hdr's state.

### How Has This Been Tested?
Let's see what CI says here.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
