### PR TITLE
CI: removed freebsd15-1s from qemu workflow since the images is not found in official site

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -75,7 +75,7 @@ Auto-selected:
 
 - Linux: almalinux 8/9/10, centos-stream 9/10, debian 11/12/13,
   fedora 43/44, ubuntu 22/24/26
-- FreeBSD: 14.4-RELEASE/STABLE, 15.1-RELEASE/STABLE, 16.0-CURRENT
+- FreeBSD: 14.4-RELEASE/STABLE, 15.1-RELEASE, 16.0-CURRENT
 
 Available via `specific_os` or `ZTS_OS_OVERRIDE`:
 

--- a/.github/workflows/scripts/qemu-2-start.sh
+++ b/.github/workflows/scripts/qemu-2-start.sh
@@ -121,13 +121,6 @@ case "$OS" in
     URLxz="$FREEBSD_SNAP/$FreeBSD/amd64/Latest/FreeBSD-$FreeBSD-amd64-BASIC-CI-ufs.raw.xz"
     KSRC="$FREEBSD_SNAP/../amd64/$FreeBSD/src.txz"
     ;;
-  freebsd15-1s)
-    FreeBSD="15.1-STABLE"
-    OSNAME="FreeBSD $FreeBSD"
-    OSv="freebsd14.0"
-    URLxz="$FREEBSD_SNAP/$FreeBSD/amd64/Latest/FreeBSD-$FreeBSD-amd64-BASIC-CI-ufs.raw.xz"
-    KSRC="$FREEBSD_SNAP/../amd64/$FreeBSD/src.txz"
-    ;;
   freebsd16-0c)
     FreeBSD="16.0-CURRENT"
     OSNAME="FreeBSD $FreeBSD"

--- a/.github/workflows/zfs-qemu.yml
+++ b/.github/workflows/zfs-qemu.yml
@@ -50,17 +50,17 @@ jobs:
             os_selection='[]'
             ;;
           quick)
-            os_selection='["almalinux8", "almalinux9", "almalinux10", "debian12", "fedora44", "freebsd15-1s", "ubuntu26"]'
+            os_selection='["almalinux8", "almalinux9", "almalinux10", "debian12", "fedora44", "ubuntu26"]'
             ;;
           linux)
             os_selection='["almalinux8", "almalinux9", "almalinux10", "centos-stream9", "centos-stream10", "debian11", "debian12", "debian13", "fedora43", "fedora44", "ubuntu22", "ubuntu24", "ubuntu26"]'
             ;;
           freebsd)
-            os_selection='["freebsd14-4r", "freebsd14-4s", "freebsd15-1r", "freebsd15-1s", "freebsd16-0c"]'
+            os_selection='["freebsd14-4r", "freebsd14-4s", "freebsd15-1r", "freebsd16-0c"]'
             ;;
           *)
             # default list
-            os_selection='["almalinux8", "almalinux9", "almalinux10", "centos-stream9", "centos-stream10", "debian12", "debian13", "fedora43", "fedora44", "freebsd14-4r", "freebsd15-1r", "freebsd15-1s", "freebsd16-0c", "ubuntu22", "ubuntu24", "ubuntu26"]'
+            os_selection='["almalinux8", "almalinux9", "almalinux10", "centos-stream9", "centos-stream10", "debian12", "debian13", "fedora43", "fedora44", "freebsd14-4r", "freebsd15-1r", "freebsd16-0c", "ubuntu22", "ubuntu24", "ubuntu26"]'
             ;;
           esac
 
@@ -107,7 +107,7 @@ jobs:
         # misc:    archlinux, tumbleweed
         # FreeBSD variants of november 2025:
         # FreeBSD Release: freebsd14-4r, freebsd15-1r
-        # FreeBSD Stable:  freebsd14-4s, freebsd15-1s
+        # FreeBSD Stable:  freebsd14-4s
         # FreeBSD Current: freebsd16-0c
         os: ${{ fromJson(needs.test-config.outputs.test_os) }}
     runs-on: ubuntu-24.04


### PR DESCRIPTION
### Motivation and Context
Looks the official site dose not build stable image anymore, and the workflow is always failed. Removed it to get green check mark back for PRs.

### Description
Now it always complains like following:
```shell
Run .github/workflows/scripts/qemu-2-start.sh freebsd15-1s
Loading https://download.freebsd.org/snapshots/CI-IMAGES/15.1-STABLE/amd64/Latest/FreeBSD-15.1-STABLE-amd64-BASIC-CI-ufs.raw.xz with axel -q -o...
ERROR 404: Not Found.

real	0m0.398s
user	0m0.023s
sys	0m0.004s
Loading https://download.freebsd.org/snapshots/CI-IMAGES/../amd64/15.1-STABLE/src.txz with axel -q -o...
ERROR 404: Not Found.

real	0m0.077s
user	0m0.023s
sys	0m0.004s
Loading https://download.freebsd.org/snapshots/CI-IMAGES/15.1-STABLE/amd64/Latest/FreeBSD-15.1-STABLE-amd64-BASIC-CI-ufs.raw.xz with curl --fail -LSs -o...
curl: (22) The requested URL returned error: 404

real	0m0.058s
user	0m0.025s
sys	0m0.006s
Loading https://download.freebsd.org/snapshots/CI-IMAGES/../amd64/15.1-STABLE/src.txz with curl --fail -LSs -o...
curl: (22) The requested URL returned error: 404

real	0m0.060s
user	0m0.025s
sys	0m0.005s
Couldn't download FreeBSD raw.xz.  Trying fallback snapshot 
curl: (2) no URL specified
curl: try 'curl --help' or 'curl --manual' for more information
```
We can bring freebsd15-2s once the official sites has it.

### How Has This Been Tested?
CI

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
