### PR TITLE
man: zvol_request_sync is not ignored under blk-mq

### DIFF
--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -2914,9 +2914,9 @@ for each I/O submitter.
 When unset, requests are handled asynchronously by a thread pool.
 The number of requests which can be handled concurrently is controlled by
 .Sy zvol_threads .
-.Sy zvol_request_sync
-is ignored when running on a kernel that supports block multiqueue
-.Pq Li blk-mq .
+This parameter applies regardless of the
+.Sy zvol_use_blk_mq
+setting.
 .
 .It Sy zvol_num_taskqs Ns = Ns Sy 0 Pq uint
 Number of zvol taskqs.


### PR DESCRIPTION
The zfs.4 entry for zvol_request_sync claims it "is ignored when running on a kernel that supports block multiqueue (blk-mq)". This has never been true. The sentence and the blk-mq support that it describes landed in the same commit (6f73d0216 "zvol: Support blk-mq for better performance"), which added

	if (zvol_request_sync)
		force_sync = 1;

to zvol_request_impl() -- the function shared by both submission paths, reached from zvol_submit_bio() and from zvol_mq_queue_rq() alike. No blk-mq guard was added there then, and none exists now.

Taken literally the sentence is worse than inaccurate: HAVE_BLK_MQ was removed in 9601eeea1 because every supported kernel has blk-mq, so the documented condition is always satisfied and the parameter would never do anything.

Verified on 6.12.101 by counting call sites with kprobes during an fio run. zvol_write() is reached either via the taskq (zvol_write_task) or directly, so the two are a clean discriminator:
```
  config                zvol_write   zvol_write_task   zvol_tq CPU
  bio, default             1477413           1477413    7902 jiffies
  bio, sync=1              3873491                 0               0
  blk-mq, default          2787187           2787187    7948 jiffies
  blk-mq, sync=1           3816106                 0               0
```
With zvol_request_sync=1 no task is ever dispatched and the zvol taskq threads get no CPU, on both paths.

Replace the sentence with an accurate one.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
