### PR TITLE
ZTS: don't read a command's exit status as a missing binary

### DIFF
--- a/tests/test-runner/include/logapi.shlib
+++ b/tests/test-runner/include/logapi.shlib
@@ -209,12 +209,24 @@ function log_neg_expect
 	"$@" 2>$logfile
 	typeset status=$?
 
+	#
+	# A command which printed what was expected of it plainly ran, so
+	# its exit status is its own to interpret.  Some commands report a
+	# count there: fio exits with the number of jobs which failed, and
+	# a run of 127 failing jobs is indistinguishable from a missing
+	# binary by status alone.
+	#
+	typeset expect_missing=1
+	if [[ -n $expect ]] && grep -qi "$expect" $logfile; then
+		expect_missing=0
+	fi
+
 	# unexpected status
 	if (( $status == EXIT_SUCCESS )); then
 		 cat $logfile >&2
 		_printerror "$@" "unexpectedly exited $status"
 	# missing binary
-	elif (( $status == EXIT_NOTFOUND )); then
+	elif (( $status == EXIT_NOTFOUND && expect_missing )); then
 		cat $logfile >&2
 		_printerror "$@" "unexpectedly exited $status (File not found)"
 	# bus error - core dump


### PR DESCRIPTION
### Motivation and Context

Closes #18726.

`no_space/enospc_rm` fails occasionally, and the reason is not in the test.

`log_neg_expect()` treats an exit status of 127 as a missing binary and reports
that before it looks at what the command printed:

```ksh
	# missing binary
	elif (( $status == EXIT_NOTFOUND )); then
		cat $logfile >&2
		_printerror "$@" "unexpectedly exited $status (File not found)"
```

127 is a convention of the shell. A command is free to return it for its own
reasons, and fio does: its exit status is the number of jobs which failed. The
second phase of `enospc_rm` runs 200 jobs and requires them to hit ENOSPC, so
the status lands wherever the fill happens to land. Twelve runs here gave 183 to
199. The CI failure in the issue reported 127, and the test failed with

```
fio ... unexpectedly exited 127 (File not found)
```

with "No space left on device" sitting in the captured output, which is exactly
what the test asked to see.

The failing run proves the mechanism by itself. Its second phase logs exactly
127 distinct `fio: pid=..., err=28` entries before the error, and the first
phase of the same run logs `SUCCESS: fio ... --numjobs=4 ... exited 4`. The exit
status is the count of jobs which failed, visible in the failure being fixed.

You noted you had only seen this on FreeBSD, and that run was
`qemu-x86 (freebsd15-1r)`. Nothing in the mechanism is platform specific: it
needs the count to land on exactly 127, and where it lands depends on how the
fill happens to divide between the jobs.

### Description

Only read 127 as a missing binary when the expected output is absent. A command
which printed what was asked of it plainly ran, so this only widens what is
accepted and nothing which passed before can start failing. A genuinely missing
binary cannot produce the expected message, so it is still caught.

### How Has This Been Tested?

Driving `log_neg_expect()` directly with a command that prints the expected
message and exits with a chosen status, before and after:

| command exits | before | after |
| --- | --- | --- |
| 126, message present | pass | pass |
| 127, message present | **fail** | pass |
| 200, message present | pass | pass |
| 127, message absent | fail | fail |
| genuinely missing binary | fail | fail |

The last two are the ones which matter for the change being safe.

fio's exit status was confirmed to be the count of failed jobs, on a pool filled
beforehand so that every job fails: 1 job exits 1, 3 exits 3, 10 exits 10, and
127 exits 127.

All eight tests which use `log_mustnot_expect` or `log_neg_expect` pass:
`zdb_tunables`, `zfs_bookmark_cliargs`, `zfs_destroy_007_neg`,
`enospc_002_pos`, `enospc_rm`, `raidz_expand_006_neg`, `raidz_expand_007_neg`
and `redacted_negative`. The `no_space` group is 8 of 8.

Ubuntu 24.04, debug build. I could not reproduce the original failure directly,
since the job count on this rig settles well above 127, so the evidence for the
mechanism is the exit status behaviour above rather than a reproduction of the
CI failure itself.

### Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the OpenZFS code style requirements.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
