### PR TITLE
Fix out-of-bound access when resizing in receive_spill

### DIFF
--- a/include/sys/dbuf.h
+++ b/include/sys/dbuf.h
@@ -347,7 +347,8 @@ uint64_t dbuf_whichblock(const struct dnode *di, const int64_t level,
     const uint64_t offset);
 
 void dbuf_create_bonus(struct dnode *dn);
-int dbuf_spill_set_blksz(dmu_buf_t *db, uint64_t blksz, dmu_tx_t *tx);
+int dbuf_spill_set_blksz(dmu_buf_t *db, uint64_t blksz, boolean_t copy,
+    dmu_tx_t *tx);
 
 void dbuf_rm_spill(struct dnode *dn, dmu_tx_t *tx);
 
@@ -414,7 +415,7 @@ void dbuf_free_range(struct dnode *dn, uint64_t start, uint64_t end,
 void dbuf_evict_range(struct dnode *dn, uint64_t start_blkid,
     uint64_t end_blkid);
 
-void dbuf_new_size(dmu_buf_impl_t *db, int size, dmu_tx_t *tx);
+void dbuf_new_size(dmu_buf_impl_t *db, int size, boolean_t copy, dmu_tx_t *tx);
 
 void dbuf_stats_init(dbuf_hash_table_t *hash);
 void dbuf_stats_destroy(void);

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -2149,7 +2149,7 @@ dbuf_evict_range(dnode_t *dn, uint64_t start_blkid, uint64_t end_blkid)
 }
 
 void
-dbuf_new_size(dmu_buf_impl_t *db, int size, dmu_tx_t *tx)
+dbuf_new_size(dmu_buf_impl_t *db, int size, boolean_t copy, dmu_tx_t *tx)
 {
 	arc_buf_t *buf, *old_buf;
 	dbuf_dirty_record_t *dr;
@@ -2173,12 +2173,15 @@ dbuf_new_size(dmu_buf_impl_t *db, int size, dmu_tx_t *tx)
 	/* create the data buffer for the new block */
 	buf = arc_alloc_buf(dn->dn_objset->os_spa, db, type, size);
 
-	/* copy old block data to the new block */
 	old_buf = db->db_buf;
-	memcpy(buf->b_data, old_buf->b_data, MIN(osize, size));
-	/* zero the remainder */
-	if (size > osize)
-		memset((uint8_t *)buf->b_data + osize, 0, size - osize);
+	if (copy) {
+		ASSERT(arc_get_compression(old_buf) == ZIO_COMPRESS_OFF);
+		/* copy old block data to the new block */
+		memcpy(buf->b_data, old_buf->b_data, MIN(osize, size));
+		/* zero the remainder */
+		if (size > osize)
+			memset((uint8_t *)buf->b_data + osize, 0, size - osize);
+	}
 
 	mutex_enter(&db->db_mtx);
 	dbuf_set_data(db, buf);
@@ -4129,7 +4132,8 @@ dbuf_create_bonus(dnode_t *dn)
 }
 
 int
-dbuf_spill_set_blksz(dmu_buf_t *db_fake, uint64_t blksz, dmu_tx_t *tx)
+dbuf_spill_set_blksz(dmu_buf_t *db_fake, uint64_t blksz, boolean_t copy,
+    dmu_tx_t *tx)
 {
 	dmu_buf_impl_t *db = (dmu_buf_impl_t *)db_fake;
 
@@ -4140,7 +4144,7 @@ dbuf_spill_set_blksz(dmu_buf_t *db_fake, uint64_t blksz, dmu_tx_t *tx)
 	ASSERT3U(blksz, <=, spa_maxblocksize(dmu_objset_spa(db->db_objset)));
 	blksz = P2ROUNDUP(blksz, SPA_MINBLOCKSIZE);
 
-	dbuf_new_size(db, blksz, tx);
+	dbuf_new_size(db, blksz, copy, tx);
 
 	return (0);
 }

--- a/module/zfs/dmu_recv.c
+++ b/module/zfs/dmu_recv.c
@@ -3521,7 +3521,7 @@ receive_spill(struct receive_writer_arg *rwa, struct drr_spill *drrs,
 	if (db_spill->db_size != drrs->drr_length) {
 		dmu_buf_will_fill(db_spill, tx, B_FALSE);
 		VERIFY0(dbuf_spill_set_blksz(db_spill,
-		    drrs->drr_length, tx));
+		    drrs->drr_length, B_FALSE, tx));
 	}
 
 	arc_buf_t *abuf;

--- a/module/zfs/dnode.c
+++ b/module/zfs/dnode.c
@@ -1978,7 +1978,7 @@ dnode_set_blksz(dnode_t *dn, uint64_t size, int ibs, dmu_tx_t *tx)
 		/* resize the old block */
 		err = dbuf_hold_impl(dn, 0, 0, TRUE, FALSE, FTAG, &db);
 		if (err == 0) {
-			dbuf_new_size(db, size, tx);
+			dbuf_new_size(db, size, B_TRUE, tx);
 		} else if (err != ENOENT) {
 			goto fail;
 		}

--- a/module/zfs/dsl_bookmark.c
+++ b/module/zfs/dsl_bookmark.c
@@ -493,7 +493,7 @@ dsl_bookmark_create_sync_impl_snap(const char *bookmark, const char *snapshot,
 			    DB_RF_MUST_SUCCEED, tag, &db));
 			dmu_buf_will_fill(db, tx, B_FALSE);
 			VERIFY0(dbuf_spill_set_blksz(db, P2ROUNDUP(bonuslen,
-			    SPA_MINBLOCKSIZE), tx));
+			    SPA_MINBLOCKSIZE), B_TRUE, tx));
 			local_rl->rl_phys = db->db_data;
 			local_rl->rl_dbuf = db;
 		}

--- a/module/zfs/sa.c
+++ b/module/zfs/sa.c
@@ -504,7 +504,7 @@ sa_resize_spill(sa_handle_t *hdl, uint32_t size, dmu_tx_t *tx)
 		blocksize = P2ROUNDUP_TYPED(size, SPA_MINBLOCKSIZE, uint32_t);
 	}
 
-	error = dbuf_spill_set_blksz(hdl->sa_spill, blocksize, tx);
+	error = dbuf_spill_set_blksz(hdl->sa_spill, blocksize, B_TRUE, tx);
 	ASSERT0(error);
 	return (error);
 }


### PR DESCRIPTION
receive_spill will call dbuf_spill_set_blksz, which in turn calls dbuf_new_size when resizing spill block. However, receive_spill holds a raw buf, which can be compressed and less than db_size. This causes an out-of-bound access when dbuf_new_size tries to copy the data using db_size as length.

To fix this, we just disable the copy when coming from receive_spill, since we will assign a new arc_buf later anyway.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
