### PR TITLE
Linux: avoid prefaulting under the ZFS range lock

### DIFF
--- a/module/os/linux/zfs/zfs_uio.c
+++ b/module/os/linux/zfs/zfs_uio.c
@@ -237,10 +237,19 @@ zfs_uiomove_iter(void *p, size_t n, zfs_uio_rw_t rw, zfs_uio_t *uio,
 	size_t oldcnt = cnt;
 	int error = 0;
 
-	if (rw == UIO_READ)
+	if (rw == UIO_READ) {
 		cnt = copy_to_iter(p, cnt, uio->uio_iter);
-	else
+	} else if (uio->uio_fault_disable) {
+		/*
+		 * The caller prefaulted this range. Do not fault while a
+		 * transaction or range lock is held.
+		 */
+		pagefault_disable();
 		cnt = copy_from_iter(p, cnt, uio->uio_iter);
+		pagefault_enable();
+	} else {
+		cnt = copy_from_iter(p, cnt, uio->uio_iter);
+	}
 
 	/*
 	 * When operating on a full pipe no bytes are processed.

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -683,11 +683,13 @@ zfs_write(znode_t *zp, zfs_uio_t *uio, int ioflag, cred_t *cr)
 	}
 
 	/*
-	 * Pre-fault the pages to ensure slow (eg NFS) pages
-	 * don't hold up txg.
+	 * Pre-fault one transaction-sized chunk before acquiring the range
+	 * lock.  Copying later chunks with page faults disabled may produce a
+	 * short write, but it must not fault while holding this lock: if the
+	 * source is an mmap of this file, that fault would enter zfs_getpage()
+	 * and deadlock on the same lock.
 	 */
-	ssize_t pfbytes = MIN(n, DMU_MAX_ACCESS >> 1);
-	if (zfs_uio_prefaultpages(pfbytes, uio)) {
+	if (zfs_uio_prefaultpages(MIN(n, DMU_MAX_ACCESS >> 1), uio)) {
 		zfs_exit(zfsvfs, FTAG);
 		return (SET_ERROR(EFAULT));
 	}
@@ -834,22 +836,19 @@ zfs_write(znode_t *zp, zfs_uio_t *uio, int ioflag, cred_t *cr)
 			    blksz);
 			ASSERT(abuf != NULL);
 			ASSERT(arc_buf_size(abuf) == blksz);
-			if ((error = zfs_uiocopy(abuf->b_data, blksz,
-			    UIO_WRITE, uio, &nbytes))) {
+			zfs_uio_fault_disable(uio, B_TRUE);
+			error = zfs_uiocopy(abuf->b_data, blksz, UIO_WRITE,
+			    uio, &nbytes);
+			zfs_uio_fault_disable(uio, B_FALSE);
+			if (error != 0 || nbytes != blksz) {
+				if (error == 0)
+					error = SET_ERROR(EFAULT);
 				dmu_return_arcbuf(abuf);
 				break;
 			}
-			ASSERT3S(nbytes, ==, blksz);
 		} else {
 			nbytes = MIN(n, (DMU_MAX_ACCESS >> 1) -
 			    P2PHASE(woff, blksz));
-			if (pfbytes < nbytes) {
-				if (zfs_uio_prefaultpages(nbytes, uio)) {
-					error = SET_ERROR(EFAULT);
-					break;
-				}
-				pfbytes = nbytes;
-			}
 		}
 
 		/*
@@ -899,32 +898,12 @@ zfs_write(znode_t *zp, zfs_uio_t *uio, int ioflag, cred_t *cr)
 			error = dmu_write_uio_dbuf(sa_get_db(zp->z_sa_hdl),
 			    uio, nbytes, tx, dflags);
 			zfs_uio_fault_disable(uio, B_FALSE);
-#ifdef __linux__
-			if (error == EFAULT) {
-				zfs_clear_setid_bits_if_necessary(zfsvfs, zp,
-				    cr, &clear_setid_bits_txg, tx);
-				dmu_tx_commit(tx);
-				/*
-				 * Account for partial writes before
-				 * continuing the loop.
-				 * Update needs to occur before the next
-				 * zfs_uio_prefaultpages, or prefaultpages may
-				 * error, and we may break the loop early.
-				 */
-				n -= tx_bytes - zfs_uio_resid(uio);
-				/*
-				 * The prefaulted pages still faulted, so force
-				 * a re-prefault on the next pass.  If they can
-				 * no longer be faulted in (e.g. the calling
-				 * process is exiting), zfs_uio_prefaultpages()
-				 * fails and the loop breaks with EFAULT instead
-				 * of spinning on them forever.
-				 */
-				pfbytes = 0;
-				continue;
-			}
-#endif
 			/*
+			 * Account for any partial EFAULT below.  On Linux,
+			 * retrying needs another prefault while the range lock
+			 * is held.  That can deadlock when the source maps this
+			 * file.
+			 *
 			 * On FreeBSD, EFAULT should be propagated back to the
 			 * VFS, which will handle faulting and will retry.
 			 */
@@ -1055,7 +1034,6 @@ zfs_write(znode_t *zp, zfs_uio_t *uio, int ioflag, cred_t *cr)
 			break;
 		ASSERT3S(tx_bytes, ==, nbytes);
 		n -= nbytes;
-		pfbytes -= nbytes;
 	}
 
 	if (o_direct_defer) {
@@ -1072,6 +1050,14 @@ zfs_write(znode_t *zp, zfs_uio_t *uio, int ioflag, cred_t *cr)
 	 */
 	if (uio->uio_extflg & UIO_DIRECT)
 		zfs_uio_free_dio_pages(uio, UIO_WRITE);
+
+#ifdef __linux__
+	/*
+	 * Linux write(2) reports a short copy as progress instead of EFAULT.
+	 */
+	if (error == EFAULT && zfs_uio_resid(uio) != start_resid)
+		error = 0;
+#endif
 
 	/*
 	 * If we're in replay mode, or we made no progress, or the


### PR DESCRIPTION
### Motivation and Context

Fixes #18135.

The deterministic reproducer writes 32 MiB + 1 byte from an mmap of the
same ZFS file. `zfs_write()` prefaults only the first transaction-sized
32 MiB before taking the file range lock. On the next loop iteration it
prefaults the final byte while that lock is still held. The page fault
enters `zfs_getpage()` for the same file and waits forever for the range
lock held by the writing thread.

This matches the reported stack and the existing warning in
`zfs_write()` that prefaulting under the range lock can deadlock through
`zfs_getpage()`.

Reproducer:
https://github.com/jfly/2026-07-31-zfs-deadlock/blob/main/mmap_snake.py

### Description

- Keep prefaulting bounded to the existing transaction-sized limit of
  `MIN(n, DMU_MAX_ACCESS >> 1)` before range-lock acquisition.
- Make Linux iterator copies honor `uio_fault_disable`, so the normal DMU
  write path cannot fault while holding the range lock.
- Apply the same no-fault rule to the full-block ARC-buffer path and turn
  an incomplete ARC-buffer copy into `EFAULT` instead of asserting.
- Remove later prefault and retry paths under the range lock.
- Preserve normal metadata and ZIL bookkeeping for bytes copied before a
  late `EFAULT`; Linux reports that progress as a short write.

Large requests no longer require every source page to be resident at once.
If a page beyond the bounded prefault window is not resident, the syscall
returns the bytes already written and userspace can retry the remainder.
The range lock is never dropped during the write, including `O_APPEND`, so
append atomicity is not weakened.

### How Has This Been Tested?

- Traced the deterministic 32 MiB + 1 byte reproducer against the current
  `zfs_write()` and Linux `iov_iter` control flow.
- Verified there is one executable `zfs_uio_prefaultpages()` call in
  `zfs_write()` and it precedes write range-lock acquisition.
- Verified both in-lock source-copy paths bracket the copy with
  `zfs_uio_fault_disable()` and that the Linux iterator implementation now
  enforces that flag with `pagefault_disable()` / `pagefault_enable()`.
- Ran `git diff --check` successfully.
- Checked the changed lines against OpenZFS formatting conventions.
- Independently validated by the original reproducer against current `master` plus
  exact head `54cbbed772fa59221bc9bd118aac43a30acfb8d9`; the previously
  hanging reproduction completes:
  https://github.com/openzfs/zfs/pull/18872#issuecomment-5146408006

This host is Windows without WSL or Docker, so I could not build the Linux
kernel module or run ZTS locally. GitHub CI is validating the amended head.

I did not add an automated deadlock regression because the failing case
waits uninterruptibly on the file's own range lock. A userspace timeout
cannot guarantee cleanup and could wedge a bare-metal ZTS host.

### Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement
- [ ] Code cleanup
- [x] Quality assurance
- [ ] Breaking change
- [ ] Library ABI change
- [ ] Documentation

### Checklist

- [x] My code follows the OpenZFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the contributing document.
- [ ] I have added tests to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.