### PR TITLE
CI: fix a race that kills a VM's log reader and fails the job

### DIFF
--- a/.github/workflows/scripts/qemu-6-tests.sh
+++ b/.github/workflows/scripts/qemu-6-tests.sh
@@ -146,7 +146,10 @@ if [ -z ${1:-} ]; then
     tail --pid=$(cat vm${i}.pid) -f /dev/null
     pid=$(cat vm${i}log.pid)
     rm -f vm${i}log.pid
-    kill $pid
+    # Tolerate a reader that has already exited.  The ESRCH would otherwise
+    # end this script under set -e and fail a job whose tests all passed.
+    # It stays on stderr: a dead reader means output was lost.
+    kill $pid || true
   done
 
   exit 0

--- a/.github/workflows/scripts/qemu-6-tests.sh
+++ b/.github/workflows/scripts/qemu-6-tests.sh
@@ -24,7 +24,13 @@ function prefix() {
   S=$((DIFF-(M*60)))
 
   CTR=$(cat /tmp/ctr-vm${ID})
-  echo $LINE| grep -q '^\[.*] Test[: ]' && CTR=$((CTR+1)) && echo $CTR > /tmp/ctr-vm${ID}
+  # Publish the counter with a rename so it is never momentarily empty: the
+  # other VM's reader reads this file, and a plain redirect truncates before
+  # it writes.  A read landing in that window fails, which under set -e ends
+  # the reader and silently stops prefixing that VM's output.
+  echo $LINE| grep -q '^\[.*] Test[: ]' && CTR=$((CTR+1)) \
+    && echo $CTR > "/tmp/ctr-vm${ID}.new" \
+    && mv "/tmp/ctr-vm${ID}.new" "/tmp/ctr-vm${ID}"
 
   BASE="$HOME/work/zfs/zfs"
   COLOR="$BASE/scripts/zfs-tests-color.sh"


### PR DESCRIPTION
### Motivation and Context

Two bugs in the runner half of `qemu-6-tests.sh`, found while triaging a red
`fedora44` job in
https://github.com/openzfs/zfs/actions/runs/30772421272 whose tests had all
passed.

**A log reader can be killed by the counter it shares.** Each VM's reader keeps
its running test count in `/tmp/ctr-vm$ID` and reads every other VM's counter to
print the combined progress figure. The counter is published with a plain
redirect, which truncates the file before writing it, so a reader can catch it
empty. `read` then returns 1, and since the reader inherits `set -eu` from the
top of the script, that ends the reader subshell.

In that run it happened to vm2. Its last prefixed line is
`refreserv/cleanup` at 01:57 carrying counter 745, while vm1 goes on reporting
vm2 frozen at 746 for the remaining 38 minutes: the reader incremented the
counter and died before printing that line. vm2 itself kept testing until 02:14,
and its `899 / 11 / 6` summary never reached the live log. The results were
recovered from the artifact and no test outcome was affected, but roughly 17
minutes of that VM's live output was dropped with nothing said about why.

**A dead reader then fails the whole job.** When a VM's tests finish the runner
kills that VM's reader. If the reader is already gone, `kill` reports ESRCH, and
under `set -eu` that ends the script:

```
vm1: Results Summary
vm1: PASS	 1151
vm1: FAIL	    2
vm1: SKIP	    6
...
vm1: Tests with results other than PASS that are unexpected:
.github/workflows/scripts/qemu-6-tests.sh: line 143: kill: (20700) - No such process
##[error]Process completed with exit code 1.
```

All 13 failures in that run were on the expected list (`casenorm` x6,
`fault/auto_replace_001_pos`, `fault/auto_replace_002_pos`,
`fault/auto_spare_multiple`, `import_rewind_device_replaced`,
`refreserv_004_pos`, `xdr_bookmark_raw_with_write`, `vdev_zaps_007_pos`) and
neither VM listed an unexpected one. Only the exit status was wrong.

### Description

Publish the counter through a temporary file and rename, so a reader sees either
the old value or the new one and never an empty file.

Guard the `kill`, since a reader can still die for reasons this script does not
control and losing a three hour run at the cleanup step is a poor trade. The
message is left on stderr rather than discarded, because a reader exiting early
means live output was lost and that is worth seeing.

### How Has This Been Tested?

Both are races, so rather than wait for them I reproduced each mechanism
directly.

The counter race, racing a writer against a reader 20000 times:

```
plain redirect:  10805 / 20000 reads hit the empty window
temp + rename:       0 / 20000
```

and confirming that such a read is fatal under the shell options the reader
inherits:

```
read -r val < ctr            rc=1   (subshell dies)
read -r val < ctr || val=0   rc=0   SURVIVED
```

The cleanup abort, with the pid read back from a file and the process already
gone, as in the loop:

```
kill $pid           rc=1   kill: (…) - No such process   <- script ends here
kill $pid || true   rc=0   REACHED-END
```

`shellcheck` 0.9.0 reports no new rule codes against master, and one SC2086
fewer, since the rewritten counter line quotes its paths the way the adjacent
`read` already does. `bash -n` is clean. This PR's own qemu jobs exercise the
modified loop on every OS in the matrix.

### Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

The ZTS box is unticked deliberately: the change is to the runner-side driver
script and never touches a test path. The matrix jobs on this PR are the
relevant exercise.

### Left out on purpose

`$!` after a pipeline is the pid of its last element, so this `kill` only ever
targeted the `while read` subshell and left `stdbuf -oL tail -fq` running. It is
harmless on a runner about to exit, so I have not touched it here.

A tidier shape would drop the `kill` altogether: give the reader
`tail --pid=$(cat vm${i}.pid) -fq vm${i}log.txt` so it exits on its own once the
VM's ssh does, and `wait` for it instead. That drains the reader fully and
removes the orphan and the pid-reuse window together. Happy to do that instead
if you would rather have it in one go.
