### PR TITLE
Fix NULL pointer dereference in dsl_deadlist_close() after error

### DIFF
--- a/module/zfs/dsl_deadlist.c
+++ b/module/zfs/dsl_deadlist.c
@@ -368,8 +368,14 @@ dsl_deadlist_close(dsl_deadlist_t *dl)
 		}
 		avl_destroy(&dl->dl_cache);
 	}
-	dmu_buf_rele(dl->dl_dbuf, dl);
-	dl->dl_dbuf = NULL;
+	/*
+	 * If dmu_bonus_hold() fails in dsl_deadlist_open(), we are left with
+	 * an "open" deadlist that has no hold to release.
+	 */
+	if (dl->dl_dbuf != NULL) {
+		dmu_buf_rele(dl->dl_dbuf, dl);
+		dl->dl_dbuf = NULL;
+	}
 	dl->dl_phys = NULL;
 	dl->dl_os = NULL;
 	dl->dl_object = 0;


### PR DESCRIPTION
### Motivation and Context
c33a55b0c201dce9457bc6632f68fc87a903a6af allowed dsl_deadlist_open() to return errors. However, when dsl_deadlist_open() returns an error, dsl_deadlist_close() is called. If the error is from dmu_bonus_hold(), dsl_deadlist_close() will call dmu_buf_rele() on a NULL pointer.

Closes #17809

### Description
We check for a NULL pointer and refrain from calling `dmu_buf_rele()` if we have one. This should fix the issue, since the pointer should be zero-initialized and remain that way unless a valid address is assigned to it.

Grok 4.5 Build Beta found this bug.

### How Has This Been Tested?
The buildbot can test.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
