### PR TITLE
DDT: Make ddt_zap_walk() use cursor _by_dnode functions

### DIFF
--- a/include/sys/zap.h
+++ b/include/sys/zap.h
@@ -474,6 +474,7 @@ void zap_cursor_fini(zap_cursor_t *zc);
  */
 int zap_cursor_init_noprefetch(zap_cursor_t *zc, objset_t *os,
     uint64_t zapobj);
+int zap_cursor_init_noprefetch_by_dnode(zap_cursor_t *zc, dnode_t *dn);
 
 /*
  * Initialize a zap cursor pointing to the position recorded by

--- a/module/zfs/ddt_zap.c
+++ b/module/zfs/ddt_zap.c
@@ -204,10 +204,9 @@ ddt_zap_walk(dnode_t *dn, uint64_t *walk, ddt_key_t *ddk,
 		 * scrub I/Os for each ZAP block that we read in, so
 		 * reading the ZAP is unlikely to be the bottleneck.
 		 */
-		zap_cursor_init_noprefetch(&zc, dn->dn_objset, dn->dn_object);
+		zap_cursor_init_noprefetch_by_dnode(&zc, dn);
 	} else {
-		zap_cursor_init_serialized(&zc, dn->dn_objset, dn->dn_object,
-		    *walk);
+		zap_cursor_init_serialized_by_dnode(&zc, dn, *walk);
 	}
 	if ((error = zap_cursor_retrieve(&zc, za)) == 0) {
 		uint64_t csize = za->za_num_integers;

--- a/module/zfs/zap.c
+++ b/module/zfs/zap.c
@@ -1109,6 +1109,12 @@ zap_cursor_init_noprefetch(zap_cursor_t *zc, objset_t *os, uint64_t zapobj)
 }
 
 int
+zap_cursor_init_noprefetch_by_dnode(zap_cursor_t *zc, dnode_t *dn)
+{
+	return (zap_cursor_init_by_dnode_impl(zc, dn, 0, B_FALSE));
+}
+
+int
 zap_cursor_init_serialized(zap_cursor_t *zc, objset_t *os, uint64_t zapobj,
     uint64_t serialized)
 {


### PR DESCRIPTION
ddt_zap_walk() already receives dnode as an argument.  We can save one dnode_hold() per entry by using _by_dnode cursor functions. zap_cursor_init_noprefetch_by_dnode() is added in the process.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
