### PR TITLE
libzfs: don't truncate a resolved vdev path in zpool_vdev_name()

### DIFF
--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -4740,6 +4740,7 @@ zpool_vdev_name(libzfs_handle_t *hdl, zpool_handle_t *zhp, nvlist_t *nv,
 	uint64_t value;
 	char buf[PATH_BUF_LEN];
 	char tmpbuf[PATH_BUF_LEN * 2];
+	char rpath[MAXPATHLEN];
 
 	/*
 	 * vdev_name will be "root"/"root-0" for the root vdev, but it is the
@@ -4765,12 +4766,8 @@ zpool_vdev_name(libzfs_handle_t *hdl, zpool_handle_t *zhp, nvlist_t *nv,
 		path = tpath;
 
 		if (name_flags & VDEV_NAME_FOLLOW_LINKS) {
-			char *rp = realpath(path, NULL);
-			if (rp) {
-				strlcpy(buf, rp, sizeof (buf));
-				path = buf;
-				free(rp);
-			}
+			if (realpath(path, rpath) != NULL)
+				path = rpath;
 		}
 
 		/*

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -594,6 +594,7 @@ tests = ['zpool_status_001_pos', 'zpool_status_002_pos',
     'zpool_status_003_pos', 'zpool_status_004_pos',
     'zpool_status_005_pos', 'zpool_status_006_pos',
     'zpool_status_007_pos', 'zpool_status_008_pos',
+    'zpool_status_009_pos',
     'zpool_status_features_001_pos']
 tags = ['functional', 'cli_root', 'zpool_status']
 

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1386,6 +1386,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zpool_status/zpool_status_006_pos.ksh \
 	functional/cli_root/zpool_status/zpool_status_007_pos.ksh \
 	functional/cli_root/zpool_status/zpool_status_008_pos.ksh \
+	functional/cli_root/zpool_status/zpool_status_009_pos.ksh \
 	functional/cli_root/zpool_status/zpool_status_features_001_pos.ksh \
 	functional/cli_root/zpool_sync/cleanup.ksh \
 	functional/cli_root/zpool_sync/setup.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_status/zpool_status_009_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_status/zpool_status_009_pos.ksh
@@ -1,0 +1,89 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2026 by Michael Heller.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# Verify 'zpool status -L' does not truncate a long vdev path.
+#
+# STRATEGY:
+# 1. Create a pool on a file vdev whose path is longer than the buffer the
+#    resolved path used to be copied into.
+# 2. Verify 'zpool status -L' reports the whole path.
+# 3. Verify 'zpool status' without -L reports it too, which it always did.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	poolexists $TESTPOOL2 && destroy_pool $TESTPOOL2
+	log_must rm -rf $longdir
+}
+
+log_assert "'zpool status -L' does not truncate a long vdev path"
+
+log_onexit cleanup
+
+#
+# The resolved path has to exceed 63 bytes to reach the case this covers, so
+# the name is padded out and the length checked rather than assumed.
+#
+longdir=$TESTDIR/$(printf 'd%.0s' {1..40})
+longvdev=$longdir/$(printf 'v%.0s' {1..40})
+
+typeset -i pathlen=${#longvdev}
+if (( pathlen <= 63 )); then
+	log_fail "vdev path is only $pathlen bytes, too short to truncate"
+fi
+log_note "vdev path is $pathlen bytes"
+
+log_must mkdir -p $longdir
+log_must truncate -s $MINVDEVSIZE $longvdev
+log_must zpool create -f $TESTPOOL2 $longvdev
+
+#
+# -L resolves symlinks in the path.  A file vdev resolves to itself, so the
+# whole path must come back unchanged.  Report whatever name was printed
+# rather than only whether it matched, so a failure shows how far it was cut.
+#
+function vdev_name_from_status # args
+{
+	zpool status "$@" $TESTPOOL2 |
+	    awk -v d="$TESTDIR" 'index($1, d) == 1 {print $1; exit}'
+}
+
+typeset name
+name=$(vdev_name_from_status -L)
+if [[ "$name" != "$longvdev" ]]; then
+	log_fail "'zpool status -L' reported a ${#name} byte name," \
+	    "expected $pathlen bytes: '$name'"
+fi
+
+name=$(vdev_name_from_status)
+if [[ "$name" != "$longvdev" ]]; then
+	log_fail "'zpool status' reported a ${#name} byte name," \
+	    "expected $pathlen bytes: '$name'"
+fi
+
+log_pass "'zpool status -L' does not truncate a long vdev path"


### PR DESCRIPTION
### Motivation and Context

Closes #18851.

`zpool_vdev_name()` resolves a vdev path with `realpath()` when the caller asks
for `VDEV_NAME_FOLLOW_LINKS`, then copies the result into a 64 byte stack
buffer it shares with the short formatted names. A vdev whose resolved path is
longer than 63 bytes is therefore reported cut short by `zpool status -L`, and
by anything else which sets that flag.

The cut lands on a byte boundary, so a multi-byte character straddling it is
left as invalid UTF-8. That also breaks the JSON output, since `zpool status -j
-L` then emits a string a parser rejects:

```
# f="/tmp/zt/$(printf 'a%.0s' $(seq 1 54))é"     # 64 bytes
# zpool status -L jsonbug
	  /tmp/zt/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa�  ONLINE
# zpool status -j -L jsonbug | jq
jq: parse error: Unfinished string at EOF at line 2, column 0
```

### Description

Resolve straight into a buffer of the right size. `realpath()` fills a caller
supplied buffer of at least `PATH_MAX`, which is how it is already used in
`libzutil`, and that also removes the intermediate allocation and its `free()`.

The other three users of the 64 byte buffer format a guid, a raidz name, or a
draid name, none of which can exceed its length, so it is left alone.

### How Has This Been Tested?

New ZTS test `cli_root/zpool_status/zpool_status_009_pos`, which creates a pool
on a file vdev with a path longer than 63 bytes and checks `zpool status -L`
reports the whole thing. It fails rather than passing if the path it builds is
too short to reach the case, so it cannot quietly stop testing anything, and it
reports the length it got so a failure shows how far the name was cut.

Ubuntu 24.04, debug build, on 023d44b9e. The test was run against a stock tree
at the same commit carrying only the test, so the fix is the sole variable:

| build | `zpool_status_009_pos` |
| --- | --- |
| this branch | 3/3 pass |
| stock 023d44b9e | 3/3 fail |

On stock it reports `'zpool status -L' reported a 63 byte name, expected 98
bytes`, which is the buffer less its terminator.

Also confirmed by hand that `zpool status -j -L` output goes from being
rejected by `jq` to parsing cleanly, using the reporter's 64 byte path with a
multi-byte character on the boundary.

The `json` group passes 3/3, which covers `zpool status -j` going through the
same code.

The `zpool_status` group goes from 12 to 13 passes, the difference being the new
test. Five other tests in that group fail on both trees in my VM: the four
`cli_user` cases, which need an unprivileged test user I have not set up, and
`zpool_status_features_001_pos`. They fail the same way with and without the
fix.

`cstyle.pl` and `commitcheck.sh` are clean.

### Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the OpenZFS code style requirements.
- [x] I have added tests to cover my changes.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
