### PR TITLE
libzfs: don't read a dataset handle after closing it in resume send

### DIFF
--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -1986,8 +1986,10 @@ zfs_send_resume_impl_cb_impl(libzfs_handle_t *hdl, sendflags_t *flags,
 		}
 
 		char errbuf[ERRBUFLEN];
+		char sendname[ZFS_MAX_DATASET_NAME_LEN];
 		(void) snprintf(errbuf, sizeof (errbuf), dgettext(TEXT_DOMAIN,
 		    "warning: cannot send '%s'"), zhp->zfs_name);
+		(void) strlcpy(sendname, zhp->zfs_name, sizeof (sendname));
 
 		zfs_close(zhp);
 
@@ -1999,7 +2001,7 @@ zfs_send_resume_impl_cb_impl(libzfs_handle_t *hdl, sendflags_t *flags,
 			    "source key must be loaded"));
 			return (zfs_error(hdl, EZFS_CRYPTOFAILED, errbuf));
 		case ESRCH:
-			if (lzc_exists(zhp->zfs_name)) {
+			if (lzc_exists(sendname)) {
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
 				    "incremental source could not be found"));
 			}


### PR DESCRIPTION

### Motivation and Context

Closes #18870, reported by @RigelYoung.

`zfs_send_resume_impl_cb_impl()` closes the dataset handle at
`lib/libzfs/libzfs_sendrecv.c:1992`, before the switch on the send error, and
the `ESRCH` case then reads `zhp->zfs_name` again at :2002. `zfs_name` is a
`char[]` declared inside `struct zfs_handle`, so the `free(zhp)` at the end of
`zfs_close()` releases the array along with the handle, and `lzc_exists()`
copies out of the freed block.

The close came in with resume send (47dfff3b8, 2016), when nothing below it
touched the handle. The `ESRCH` case was added three years later by redacted
send (30af21b02, 2019), below a handle that was no longer live.

The path is reachable. `dsl_bookmark_lookup_impl()` returns `ESRCH` when a
bookmark is missing (`dsl_bookmark.c:78,93`), and `dmu_send()` gets there for a
`fromsnap` that is a bookmark. A resume whose incremental source is a bookmark
can lose a race with that bookmark being destroyed between libzfs resolving it
and the kernel looking it up. I went looking for a non-racy trigger and did not
find one: both `guid_to_name_redact_snaps()` and `find_redact_book()` confirm
the object exists client-side first, so the window is the only way in.

### Description

@RigelYoung's report proposed two fixes. This takes the second: copy the name
into a local before the close and test that in the `ESRCH` case, in preference
to hoisting the `lzc_exists()` call above the close. It keeps the ESRCH-only
work inside the ESRCH case and mirrors the `errbuf` capture already on the line
above.

The report also warned that the existing local `name` cannot be reused here,
which is correct: `guid_to_name_redact_snaps()` overwrites it with the
incremental source when `fromguid != 0`, so it would test the wrong object.

### How Has This Been Tested?

Ubuntu 24.04, `--enable-debug`, on 74e76f2d8, in a VM.

Reproduction: pool, dataset, `@s1`, `zfs bookmark ... #bm`, destroy `@s1` so
only the bookmark carries that guid, more data, `@s2`, then a truncated
resumable receive to mint a token. Resuming makes libzfs pass
`from=<pool>/src#bm`. To make the interleaving deterministic without touching
the code under test, an LD_PRELOAD shim holds the exported
`lzc_send_resume_redacted()` for a few seconds while a helper destroys the
bookmark.

Under valgrind on stock master:

```
Invalid read of size 1
   at strlen
   by strlcpy (strlcpy.c:24)
   by lzc_exists (libzfs_core.c:527)
   by zfs_send_resume_impl_cb_impl (libzfs_sendrecv.c:2002)
 Address 0x548b680 is 16 bytes inside a block of size 616 free'd
   by zfs_send_resume_impl_cb_impl (libzfs_sendrecv.c:1992)
 Block was alloc'd at
   by make_dataset_handle (libzfs_dataset.c:483)
   by zfs_open (libzfs_dataset.c:735)
   by zfs_send_resume_impl_cb_impl (libzfs_sendrecv.c:1884)
```

Offset 16 is `offsetof(struct zfs_handle, zfs_name)`.

Three runs each way, rebuilding between arms, with every run asserting the
ESRCH arm was actually reached:

| | stock | patched |
|---|---|---|
| invalid reads at :2002 | 4, in 3/3 runs | 0, in 3/3 runs |
| conditional jump on uninitialised | 165 | 165 |
| use of uninitialised value | 48 | 48 |
| syscall param uninitialised | 1 | 1 |
| total error contexts | 218 | 214 |

so the four removed contexts are the use-after-free and nothing else moved.
The remaining reports are pre-existing noise present in both arms. The
user-visible error text is identical either way, and a resume with the bookmark
still in place sends and receives normally.

Worth noting for anyone reaching for it: ASan does not catch this. The only
read is through `strlcpy`, which resolves to `strlcpy@GLIBC_2.38`, and libasan
ships no `strlcpy` interceptor, so the access happens inside uninstrumented
glibc.

ZTS `rsend` 79 pass / 1 known skip, `zfs_send` and `zfs_receive` all pass,
`make checkstyle` and `scripts/commitcheck.sh` pass.

No ZTS test is included, and I do not think one is worth adding here. The
user-visible behaviour is the same with and without the patch, so a test could
only ever pass; the defect shows up under memcheck alone, and forcing the
window needs the LD_PRELOAD shim, which is not something ZTS should carry.
Happy to be told otherwise.

### Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

---

### Separate note, not in this patch

Two `zfs_handle_t` leaks sit in the same function on error paths between the
`zfs_open()` at :1884 and the first close: :1902 and :1922 both return without
closing the handle. I left them out to keep this diff to the reported bug.
Happy to fold them in or send them separately, whichever you prefer.
