### PR TITLE
unit/cityhash: test the cityhash hash functions

### DIFF
--- a/tests/unit/.gitignore
+++ b/tests/unit/.gitignore
@@ -6,3 +6,4 @@
 /test_namecheck
 /test_btree
 /test_sha2
+/test_cityhash

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -19,7 +19,8 @@ UNIT_TESTS = \
 	%D%/test_namecheck \
 	%D%/test_btree \
 	%D%/test_fletcher \
-	%D%/test_sha2
+	%D%/test_sha2 \
+	%D%/test_cityhash
 noinst_PROGRAMS = $(UNIT_TESTS)
 
 
@@ -100,6 +101,19 @@ nodist_%C%_test_sha2_SOURCES = \
 	libicp.la \
 	libspl.la \
 	libunit.la
+
+
+%C%_test_cityhash_CFLAGS = $(AM_CFLAGS)
+
+nodist_%C%_test_cityhash_SOURCES = \
+	module/zcommon/cityhash.c
+
+%C%_test_cityhash_SOURCES = \
+	%D%/test_cityhash.c
+
+%C%_test_cityhash_LDADD = \
+	libunit.la \
+	libspl.la
 
 
 # test run and coverage targets below

--- a/tests/unit/test_cityhash.c
+++ b/tests/unit/test_cityhash.c
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: CDDL-1.0
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2026, Christos Longros.
+ */
+
+#include <sys/types.h>
+#include <cityhash.h>
+
+#include "unit.h"
+
+/* ========== */
+
+/*
+ * cityhash maps one to four uint64_t words to a single uint64_t hash.  The
+ * output is fixed by the algorithm, so we can verify exact results.
+ */
+static MunitResult
+test_cityhash_known(const MunitParameter params[], void *data)
+{
+	(void) params, (void) data;
+
+	unit_eq(cityhash1(0), 0x7087061603e53293ULL);
+	unit_eq(cityhash1(0x0123456789abcdefULL), 0x4d72820d4fcae8ffULL);
+	unit_eq(cityhash2(1, 2), 0x8f1c7927f8b5dff2ULL);
+	unit_eq(cityhash3(1, 2, 3), 0x4f6fe08120ecb540ULL);
+	unit_eq(cityhash4(0x1111111111111111ULL, 0x2222222222222222ULL,
+	    0x3333333333333333ULL, 0x4444444444444444ULL),
+	    0xa6370a2070fdfd12ULL);
+
+	return (MUNIT_OK);
+}
+
+/*
+ * cityhash1/2/3 are specialized versions of cityhash4, so each must match
+ * cityhash4 on the same arguments.  cityhash1 passes its word as the 2nd
+ * argument.
+ */
+static MunitResult
+test_cityhash_specialized(const MunitParameter params[], void *data)
+{
+	(void) params, (void) data;
+
+	uint64_t a = 0xdeadbeefULL, b = 0xfeedfaceULL, c = 0x00c0ffeeULL;
+
+	unit_eq(cityhash1(a), cityhash4(0, a, 0, 0));
+	unit_eq(cityhash2(a, b), cityhash4(a, b, 0, 0));
+	unit_eq(cityhash3(a, b, c), cityhash4(a, b, c, 0));
+
+	return (MUNIT_OK);
+}
+
+/* Different arguments produce different hash results. */
+static MunitResult
+test_cityhash_distinct(const MunitParameter params[], void *data)
+{
+	(void) params, (void) data;
+
+	uint64_t base = cityhash4(1, 2, 3, 4);
+	unit_ne(base, cityhash4(9, 2, 3, 4));	/* first word */
+	unit_ne(base, cityhash4(1, 9, 3, 4));	/* second word */
+	unit_ne(base, cityhash4(1, 2, 9, 4));	/* third word */
+	unit_ne(base, cityhash4(1, 2, 3, 9));	/* fourth word */
+	unit_ne(cityhash1(0), cityhash1(1));
+
+	return (MUNIT_OK);
+}
+
+/* ========== */
+
+static const MunitTest cityhash_tests[] = {
+	UNIT_TEST("known",		test_cityhash_known),
+	UNIT_TEST("specialized",	test_cityhash_specialized),
+	UNIT_TEST("distinct",		test_cityhash_distinct),
+	{ 0 },
+};
+
+static const MunitSuite cityhash_test_suite = {
+	"cityhash.",
+	cityhash_tests,
+	NULL,
+	1,
+	MUNIT_SUITE_OPTION_NONE,
+};
+
+int
+main(int argc, char **argv)
+{
+	return (munit_suite_main(&cityhash_test_suite, NULL, argc, argv));
+}


### PR DESCRIPTION
### Motivation and Context

cityhash has no coverage in `tests/unit/` or the ZTS, though it is used in ARC, dbuf and dmu_objset hashes.

### Description

Adds `tests/unit/test_cityhash.c`:

- `cityhash.known` — known answer test.
- `cityhash.specialized` — the 1/2/3-argument forms are checked against  `cityhash4`.
- `cityhash.distinct` — one argument changed at a time.

### How Has This Been Tested?

Arch Linux x86_64

```
$ make unit T=cityhash
  UNITTEST tests/unit/test_cityhash
Running test suite with seed 0x5a66b41e...
cityhash.known                       [ OK    ] [ 0.00000186 / 0.00000078 CPU ]
cityhash.specialized                 [ OK    ] [ 0.00000110 / 0.00000065 CPU ]
cityhash.distinct                    [ OK    ] [ 0.00000131 / 0.00000057 CPU ]
3 of 3 (100%) tests successful, 0 (0%) test skipped.
```

### Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
