### PR TITLE
libzfs: String trimming should not operate out of bounds

### DIFF
--- a/lib/libzfs/os/linux/libzfs_share_smb.c
+++ b/lib/libzfs/os/linux/libzfs_share_smb.c
@@ -130,8 +130,9 @@ smb_retrieve_shares(void)
 				continue;
 
 			/* Trim trailing new-line character(s). */
-			while (line[strlen(line) - 1] == '\r' ||
-			    line[strlen(line) - 1] == '\n')
+			while ((line[0] != '\0') &&
+			    (line[strlen(line) - 1] == '\r' ||
+			    line[strlen(line) - 1] == '\n'))
 				line[strlen(line) - 1] = '\0';
 
 			/* Split the line in two, separated by '=' */

--- a/lib/libzutil/zutil_device_path.c
+++ b/lib/libzutil/zutil_device_path.c
@@ -134,7 +134,7 @@ zfs_strcmp_shortname(const char *name, const char *cmp_name, int wholedisk)
 	while (dir) {
 		/* Trim trailing directory slashes from ZPOOL_IMPORT_PATH */
 		if (env) {
-			while (dir[strlen(dir)-1] == '/')
+			while ((dir[0] != '\0') && (dir[strlen(dir)-1] == '/'))
 				dir[strlen(dir)-1] = '\0';
 		}
 


### PR DESCRIPTION
### Motivation and Context
Forward slashes are trimmed from ZPOOL_IMPORT_PATH, but if someone sets a ZPOOL_IMPORT_PATH that is only forward slashes, our trim code will underflow the string, causing an out of bounds operation.

Similarly, the SMB code could potentially trim a string consisting of only new line characters until it experiences the same bug. The same fix is applied to it.

These are memory bugs, but I suspect that it is very unlikely that they would cause a problem, since the probability that an out of bounds write would follow the out of bounds read should be low. That said, going out of bounds is undefined behavior, which could cause incorrect code generation should a compiler look at it wrong, so let us fix this.

### Description
We add a check in the loop condition for an empty string. If it is empty, we exit the loop rather than continuing.

Grok 4.5 Build Beta found this bug.

### How Has This Been Tested?
The buildbot can test it.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
