### PR TITLE
Further parallelize block cloning

### DIFF
--- a/include/sys/brt_impl.h
+++ b/include/sys/brt_impl.h
@@ -169,6 +169,26 @@ struct brt_vdev {
 	avl_tree_t	bv_tree;
 };
 
+/*
+ * Clones of blocks with the DEDUP bit set reference the DDT instead of
+ * the BRT.  Their pending entries are kept separately from the per-vdev
+ * pending trees, sorted by the block checksum, matching the DDT ZAP hash
+ * order (the first checksum word is the pre-hashed ZAP key), and sharded
+ * by its top bits.  It allows syncing context to process the shards in
+ * parallel, each walking a disjoint range of DDT ZAP leaves in the hash
+ * order, so that each compressed leaf block is decompressed only once
+ * and never by more than one thread.
+ */
+#define	BRT_DEDUP_SHARDS_SHIFT	4
+#define	BRT_DEDUP_SHARDS	(1 << BRT_DEDUP_SHARDS_SHIFT)
+#define	BRT_DEDUP_SHARD(bp)						\
+	((bp)->blk_cksum.zc_word[0] >> (64 - BRT_DEDUP_SHARDS_SHIFT))
+
+struct brt_dedup_shard {
+	kmutex_t	bds_lock;
+	avl_tree_t	bds_tree[TXG_SIZE];
+};
+
 /* Size of offset / sizeof (uint64_t). */
 #define	BRT_KEY_WORDS	(1)
 

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -56,6 +56,7 @@ extern "C" {
  * Forward references that lots of things need.
  */
 typedef struct brt_vdev brt_vdev_t;
+typedef struct brt_dedup_shard brt_dedup_shard_t;
 typedef struct spa spa_t;
 typedef struct vdev vdev_t;
 typedef struct metaslab metaslab_t;

--- a/include/sys/spa_impl.h
+++ b/include/sys/spa_impl.h
@@ -441,6 +441,7 @@ struct spa {
 	boolean_t	spa_active_ddt_prune;	/* ddt prune process active */
 	brt_vdev_t	**spa_brt_vdevs;	/* array of per-vdev BRTs */
 	uint64_t	spa_brt_nvdevs;		/* number of vdevs in BRT */
+	brt_dedup_shard_t *spa_brt_dedup;	/* pending dedup'd clones */
 	uint64_t	spa_brt_rangesize;	/* pool's BRT range size */
 	krwlock_t	spa_brt_lock;		/* Protects brt_vdevs/nvdevs */
 	kmutex_t	spa_vdev_top_lock;	/* dueling offline/remove */

--- a/module/zfs/brt.c
+++ b/module/zfs/brt.c
@@ -1348,9 +1348,19 @@ brt_pending_remove(spa_t *spa, const blkptr_t *bp, dmu_tx_t *tx)
 		kmem_cache_free(brt_entry_cache, bre);
 }
 
+typedef struct brt_pending_vdev_arg {
+	spa_t		*bpva_spa;
+	brt_vdev_t	*bpva_brtvd;
+	uint64_t	bpva_txg;
+} brt_pending_vdev_arg_t;
+
 static void
-brt_pending_apply_vdev(spa_t *spa, brt_vdev_t *brtvd, uint64_t txg)
+brt_pending_apply_vdev(void *arg)
 {
+	brt_pending_vdev_arg_t *bpva = arg;
+	spa_t *spa = bpva->bpva_spa;
+	brt_vdev_t *brtvd = bpva->bpva_brtvd;
+	uint64_t txg = bpva->bpva_txg;
 	brt_entry_t *bre, *nbre;
 
 	/*
@@ -1488,16 +1498,38 @@ brt_pending_apply(spa_t *spa, uint64_t txg)
 		}
 	}
 
+	/*
+	 * Add pending references to the BRTs of their vdevs.  Process the
+	 * vdevs in parallel, since random BRT ZAP lookups are CPU-expensive
+	 * due to the leaf block decompression.  The BRT ZAP hash is salted,
+	 * so unlike the DDT above the lookups can not be ordered to match
+	 * the leaf blocks order.
+	 */
 	brt_rlock(spa);
-	for (uint64_t vdevid = 0; vdevid < spa->spa_brt_nvdevs; vdevid++) {
+	uint64_t nvdevs = spa->spa_brt_nvdevs;
+	brt_unlock(spa);
+	if (nvdevs == 0)
+		return;
+	brt_pending_vdev_arg_t *bpva =
+	    kmem_zalloc(sizeof (*bpva) * nvdevs, KM_SLEEP);
+	brt_rlock(spa);
+	for (uint64_t vdevid = 0; vdevid < nvdevs; vdevid++) {
 		brt_vdev_t *brtvd = spa->spa_brt_vdevs[vdevid];
-		brt_unlock(spa);
-
-		brt_pending_apply_vdev(spa, brtvd, txg);
-
-		brt_rlock(spa);
+		if (avl_is_empty(&brtvd->bv_pending_tree[txg & TXG_MASK]))
+			continue;
+		bpva[vdevid].bpva_spa = spa;
+		bpva[vdevid].bpva_brtvd = brtvd;
+		bpva[vdevid].bpva_txg = txg;
 	}
 	brt_unlock(spa);
+	for (uint64_t vdevid = 0; vdevid < nvdevs; vdevid++) {
+		if (bpva[vdevid].bpva_spa == NULL)
+			continue;
+		VERIFY(taskq_dispatch(tq, brt_pending_apply_vdev,
+		    &bpva[vdevid], TQ_SLEEP) != TASKQID_INVALID);
+	}
+	taskq_wait(tq);
+	kmem_free(bpva, sizeof (*bpva) * nvdevs);
 }
 
 static void

--- a/module/zfs/brt.c
+++ b/module/zfs/brt.c
@@ -216,9 +216,12 @@
  * At the beginning of spa_sync() where there can be no more block cloning,
  * but before issuing frees we call brt_pending_apply(). This function applies
  * all the new clones to the BRT table - we load BRT entries and update
- * reference counters. To sync new BRT entries to disk, we use brt_sync()
- * function. This function will sync all dirty per-top-level-vdev BRTs,
- * the entry counters arrays, etc.
+ * reference counters. Blocks with the DEDUP bit set are referenced in the
+ * DDT instead and are kept on separate pending trees, sorted and sharded by
+ * the DDT ZAP hash, so that syncing context can process them in parallel
+ * with sequential access to the DDT ZAP leaves. To sync new BRT entries to
+ * disk, we use brt_sync() function. This function will sync all dirty
+ * per-top-level-vdev BRTs, the entry counters arrays, etc.
  *
  * Block Cloning and ZIL.
  *
@@ -1207,6 +1210,34 @@ brt_entry_compare(const void *x1, const void *x2)
 	    DVA_GET_OFFSET(&bp2->blk_dva[0])));
 }
 
+static int
+brt_entry_dedup_compare(const void *x1, const void *x2)
+{
+	const brt_entry_t *bre1 = x1, *bre2 = x2;
+	const blkptr_t *bp1 = &bre1->bre_bp, *bp2 = &bre2->bre_bp;
+	const uint64_t *k1 = bp1->blk_cksum.zc_word;
+	const uint64_t *k2 = bp2->blk_cksum.zc_word;
+	int cmp;
+
+	/* Sort by the checksum, matching the DDT ZAP hash order. */
+	for (int i = 0; i < (sizeof (zio_cksum_t) / sizeof (uint64_t)); i++) {
+		if (likely((cmp = TREE_CMP(k1[i], k2[i])) != 0))
+			return (cmp);
+	}
+
+	/*
+	 * The same checksum may reference different blocks if the DDT
+	 * entry for the older one was pruned.
+	 */
+	cmp = TREE_CMP(DVA_GET_VDEV(&bp1->blk_dva[0]),
+	    DVA_GET_VDEV(&bp2->blk_dva[0]));
+	if (likely(cmp == 0)) {
+		cmp = TREE_CMP(DVA_GET_OFFSET(&bp1->blk_dva[0]),
+		    DVA_GET_OFFSET(&bp2->blk_dva[0]));
+	}
+	return (cmp);
+}
+
 void
 brt_pending_add(spa_t *spa, const blkptr_t *bp, dmu_tx_t *tx)
 {
@@ -1217,14 +1248,42 @@ brt_pending_add(spa_t *spa, const blkptr_t *bp, dmu_tx_t *tx)
 	txg = dmu_tx_get_txg(tx);
 	ASSERT3U(txg, !=, 0);
 
-	uint64_t vdevid = DVA_GET_VDEV(&bp->blk_dva[0]);
-	brt_vdev_t *brtvd = brt_vdev(spa, vdevid, B_TRUE);
-	avl_tree_t *pending_tree = &brtvd->bv_pending_tree[txg & TXG_MASK];
-
 	newbre = kmem_cache_alloc(brt_entry_cache, KM_SLEEP);
 	newbre->bre_bp = *bp;
 	newbre->bre_count = 0;
 	newbre->bre_pcount = 1;
+
+	/*
+	 * Blocks with the DEDUP bit set are referenced in the DDT instead
+	 * of the BRT and are kept on separate trees until then.
+	 */
+	if (BP_GET_DEDUP(bp)) {
+		brt_dedup_shard_t *bds =
+		    &spa->spa_brt_dedup[BRT_DEDUP_SHARD(bp)];
+		avl_tree_t *pending_tree = &bds->bds_tree[txg & TXG_MASK];
+
+		mutex_enter(&bds->bds_lock);
+		bre = avl_find(pending_tree, newbre, &where);
+		if (bre == NULL) {
+			avl_insert(pending_tree, newbre, where);
+			newbre = NULL;
+		} else {
+			bre->bre_pcount++;
+		}
+		mutex_exit(&bds->bds_lock);
+
+		if (newbre != NULL) {
+			kmem_cache_free(brt_entry_cache, newbre);
+		} else {
+			/* Prefetch DDT entry for the syncing context. */
+			ddt_prefetch(spa, bp);
+		}
+		return;
+	}
+
+	uint64_t vdevid = DVA_GET_VDEV(&bp->blk_dva[0]);
+	brt_vdev_t *brtvd = brt_vdev(spa, vdevid, B_TRUE);
+	avl_tree_t *pending_tree = &brtvd->bv_pending_tree[txg & TXG_MASK];
 
 	mutex_enter(&brtvd->bv_pending_lock);
 	bre = avl_find(pending_tree, newbre, &where);
@@ -1257,14 +1316,24 @@ brt_pending_remove(spa_t *spa, const blkptr_t *bp, dmu_tx_t *tx)
 	txg = dmu_tx_get_txg(tx);
 	ASSERT3U(txg, !=, 0);
 
-	uint64_t vdevid = DVA_GET_VDEV(&bp->blk_dva[0]);
-	brt_vdev_t *brtvd = brt_vdev(spa, vdevid, B_FALSE);
-	ASSERT(brtvd != NULL);
-	avl_tree_t *pending_tree = &brtvd->bv_pending_tree[txg & TXG_MASK];
-
 	bre_search.bre_bp = *bp;
 
-	mutex_enter(&brtvd->bv_pending_lock);
+	kmutex_t *pending_lock;
+	avl_tree_t *pending_tree;
+	if (BP_GET_DEDUP(bp)) {
+		brt_dedup_shard_t *bds =
+		    &spa->spa_brt_dedup[BRT_DEDUP_SHARD(bp)];
+		pending_lock = &bds->bds_lock;
+		pending_tree = &bds->bds_tree[txg & TXG_MASK];
+	} else {
+		uint64_t vdevid = DVA_GET_VDEV(&bp->blk_dva[0]);
+		brt_vdev_t *brtvd = brt_vdev(spa, vdevid, B_FALSE);
+		ASSERT(brtvd != NULL);
+		pending_lock = &brtvd->bv_pending_lock;
+		pending_tree = &brtvd->bv_pending_tree[txg & TXG_MASK];
+	}
+
+	mutex_enter(pending_lock);
 	bre = avl_find(pending_tree, &bre_search, NULL);
 	ASSERT(bre != NULL);
 	ASSERT(bre->bre_pcount > 0);
@@ -1273,7 +1342,7 @@ brt_pending_remove(spa_t *spa, const blkptr_t *bp, dmu_tx_t *tx)
 		avl_remove(pending_tree, bre);
 	else
 		bre = NULL;
-	mutex_exit(&brtvd->bv_pending_lock);
+	mutex_exit(pending_lock);
 
 	if (bre)
 		kmem_cache_free(brt_entry_cache, bre);
@@ -1293,24 +1362,6 @@ brt_pending_apply_vdev(spa_t *spa, brt_vdev_t *brtvd, uint64_t txg)
 
 	for (bre = avl_first(&brtvd->bv_tree); bre; bre = nbre) {
 		nbre = AVL_NEXT(&brtvd->bv_tree, bre);
-
-		/*
-		 * If the block has DEDUP bit set, it means that it
-		 * already exists in the DEDUP table, so we can just
-		 * use that instead of creating new entry in the BRT.
-		 */
-		if (BP_GET_DEDUP(&bre->bre_bp)) {
-			while (bre->bre_pcount > 0) {
-				if (!ddt_addref(spa, &bre->bre_bp))
-					break;
-				bre->bre_pcount--;
-			}
-			if (bre->bre_pcount == 0) {
-				avl_remove(&brtvd->bv_tree, bre);
-				kmem_cache_free(brt_entry_cache, bre);
-				continue;
-			}
-		}
 
 		/*
 		 * Unless we know that the block is definitely not in ZAP,
@@ -1340,10 +1391,7 @@ brt_pending_apply_vdev(spa_t *spa, brt_vdev_t *brtvd, uint64_t txg)
 		}
 	}
 
-	/*
-	 * If all the cloned blocks we had were handled by DDT, we don't need
-	 * to initiate the vdev.
-	 */
+	/* If we had no new clones for this vdev, we don't need to initiate. */
 	if (avl_is_empty(&brtvd->bv_tree))
 		return;
 
@@ -1366,9 +1414,79 @@ brt_pending_apply_vdev(spa_t *spa, brt_vdev_t *brtvd, uint64_t txg)
 	}
 }
 
+typedef struct brt_pending_dedup_arg {
+	spa_t		*bpda_spa;
+	avl_tree_t	*bpda_tree;
+} brt_pending_dedup_arg_t;
+
+static void
+brt_pending_apply_dedup(void *arg)
+{
+	brt_pending_dedup_arg_t *bpda = arg;
+	spa_t *spa = bpda->bpda_spa;
+	avl_tree_t *tree = bpda->bpda_tree;
+	brt_entry_t *bre, *nbre;
+
+	for (bre = avl_first(tree); bre; bre = nbre) {
+		nbre = AVL_NEXT(tree, bre);
+		while (bre->bre_pcount > 0) {
+			if (!ddt_addref(spa, &bre->bre_bp))
+				break;
+			bre->bre_pcount--;
+		}
+		if (bre->bre_pcount == 0) {
+			avl_remove(tree, bre);
+			kmem_cache_free(brt_entry_cache, bre);
+		}
+		/* Else leave it for the caller to reference in the BRT. */
+	}
+}
+
 void
 brt_pending_apply(spa_t *spa, uint64_t txg)
 {
+	brt_pending_dedup_arg_t bpda[BRT_DEDUP_SHARDS];
+	taskq_t *tq = spa->spa_dsl_pool->dp_sync_taskq;
+
+	/*
+	 * We are in syncing context, so no open context accesses to the
+	 * pending trees of this TXG are possible and we need no locks.
+	 *
+	 * Reference the dedup'd blocks in the DDT.  Process the shards in
+	 * parallel, since random DDT ZAP lookups are CPU-expensive due to
+	 * the leaf block decompression.  Each shard covers a disjoint part
+	 * of the DDT ZAP hash space and is walked in the hash order, so
+	 * each leaf is decompressed at most once and only by one thread.
+	 */
+	for (int i = 0; i < BRT_DEDUP_SHARDS; i++) {
+		avl_tree_t *tree =
+		    &spa->spa_brt_dedup[i].bds_tree[txg & TXG_MASK];
+		if (avl_is_empty(tree))
+			continue;
+		bpda[i].bpda_spa = spa;
+		bpda[i].bpda_tree = tree;
+		VERIFY(taskq_dispatch(tq, brt_pending_apply_dedup,
+		    &bpda[i], TQ_SLEEP) != TASKQID_INVALID);
+	}
+	taskq_wait(tq);
+
+	/*
+	 * Turn blocks that could not be referenced in the DDT (their
+	 * entries were pruned or are over the dedup quota) into regular
+	 * BRT pending entries for their vdevs.
+	 */
+	for (int i = 0; i < BRT_DEDUP_SHARDS; i++) {
+		avl_tree_t *tree =
+		    &spa->spa_brt_dedup[i].bds_tree[txg & TXG_MASK];
+		brt_entry_t *bre;
+		void *cookie = NULL;
+
+		while ((bre = avl_destroy_nodes(tree, &cookie)) != NULL) {
+			uint64_t vdevid = DVA_GET_VDEV(&bre->bre_bp.blk_dva[0]);
+			brt_vdev_t *brtvd = brt_vdev(spa, vdevid, B_TRUE);
+			avl_add(&brtvd->bv_pending_tree[txg & TXG_MASK], bre);
+		}
+	}
 
 	brt_rlock(spa);
 	for (uint64_t vdevid = 0; vdevid < spa->spa_brt_nvdevs; vdevid++) {
@@ -1480,6 +1598,18 @@ brt_alloc(spa_t *spa)
 	spa->spa_brt_vdevs = NULL;
 	spa->spa_brt_nvdevs = 0;
 	spa->spa_brt_rangesize = 0;
+
+	spa->spa_brt_dedup = kmem_zalloc(sizeof (brt_dedup_shard_t) *
+	    BRT_DEDUP_SHARDS, KM_SLEEP);
+	for (int i = 0; i < BRT_DEDUP_SHARDS; i++) {
+		brt_dedup_shard_t *bds = &spa->spa_brt_dedup[i];
+		mutex_init(&bds->bds_lock, NULL, MUTEX_DEFAULT, NULL);
+		for (int t = 0; t < TXG_SIZE; t++) {
+			avl_create(&bds->bds_tree[t], brt_entry_dedup_compare,
+			    sizeof (brt_entry_t),
+			    offsetof(brt_entry_t, bre_node));
+		}
+	}
 }
 
 void
@@ -1564,6 +1694,16 @@ brt_unload(spa_t *spa)
 	brt_vdevs_free(spa);
 	rw_destroy(&spa->spa_brt_lock);
 	spa->spa_brt_rangesize = 0;
+
+	for (int i = 0; i < BRT_DEDUP_SHARDS; i++) {
+		brt_dedup_shard_t *bds = &spa->spa_brt_dedup[i];
+		for (int t = 0; t < TXG_SIZE; t++)
+			avl_destroy(&bds->bds_tree[t]);
+		mutex_destroy(&bds->bds_lock);
+	}
+	kmem_free(spa->spa_brt_dedup, sizeof (brt_dedup_shard_t) *
+	    BRT_DEDUP_SHARDS);
+	spa->spa_brt_dedup = NULL;
 }
 
 ZFS_MODULE_PARAM(zfs_brt, , brt_zap_prefetch, INT, ZMOD_RW,


### PR DESCRIPTION
Before this PR `brt_pending_apply()` running in sync context could create a single-threaded bottleneck, especially if BRT and DDT lookups caused dbuf cache misses, requiring ZAP leaves decompression, or even ARC misses, requiring disk reads.  This PR allows pending clones to be processed by multiple sync threads in parallel, additionally refactoring cloning of deduplicated blocks for more DDT dbuf cache hits.  See the commit messages for more details.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
