### PR TITLE
zhack: add "mmp reclaim" to recover a pool stranded by MMP

### DIFF
--- a/cmd/zhack.c
+++ b/cmd/zhack.c
@@ -45,6 +45,7 @@
 #include <sys/dsl_synctask.h>
 #include <sys/vdev.h>
 #include <sys/vdev_impl.h>
+#include <sys/mmp.h>
 #include <sys/fs/zfs.h>
 #include <sys/dmu_objset.h>
 #include <sys/dsl_pool.h>
@@ -110,6 +111,13 @@ usage(void)
 	    "        -u restore the label on a detached device\n"
 	    "\n"
 	    "    <device> : path to vdev\n"
+	    "\n"
+	    "    mmp reclaim <pool>\n"
+	    "        import a pool whose MMP claim cannot reach every mirror\n"
+	    "        leg the config still expects, then mark the unreachable\n"
+	    "        leaves offline so ordinary imports succeed.  Manual\n"
+	    "        recovery: fence the peer first, this cannot see a\n"
+	    "        live host whose legs are all invisible from here\n"
 	    "\n"
 	    "    metaslab leak <pool>\n"
 	    "        apply allocation map from zdb to specified pool\n");
@@ -599,6 +607,174 @@ zhack_do_action_idle(int argc, char **argv)
 	sleep(idle_time);
 
 	spa_close(spa, FTAG);
+}
+
+/*
+ * Collect the mirror legs this host could not open.  vdev_not_present is set
+ * during import for any leaf whose open failed (vdev.c), and a leg in that
+ * state is what the relaxed claim forgives, so it is also what has to be
+ * marked offline for the ordinary imports which follow to succeed.
+ */
+static void
+zhack_collect_absent(vdev_t *vd, uint64_t *guids, uint_t *n, uint_t max)
+{
+	/*
+	 * Skip the same subtrees mmp_claim_uberblock_sync() skips.  The claim
+	 * never counts these, so offlining them buys nothing, and offlining a
+	 * log leg would drag in spa_reset_logs().  Pruned at the interior node
+	 * because the log flag lives on the top-level vdev.
+	 */
+	if (vd->vdev_islog || vd->vdev_isspare || vd->vdev_isl2cache ||
+	    vd->vdev_ishole || vd->vdev_ops == &vdev_indirect_ops)
+		return;
+
+	for (uint64_t c = 0; c < vd->vdev_children; c++)
+		zhack_collect_absent(vd->vdev_child[c], guids, n, max);
+
+	if (!vd->vdev_ops->vdev_op_leaf || !vd->vdev_not_present)
+		return;
+
+	/*
+	 * Take only the legs the relaxed claim can forgive, which are the
+	 * direct children of a top-level mirror: the relaxation lives in the
+	 * nparity == 0 branch and walks that vdev's children.  A raidz or
+	 * draid member is required as parity+1 in aggregate and never demanded
+	 * individually, so an absent one does not raise the requirement and
+	 * offlining it would be a persistent change that buys nothing.
+	 */
+	if (vd->vdev_parent != vd->vdev_top ||
+	    vdev_get_nparity(vd->vdev_top) != 0)
+		return;
+
+	VERIFY3U(*n, <, max);
+	guids[(*n)++] = vd->vdev_guid;
+}
+
+static int
+zhack_do_mmp_reclaim(int argc, char **argv)
+{
+	spa_t *spa;
+	char *target;
+	uint64_t *guids;
+	uint_t nguids = 0, max;
+	int c, failed = 0;
+
+	optind = 1;
+	while ((c = getopt(argc, argv, "+")) != -1) {
+		switch (c) {
+		default:
+			usage();
+			break;
+		}
+	}
+	argc -= optind;
+	argv += optind;
+
+	if (argc < 1) {
+		(void) fprintf(stderr, "error: missing pool name\n");
+		usage();
+	}
+	target = argv[0];
+
+	/*
+	 * Relax the claim for this import only.  The write, the wait and the
+	 * re-read are untouched, so a competing importer which shares any
+	 * visibility with us is still refused.
+	 */
+	mmp_claim_relaxed = B_TRUE;
+	zhack_spa_open(target, B_FALSE, FTAG, &spa);
+	mmp_claim_relaxed = B_FALSE;
+
+	/*
+	 * Nothing to recover on a pool without multihost: no claim runs, so an
+	 * ordinary import already succeeds with the absent leaves simply
+	 * missing.  Offlining them here would be a permanent change to a pool
+	 * that never needed this tool.
+	 */
+	if (!spa_multihost(spa)) {
+		(void) fprintf(stderr, "%s: multihost is off, so no uberblock "
+		    "claim runs and an ordinary import will succeed; refusing "
+		    "to offline anything\n", target);
+		spa_close(spa, FTAG);
+		return (1);
+	}
+
+	/* Takes SCL_VDEV itself, so size the array before we hold it. */
+	max = MAX(vdev_count_leaves(spa), 1);
+	guids = umem_zalloc(max * sizeof (uint64_t), UMEM_NOFAIL);
+
+	spa_config_enter(spa, SCL_VDEV, FTAG, RW_READER);
+	zhack_collect_absent(spa->spa_root_vdev, guids, &nguids, max);
+	spa_config_exit(spa, SCL_VDEV, FTAG);
+
+	if (nguids == 0) {
+		(void) fprintf(stdout, "%s: imported, no absent leaves to "
+		    "mark offline\n", target);
+	}
+
+	for (uint_t i = 0; i < nguids; i++) {
+		int error = vdev_offline(spa, guids[i], 0);
+
+		if (error == 0) {
+			(void) fprintf(stdout, "%s: marked absent leaf %llu "
+			    "offline\n", target, (u_longlong_t)guids[i]);
+			continue;
+		}
+
+		failed++;
+		if (error == EBUSY) {
+			(void) fprintf(stderr, "%s: leaf %llu holds data no "
+			    "other leaf has, left online\n", target,
+			    (u_longlong_t)guids[i]);
+		} else {
+			(void) fprintf(stderr, "%s: could not offline leaf "
+			    "%llu: %s\n", target, (u_longlong_t)guids[i],
+			    strerror(error));
+		}
+	}
+
+	if (failed != 0) {
+		/*
+		 * Not "the pool still needs zhack": this run exports cleanly
+		 * under our own hostid, so the next import here skips the
+		 * activity check entirely.  The cost lands on the next host
+		 * to take the pool, whose claim will count the leaves left
+		 * online and refuse.
+		 */
+		(void) fprintf(stderr, "%s: %d absent leaves are still "
+		    "online; a later import from another host will count "
+		    "them and be refused\n", target, failed);
+	}
+
+	umem_free(guids, max * sizeof (uint64_t));
+	spa_close(spa, FTAG);
+
+	return (failed == 0 ? 0 : 1);
+}
+
+static int
+zhack_do_mmp(int argc, char **argv)
+{
+	char *subcommand;
+
+	argc--;
+	argv++;
+	if (argc == 0) {
+		(void) fprintf(stderr,
+		    "error: no mmp operation specified\n");
+		usage();
+	}
+
+	subcommand = argv[0];
+	if (strcmp(subcommand, "reclaim") == 0) {
+		return (zhack_do_mmp_reclaim(argc, argv));
+	} else {
+		(void) fprintf(stderr, "error: unknown subcommand: %s\n",
+		    subcommand);
+		usage();
+	}
+
+	return (0);
 }
 
 static int
@@ -1372,6 +1548,8 @@ main(int argc, char **argv)
 		rv = zhack_do_action(argc, argv);
 	} else if (strcmp(subcommand, "feature") == 0) {
 		rv = zhack_do_feature(argc, argv);
+	} else if (strcmp(subcommand, "mmp") == 0) {
+		rv = zhack_do_mmp(argc, argv);
 	} else if (strcmp(subcommand, "label") == 0) {
 		return (zhack_do_label(argc, argv));
 	} else if (strcmp(subcommand, "metaslab") == 0) {

--- a/include/sys/mmp.h
+++ b/include/sys/mmp.h
@@ -74,6 +74,11 @@ extern uint64_t zfs_multihost_interval;
 extern uint_t zfs_multihost_fail_intervals;
 extern uint_t zfs_multihost_import_intervals;
 
+#ifndef _KERNEL
+/* Manual recovery only, see the comment in mmp.c.  Never in the module. */
+extern boolean_t mmp_claim_relaxed;
+#endif
+
 #ifdef	__cplusplus
 }
 #endif

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -2408,9 +2408,20 @@ zpool_import_props(libzfs_handle_t *hdl, nvlist_t *config, const char *newname,
 				const char *hostname = "<unknown>";
 				uint64_t hostid = 0;
 				mmp_state_t mmp_state;
+				uint32_t mmp_result = 0;
 
 				mmp_state = fnvlist_lookup_uint64(nvinfo,
 				    ZPOOL_CONFIG_MMP_STATE);
+
+				/*
+				 * A kernel which does not report a cause
+				 * leaves this zero, which falls through to
+				 * the messages below.
+				 */
+				if (nvlist_exists(nvinfo,
+				    ZPOOL_CONFIG_MMP_RESULT))
+					mmp_result = fnvlist_lookup_uint32(
+					    nvinfo, ZPOOL_CONFIG_MMP_RESULT);
 
 				if (nvlist_exists(nvinfo,
 				    ZPOOL_CONFIG_MMP_HOSTNAME))
@@ -2422,7 +2433,23 @@ zpool_import_props(libzfs_handle_t *hdl, nvlist_t *config, const char *newname,
 					hostid = fnvlist_lookup_uint64(nvinfo,
 					    ZPOOL_CONFIG_MMP_HOSTID);
 
-				if (mmp_state == MMP_STATE_ACTIVE) {
+				if (mmp_result == ENODEV) {
+					(void) snprintf(aux, sizeof (aux),
+					    dgettext(TEXT_DOMAIN, "the multi"
+					    "host claim could not be written "
+					    "to a device\nthe pool "
+					    "configuration expects to be "
+					    "present.\nIf the device is "
+					    "permanently gone, recover with "
+					    "'zhack mmp reclaim'."));
+				} else if (mmp_result == EIO) {
+					(void) snprintf(aux, sizeof (aux),
+					    dgettext(TEXT_DOMAIN, "I/O errors "
+					    "occurred while writing the multi"
+					    "host claim.\nClear the device "
+					    "errors, then run 'zpool "
+					    "import'."));
+				} else if (mmp_state == MMP_STATE_ACTIVE) {
 					(void) snprintf(aux, sizeof (aux),
 					    dgettext(TEXT_DOMAIN, "pool is imp"
 					    "orted on host '%s' (hostid=%lx).\n"

--- a/man/man1/zhack.1
+++ b/man/man1/zhack.1
@@ -23,7 +23,7 @@
 .\"
 .\" lint-ok: WARNING: sections out of conventional order: Sh SYNOPSIS
 .\"
-.Dd May 3, 2023
+.Dd August 3, 2026
 .Dt ZHACK 1
 .Os
 .
@@ -124,6 +124,47 @@ Example:
 .
 .It Xo
 .Nm zhack
+.Cm mmp reclaim
+.Ar pool
+.Xc
+Import a
+.Ar pool
+whose uberblock claim cannot reach every mirror leg the configuration still
+expects to be present, then mark the unreachable leaves offline so that
+ordinary imports succeed, and export it again.
+.Pp
+This exists for one situation: a host has failed together with the mirror legs
+attached to it, so the surviving labels still describe those legs as healthy,
+and every later import demands writes to them that nobody can make.
+.Pp
+.Sy This does not make the operation safe on its own .
+A live host whose legs are
+.Em all
+invisible from here cannot be detected by any write and read scheme, and this
+command will take the pool from it.
+Fence the failed host, or otherwise prove it is powered off, before running
+this.
+.Pp
+The activity check itself is unchanged: every write the reachable legs allow,
+the wait, and the re-read all still happen, so a competing host which shares
+any leg with this one is still detected and the import is refused.
+Only the number of writes the claim demands is lowered, and only for mirror
+legs this host cannot open, each of which is then marked offline.
+.Pp
+The pool is left exported, and imports degraded with those leaves offline.
+Bring each one back with
+.Xr zpool-online 8
+once the hardware returns.
+A leaf holding the only copy of some data cannot be offlined: it is reported
+and left online, and imports from other hosts stay refused.
+No leaf is marked offline on a pool which does not have
+.Sy multihost
+set, since no claim runs for it and an ordinary import already succeeds.
+Leaves of log, cache, and spare vdevs are not touched, as the claim does not
+write to them.
+.
+.It Xo
+.Nm zhack
 .Cm metaslab leak
 .Op Fl f
 .Ar pool
@@ -181,8 +222,23 @@ descriptions_obj:
 .No # Nm zhack Cm feature enable Fl d No 'Predict future disk failures.' Ar tank com.example:clairvoyance
 .No # Nm zhack Cm feature ref Ar tank com.example:clairvoyance
 .Ed
+.Pp
+Recover a pool whose peer host died together with its mirror legs, after
+confirming that host is down:
+.Bd -literal
+.No # Nm zpool Cm import Fl f Ar tank
+cannot import 'tank': pool is imported on host '<unknown>' (hostid=0).
+Export the pool on the other system, then run 'zpool import'.
+.No # Nm zhack Cm mmp reclaim Ar tank
+tank: marked absent leaf 5646371977210937898 offline
+.No # Nm zpool Cm import Ar tank
+.No # Nm zpool Cm online Ar tank Ar /dev/disk/by-id/...
+.Ed
 .
 .Sh SEE ALSO
 .Xr ztest 1 ,
 .Xr zpool-features 7 ,
-.Xr zfs 8
+.Xr zpoolprops 7 ,
+.Xr zfs 8 ,
+.Xr zpool-import 8 ,
+.Xr zpool-online 8

--- a/man/man1/zhack.1
+++ b/man/man1/zhack.1
@@ -227,8 +227,9 @@ Recover a pool whose peer host died together with its mirror legs, after
 confirming that host is down:
 .Bd -literal
 .No # Nm zpool Cm import Fl f Ar tank
-cannot import 'tank': pool is imported on host '<unknown>' (hostid=0).
-Export the pool on the other system, then run 'zpool import'.
+cannot import 'tank': the multihost claim could not be written to a device
+the pool configuration expects to be present.
+If the device is permanently gone, recover with 'zhack mmp reclaim'.
 .No # Nm zhack Cm mmp reclaim Ar tank
 tank: marked absent leaf 5646371977210937898 offline
 .No # Nm zpool Cm import Ar tank

--- a/module/zfs/mmp.c
+++ b/module/zfs/mmp.c
@@ -581,7 +581,8 @@ mmp_claim_uberblock_sync_done(zio_t *zio)
  */
 static void
 mmp_claim_uberblock_sync(zio_t *zio, uint64_t *good_writes,
-    uint64_t *req_writes, uberblock_t *ub, vdev_t *vd, int flags)
+    uint64_t *issued_writes, uint64_t *req_writes, uberblock_t *ub, vdev_t *vd,
+    int flags)
 {
 	for (uint64_t c = 0; c < vd->vdev_children; c++) {
 		vdev_t *cvd = vd->vdev_child[c];
@@ -638,8 +639,8 @@ mmp_claim_uberblock_sync(zio_t *zio, uint64_t *good_writes,
 			}
 		}
 
-		mmp_claim_uberblock_sync(zio, good_writes, req_writes,
-		    ub, cvd, flags);
+		mmp_claim_uberblock_sync(zio, good_writes, issued_writes,
+		    req_writes, ub, cvd, flags);
 	}
 
 	if (!vd->vdev_ops->vdev_op_leaf)
@@ -650,6 +651,17 @@ mmp_claim_uberblock_sync(zio_t *zio, uint64_t *good_writes,
 
 	if (vd->vdev_ops == &vdev_draid_spare_ops)
 		return;
+
+	/*
+	 * Count the writes actually issued alongside those required.  A leaf
+	 * the config expects present but which cannot be written is never
+	 * issued one, so a shortfall here means a device is missing rather
+	 * than failing.  Gated exactly as good_writes is in
+	 * mmp_claim_uberblock_sync_done() so that the two counts describe the
+	 * same set of leaves and can be compared.
+	 */
+	if (vd->vdev_top->vdev_ms_array != 0)
+		(*issued_writes)++;
 
 	abd_t *ub_abd = abd_alloc_for_io(VDEV_UBERBLOCK_SIZE(vd), B_TRUE);
 	abd_copy_from_buf(ub_abd, ub, sizeof (uberblock_t));
@@ -670,6 +682,7 @@ mmp_claim_uberblock(spa_t *spa, vdev_t *vd, uberblock_t *ub)
 {
 	int flags = ZIO_FLAG_CONFIG_WRITER | ZIO_FLAG_CANFAIL;
 	uint64_t good_writes = 0;
+	uint64_t issued_writes = 0;
 	uint64_t req_writes = 0;
 	zio_t *zio;
 
@@ -680,7 +693,8 @@ mmp_claim_uberblock(spa_t *spa, vdev_t *vd, uberblock_t *ub)
 
 	/* Sync the uberblock to all writeable leaves */
 	zio = zio_root(spa, NULL, NULL, flags);
-	mmp_claim_uberblock_sync(zio, &good_writes, &req_writes, ub, vd, flags);
+	mmp_claim_uberblock_sync(zio, &good_writes, &issued_writes, &req_writes,
+	    ub, vd, flags);
 	(void) zio_wait(zio);
 
 	/* Flush the new uberblocks so they're immediately visible */
@@ -691,16 +705,31 @@ mmp_claim_uberblock(spa_t *spa, vdev_t *vd, uberblock_t *ub)
 	spa_config_exit(spa, SCL_ALL, mmp_tag);
 
 	zfs_dbgmsg("mmp: claiming uberblock, spa=%s txg=%llu seq=%llu "
-	    "req_writes=%llu good_writes=%llu", spa_load_name(spa),
+	    "req_writes=%llu issued_writes=%llu good_writes=%llu",
+	    spa_load_name(spa),
 	    (u_longlong_t)ub->ub_txg, (u_longlong_t)MMP_SEQ(ub),
-	    (u_longlong_t)req_writes, (u_longlong_t)good_writes);
+	    (u_longlong_t)req_writes, (u_longlong_t)issued_writes,
+	    (u_longlong_t)good_writes);
 
 	/*
 	 * To guarantee visibility from a remote host we require a minimum
 	 * number of good writes. For raidz/draid vdevs parity+1 writes, for
-	 * mirrors 2 writes, and for singletons 1 write.
+	 * mirrors one write per leg the config expects present, and for
+	 * singletons 1 write.
+	 *
+	 * Distinguish the two ways of falling short.  Too few writes issued
+	 * means a device the config expects present could not be written at
+	 * all, which persists across retries and is what 'zhack mmp reclaim'
+	 * recovers.  Enough issued but too few good means the writes reached
+	 * present devices and failed, which a retry may clear.
 	 */
-	if (req_writes == 0 || good_writes < req_writes)
+	if (req_writes == 0)
+		return (SET_ERROR(EIO));
+
+	if (issued_writes < req_writes)
+		return (SET_ERROR(ENODEV));
+
+	if (good_writes < req_writes)
 		return (SET_ERROR(EIO));
 
 	return (0);

--- a/module/zfs/mmp.c
+++ b/module/zfs/mmp.c
@@ -196,6 +196,22 @@ uint_t zfs_multihost_import_intervals = MMP_DEFAULT_IMPORT_INTERVALS;
  */
 uint_t zfs_multihost_fail_intervals = MMP_DEFAULT_FAIL_INTERVALS;
 
+#ifndef _KERNEL
+/*
+ * Manual recovery only, set by zhack.  Drops the mirror legs this host
+ * cannot open from the uberblock claim's required write count, so a pool
+ * whose config still expects legs that died with a peer host can be
+ * imported by hand.  Every leg which can be opened is still required.
+ *
+ * This is deliberately absent from the kernel module.  The write, the wait
+ * and the re-read are untouched, so a competing importer which shares any
+ * visibility with us is still caught; a live peer whose legs are all
+ * invisible from here is not, and cannot be by any write-and-read scheme.
+ * That residual is why this is a manual operation guarded by fencing.
+ */
+boolean_t mmp_claim_relaxed = B_FALSE;
+#endif
+
 static const void *const mmp_tag = "mmp_write_uberblock";
 static __attribute__((noreturn)) void mmp_thread(void *arg);
 
@@ -600,6 +616,19 @@ mmp_claim_uberblock_sync(zio_t *zio, uint64_t *good_writes,
 				for (uint64_t l = 0; l < cvd->vdev_children;
 				    l++) {
 					vdev_t *lvd = cvd->vdev_child[l];
+#ifndef _KERNEL
+					/*
+					 * Manual recovery forgives the legs
+					 * this host could not open, and marks
+					 * that same set offline before it
+					 * exports, so the relaxed claim
+					 * accepts nothing the later ordinary
+					 * imports would not.
+					 */
+					if (mmp_claim_relaxed &&
+					    lvd->vdev_not_present)
+						continue;
+#endif
 					if (!lvd->vdev_offline &&
 					    !lvd->vdev_faulted &&
 					    !lvd->vdev_removed)

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -4041,8 +4041,17 @@ spa_activity_check_duration(spa_t *spa, uberblock_t *ub)
  * - ENXIO	- system hostid not set
  * - ESRCH	- activity check skipped
  * - EREMOTEIO	- activity check detected active pool
+ * - ENODEV	- claim could not be written to a device the config expects
+ * - EIO	- claim writes were issued to present devices and failed
  * - EINTR	- activity check interrupted
  * - 0		- activity check detected no activity
+ *
+ * ENODEV and EIO are reported with ZPOOL_CONFIG_MMP_STATE set to
+ * MMP_STATE_ACTIVE even though no remote host was seen.  Nothing is actually
+ * active in either case, but an older zpool(8) knows only the two existing
+ * states and reaches zfs_error_aux() with an uninitialized buffer for any
+ * other value, so the state is kept as one it understands and the real cause
+ * travels in the result.
  */
 static void
 spa_activity_set_load_info(spa_t *spa, nvlist_t *label, mmp_state_t state,
@@ -4111,6 +4120,20 @@ spa_ld_activity_result(spa_t *spa, int error, const char *state)
 		cmn_err(CE_WARN, "pool '%s' system hostid not set, "
 		    "aborted import during %s", spa_load_name(spa), state);
 		/* Userspace expects EREMOTEIO for no system hostid */
+		error = EREMOTEIO;
+		break;
+	case ENODEV:
+		cmn_err(CE_WARN, "pool '%s' could not claim every device the "
+		    "config expects present, aborted import during %s; if a "
+		    "device is permanently gone see 'zhack mmp reclaim'",
+		    spa_load_name(spa), state);
+		/* Userspace expects EREMOTEIO for a failed claim */
+		error = EREMOTEIO;
+		break;
+	case EIO:
+		cmn_err(CE_WARN, "pool '%s' had I/O errors writing the claim, "
+		    "aborted import during %s", spa_load_name(spa), state);
+		/* Userspace expects EREMOTEIO for a failed claim */
 		error = EREMOTEIO;
 		break;
 	case EREMOTEIO:
@@ -4242,6 +4265,9 @@ spa_activity_check_tryimport(spa_t *spa, uberblock_t *spa_ub,
  * error results:
  *          0 - no activity detected
  *  EREMOTEIO - remote activity detected
+ *     ENODEV - the claim could not be written to a device the config
+ *              expects to be present
+ *        EIO - the claim writes were issued to present devices and failed
  *      EINTR - user canceled the operation
  */
 static int
@@ -4323,7 +4349,13 @@ spa_activity_check_claim(spa_t *spa)
 		if (error) {
 			spa_load_failed(spa, "mmp: uberblock claim "
 			    "failed, error=%d", error);
-			error = SET_ERROR(EREMOTEIO);
+			/*
+			 * ENODEV and EIO are both kept distinct from the
+			 * EREMOTEIO returned when another host is seen below.
+			 * Failing to write the claim is not evidence of a
+			 * remote host, and only the ENODEV case has a
+			 * recovery.
+			 */
 			break;
 		}
 
@@ -4367,9 +4399,14 @@ out:
 	spa->spa_mmp.mmp_claim_ns = gethrtime() - start_time;
 	(void) spa_import_progress_set_mmp_check(spa_guid(spa), 0);
 
-	if (error == EREMOTEIO) {
+	/*
+	 * A claim shortfall reaches userspace as EREMOTEIO exactly as remote
+	 * activity does, so an older zpool(8) sees no change.  The cause
+	 * travels in the result for a zpool(8) which knows to read it.
+	 */
+	if (error == EREMOTEIO || error == ENODEV || error == EIO) {
 		spa_activity_set_load_info(spa, mmp_label,
-		    MMP_STATE_ACTIVE, 0, 0, EREMOTEIO);
+		    MMP_STATE_ACTIVE, 0, 0, error);
 	} else {
 		spa_activity_set_load_info(spa, mmp_label,
 		    MMP_STATE_INACTIVE, spa_ub.ub_txg, MMP_SEQ(&spa_ub), 0);

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -162,7 +162,7 @@ tags = ['functional', 'mmap']
 [tests/functional/mmp:Linux]
 tests = ['mmp_on_thread', 'mmp_on_uberblocks', 'mmp_on_off', 'mmp_interval',
     'mmp_active_import', 'mmp_inactive_import', 'mmp_exported_import',
-    'mmp_degraded_import',
+    'mmp_degraded_import', 'mmp_zhack_reclaim',
     'mmp_write_uberblocks', 'mmp_reset_interval', 'multihost_history',
     'mmp_on_zdb', 'mmp_write_distribution', 'mmp_hostid', 'mmp_write_slow_disk',
     'mmp_concurrent_import']

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1831,6 +1831,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/mmp/mmp_write_distribution.ksh \
 	functional/mmp/mmp_write_slow_disk.ksh \
 	functional/mmp/mmp_write_uberblocks.ksh \
+	functional/mmp/mmp_zhack_reclaim.ksh \
 	functional/mmp/multihost_history.ksh \
 	functional/mmp/setup.ksh \
 	functional/mount/cleanup.ksh \

--- a/tests/zfs-tests/tests/functional/mmp/mmp.kshlib
+++ b/tests/zfs-tests/tests/functional/mmp/mmp.kshlib
@@ -139,7 +139,7 @@ function mmp_pool_create_zhack # pool dir
 	log_must eval "ZFS_HOSTID=$HOSTID1 zhack $opts >$MMP_ZHACK_LOG 2>&1 &"
 
 	while ! is_pool_imported "$pool" "-d $dir"; do
-		log_must pgrep zhack
+		log_must pgrep -x zhack
 		log_must sleep 5
 	done
 }
@@ -149,7 +149,14 @@ function mmp_pool_destroy # pool dir
 	typeset pool=${1:-$MMP_POOL}
 	typeset dir=${2:-$MMP_DIR}
 
-	ZHACKPID=$(pgrep zhack)
+	#
+	# -x matches the process name exactly.  Without it any process whose
+	# name merely contains "zhack" is matched, which includes a test script
+	# named after the tool: a ksh script mmp_zhack_reclaim.ksh has comm
+	# "mmp_zhack_recla", so the bare form found the running test and killed
+	# it, leaving the harness with a dead test and nothing logged.
+	#
+	ZHACKPID=$(pgrep -x zhack)
 	if [ -n "$ZHACKPID" ]; then
 		log_must kill $ZHACKPID
 		wait $ZHACKPID

--- a/tests/zfs-tests/tests/functional/mmp/mmp_degraded_import.ksh
+++ b/tests/zfs-tests/tests/functional/mmp/mmp_degraded_import.ksh
@@ -15,10 +15,6 @@
 # CDDL HEADER END
 #
 
-#
-# Copyright (c) 2026 by Michael Heller.
-#
-
 # DESCRIPTION:
 #	Verify the MMP uberblock claim requires a write only to those mirror
 #	legs the pool configuration still expects to be present.
@@ -107,7 +103,7 @@ typeset out
 if out=$(zpool import -d $MMP_DIR -f $MMP_POOL 2>&1); then
 	log_fail "Imported a mirror while a required leg was unreadable"
 fi
-if ! echo "$out" | grep -q "pool is imported on host"; then
+if ! echo "$out" | grep -q "could not be written to a device"; then
 	log_fail "Import refused for an unexpected reason: $out"
 fi
 
@@ -156,7 +152,7 @@ if out=$(zpool import -d $MMP_DIR -f $MMP_POOL 2>&1); then
 	log_fail "Imported a three-way mirror while a required leg was" \
 	    "unreadable"
 fi
-if ! echo "$out" | grep -q "pool is imported on host"; then
+if ! echo "$out" | grep -q "could not be written to a device"; then
 	log_fail "Import refused for an unexpected reason: $out"
 fi
 

--- a/tests/zfs-tests/tests/functional/mmp/mmp_zhack_reclaim.ksh
+++ b/tests/zfs-tests/tests/functional/mmp/mmp_zhack_reclaim.ksh
@@ -52,11 +52,12 @@ verify_runnable "both"
 typeset HIDDEN_LEG=$TEST_BASE_DIR/mmp_zhack_hidden_leg
 typeset PEER_DIR=$TEST_BASE_DIR/mmp_zhack_peer
 typeset DBGMSG=/proc/spl/kstat/zfs/dbgmsg
+typeset MMP_IMPORT_ERR=$TEST_BASE_DIR/mmp_zhack_import_err
 
 function cleanup
 {
 	mmp_pool_destroy $MMP_POOL $MMP_DIR
-	rm -rf $HIDDEN_LEG $PEER_DIR
+	rm -rf $HIDDEN_LEG $PEER_DIR $MMP_IMPORT_ERR
 	log_must mmp_clear_hostid
 }
 
@@ -92,12 +93,15 @@ function become_third_host
 #
 function claim_reimport
 {
+	typeset re='.*req_writes=([0-9]+) issued_writes=[0-9]+'
+	re="$re good_writes=([0-9]+).*"
+
 	echo 0 >$DBGMSG
 
 	zpool import -d $MMP_DIR $MMP_POOL >/dev/null 2>&1 || return
 
 	grep -h 'mmp: claiming uberblock' $DBGMSG 2>/dev/null |
-	    sed -nE 's/.*req_writes=([0-9]+) good_writes=([0-9]+).*/\1 \2/p' |
+	    sed -nE "s/$re/\1 \2/p" |
 	    tail -1
 }
 
@@ -107,7 +111,18 @@ mmp_pool_create_simple $MMP_POOL $MMP_DIR
 crash_export_as_other_host
 log_must mv $MMP_DIR/vdev2 $HIDDEN_LEG
 
-log_mustnot zpool import -d $MMP_DIR -f $MMP_POOL
+#
+# The import has to say which of the two refusals this is.  It used to report
+# the same "pool is imported on host" text used for a pool another host holds,
+# which is wrong here: nothing holds this pool, the claim simply could not
+# reach every leg the config expects.  Both directions matter, so the wrong
+# message is asserted against as well as the right one.
+#
+log_mustnot eval "zpool import -d $MMP_DIR -f $MMP_POOL >$MMP_IMPORT_ERR 2>&1"
+log_must grep -q "could not be written to a device" $MMP_IMPORT_ERR
+log_mustnot grep -q "pool is imported on host" $MMP_IMPORT_ERR
+log_must rm -f $MMP_IMPORT_ERR
+
 log_must zhack -d $MMP_DIR mmp reclaim $MMP_POOL
 
 #

--- a/tests/zfs-tests/tests/functional/mmp/mmp_zhack_reclaim.ksh
+++ b/tests/zfs-tests/tests/functional/mmp/mmp_zhack_reclaim.ksh
@@ -1,0 +1,290 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/mmp/mmp.cfg
+. $STF_SUITE/tests/functional/mmp/mmp.kshlib
+
+#
+# DESCRIPTION:
+#	Verify `zhack mmp reclaim` recovers a pool whose configuration expects
+#	mirror legs that went away with a failed host, and that it relaxes the
+#	uberblock claim no further than that.
+#
+# STRATEGY:
+#	1. A pool stranded by legs the configuration still expects is
+#	   recovered, and the claim then accepts it on an ordinary import.
+#	   The import is made as a THIRD hostid on purpose: zhack exports
+#	   cleanly under its own hostid, so importing again as the same host
+#	   would skip the activity check and never exercise the claim at all.
+#	2. The claim is relaxed only for legs this host cannot open.  A pool
+#	   held by a live host which shares a leg with us is still refused.
+#	3. Legs of every top level vdev are still counted after a recovery.
+#	4. A pool which does not use multihost is left alone, since no claim
+#	   runs for it and an ordinary import already succeeds.
+#	5. Legs of a log vdev are not touched, since the claim never counts
+#	   them.
+#	6. Members of a raidz vdev are not touched.  The claim requires
+#	   parity+1 writes in aggregate rather than one per member, so an
+#	   absent member does not raise the requirement and there is nothing
+#	   for this tool to recover.
+#
+
+verify_runnable "both"
+
+# $HOSTID3 comes from mmp.cfg.  A third identity is needed so a post-recovery
+# import cannot take the exported-and-same-hostid shortcut past the activity
+# check, which would leave the claim unexercised.
+typeset HIDDEN_LEG=$TEST_BASE_DIR/mmp_zhack_hidden_leg
+typeset PEER_DIR=$TEST_BASE_DIR/mmp_zhack_peer
+typeset DBGMSG=/proc/spl/kstat/zfs/dbgmsg
+
+function cleanup
+{
+	mmp_pool_destroy $MMP_POOL $MMP_DIR
+	rm -rf $HIDDEN_LEG $PEER_DIR
+	log_must mmp_clear_hostid
+}
+
+log_assert "zhack mmp reclaim recovers a stranded pool and relaxes no further"
+log_onexit cleanup
+
+#
+# Leave the pool looking imported, then take on a different identity, so the
+# next import runs an activity check and an uberblock claim as it would after
+# the original host failed.
+#
+function crash_export_as_other_host
+{
+	log_must zpool export -F $MMP_POOL
+	log_must mmp_clear_hostid
+	log_must mmp_set_hostid $HOSTID2
+}
+
+#
+# Become a third host.  Kept out of claim_reimport because log_must writes
+# its SUCCESS lines to stdout, which would be captured along with the
+# numbers by the command substitution below.
+#
+function become_third_host
+{
+	log_must mmp_clear_hostid
+	log_must mmp_set_hostid $HOSTID3
+}
+
+#
+# Import and echo the claim's own accounting, "req good".  Empty if the
+# import failed.  Nothing here may write to stdout except the numbers.
+#
+function claim_reimport
+{
+	echo 0 >$DBGMSG
+
+	zpool import -d $MMP_DIR $MMP_POOL >/dev/null 2>&1 || return
+
+	grep -h 'mmp: claiming uberblock' $DBGMSG 2>/dev/null |
+	    sed -nE 's/.*req_writes=([0-9]+) good_writes=([0-9]+).*/\1 \2/p' |
+	    tail -1
+}
+
+# 1. A stranded pool is recovered, and the claim accepts it afterwards
+log_note "Verify a stranded pool is recovered and the claim then accepts it"
+mmp_pool_create_simple $MMP_POOL $MMP_DIR
+crash_export_as_other_host
+log_must mv $MMP_DIR/vdev2 $HIDDEN_LEG
+
+log_mustnot zpool import -d $MMP_DIR -f $MMP_POOL
+log_must zhack -d $MMP_DIR mmp reclaim $MMP_POOL
+
+#
+# zhack exports the pool when it is done, so there is nothing to inspect
+# until the pool is imported again.  That import is the point of the test.
+#
+become_third_host
+typeset nums=$(claim_reimport)
+if [[ "$nums" != "1 1" ]]; then
+	log_fail "claim after recovery counted '$nums', expected '1 1'"
+fi
+log_note "claim after recovery required 1 write and got 1"
+log_must check_state $MMP_POOL "" "DEGRADED"
+
+#
+# The leg has to be left OFFLINE specifically.  A faulted leg would also read
+# as DEGRADED and would also satisfy the claim, but only an offline one has
+# "zpool online" as its documented inverse.
+#
+if ! zpool status $MMP_POOL | grep -q OFFLINE; then
+	log_fail "the absent leg was not left offline after recovery"
+fi
+mmp_pool_destroy $MMP_POOL $MMP_DIR
+log_must rm -f $HIDDEN_LEG
+
+# 2. A pool held by a live host which shares a leg with us is still refused
+log_note "Verify a live host sharing a leg is still refused"
+mmp_pool_create_simple $MMP_POOL $MMP_DIR
+log_must zpool export $MMP_POOL
+
+#
+# The peer keeps both legs.  We keep a link to one of them, so we cannot open
+# the other and the relaxed claim has something to forgive, while the peer's
+# multihost writes still reach a leg we can read.
+#
+log_must mkdir -p $PEER_DIR
+log_must mv $MMP_DIR/vdev1 $PEER_DIR/vdev1
+log_must mv $MMP_DIR/vdev2 $PEER_DIR/vdev2
+log_must ln $PEER_DIR/vdev1 $MMP_DIR/vdev1
+
+log_must mmp_clear_hostid
+log_must mmp_set_hostid $HOSTID2
+log_must eval "ZFS_HOSTID=$HOSTID1 zhack -d $PEER_DIR action idle -t120 \
+    $MMP_POOL >$MMP_ZHACK_LOG 2>&1 &"
+
+#
+# Wait for the peer to hold the pool the same way mmp_pool_create_zhack does.
+# Grepping its log for the activity check line would work only by accident:
+# ZFS_HOSTID is parsed with strtoull(env, NULL, 0), so a leading zero makes it
+# octal, and the peer's hostid happens not to match the label.  Write the
+# hostid unambiguously and the check is skipped and the line never appears.
+#
+typeset -i tries=0
+while ! is_pool_imported $MMP_POOL "-d $PEER_DIR"; do
+	if (( tries++ > 30 )); then
+		log_fail "peer never imported the pool"
+	fi
+	log_must pgrep -x zhack
+	log_must sleep 4
+done
+
+log_mustnot zhack -d $MMP_DIR mmp reclaim $MMP_POOL
+log_must pgrep -x zhack
+log_must rm -f $MMP_ZHACK_LOG
+mmp_pool_destroy $MMP_POOL $MMP_DIR
+log_must rm -rf $PEER_DIR
+
+# 3. Every top level vdev is still counted after a recovery
+log_note "Verify both top level vdevs are counted after a recovery"
+log_must mkdir -p $MMP_DIR
+log_must rm -f $MMP_DIR/*
+log_must truncate -s $MINVDEVSIZE $MMP_DIR/vdev1 $MMP_DIR/vdev2 \
+    $MMP_DIR/vdev3 $MMP_DIR/vdev4
+log_must mmp_clear_hostid
+log_must mmp_set_hostid $HOSTID1
+log_must zpool create -f -o cachefile=$MMP_CACHE $MMP_POOL \
+    mirror $MMP_DIR/vdev1 $MMP_DIR/vdev2 mirror $MMP_DIR/vdev3 $MMP_DIR/vdev4
+log_must zpool set multihost=on $MMP_POOL
+crash_export_as_other_host
+log_must mv $MMP_DIR/vdev4 $HIDDEN_LEG
+
+log_mustnot zpool import -d $MMP_DIR -f $MMP_POOL
+log_must zhack -d $MMP_DIR mmp reclaim $MMP_POOL
+
+become_third_host
+nums=$(claim_reimport)
+if [[ "$nums" != "3 3" ]]; then
+	log_fail "claim across two top levels counted '$nums', expected '3 3'"
+fi
+log_note "claim across two top levels required 3 writes and got 3"
+mmp_pool_destroy $MMP_POOL $MMP_DIR
+log_must rm -f $HIDDEN_LEG
+
+# 4. A pool which does not use multihost is left alone
+log_note "Verify a pool without multihost is left alone"
+log_must mkdir -p $MMP_DIR
+log_must rm -f $MMP_DIR/*
+log_must truncate -s $MINVDEVSIZE $MMP_DIR/vdev1 $MMP_DIR/vdev2
+log_must mmp_clear_hostid
+log_must mmp_set_hostid $HOSTID1
+log_must zpool create -f -o cachefile=$MMP_CACHE $MMP_POOL \
+    mirror $MMP_DIR/vdev1 $MMP_DIR/vdev2
+log_must zpool export -F $MMP_POOL
+log_must mmp_clear_hostid
+log_must mmp_set_hostid $HOSTID2
+log_must mv $MMP_DIR/vdev2 $HIDDEN_LEG
+
+log_mustnot zhack -d $MMP_DIR mmp reclaim $MMP_POOL
+log_must zpool import -d $MMP_DIR -f $MMP_POOL
+log_must check_state $MMP_POOL "" "DEGRADED"
+if zpool status $MMP_POOL | grep -q OFFLINE; then
+	log_fail "a leg was offlined on a pool which does not use multihost"
+fi
+mmp_pool_destroy $MMP_POOL $MMP_DIR
+log_must rm -f $HIDDEN_LEG
+
+# 5. Legs of a log vdev are not touched
+log_note "Verify a log vdev leg is left alone"
+log_must mkdir -p $MMP_DIR
+log_must rm -f $MMP_DIR/*
+log_must truncate -s $MINVDEVSIZE $MMP_DIR/vdev1 $MMP_DIR/vdev2 \
+    $MMP_DIR/vdev3 $MMP_DIR/vdev4
+log_must mmp_clear_hostid
+log_must mmp_set_hostid $HOSTID1
+log_must zpool create -f -o cachefile=$MMP_CACHE $MMP_POOL \
+    mirror $MMP_DIR/vdev1 $MMP_DIR/vdev2 \
+    log mirror $MMP_DIR/vdev3 $MMP_DIR/vdev4
+log_must zpool set multihost=on $MMP_POOL
+crash_export_as_other_host
+log_must mv $MMP_DIR/vdev4 $HIDDEN_LEG
+
+log_must zhack -d $MMP_DIR mmp reclaim $MMP_POOL
+
+become_third_host
+nums=$(claim_reimport)
+if [[ "$nums" != "2 2" ]]; then
+	log_fail "pool with an absent log leg counted '$nums', expected '2 2'"
+fi
+log_note "pool with an absent log leg still imports, claim required 2 got 2"
+if zpool status $MMP_POOL | grep -q OFFLINE; then
+	log_fail "a log vdev leg was offlined"
+fi
+mmp_pool_destroy $MMP_POOL $MMP_DIR
+log_must rm -f $HIDDEN_LEG
+
+# 6. Members of a raidz vdev are not touched
+log_note "Verify a raidz member is left alone"
+log_must mkdir -p $MMP_DIR
+log_must rm -f $MMP_DIR/*
+log_must truncate -s $MINVDEVSIZE $MMP_DIR/vdev1 $MMP_DIR/vdev2 \
+    $MMP_DIR/vdev3 $MMP_DIR/vdev4
+log_must mmp_clear_hostid
+log_must mmp_set_hostid $HOSTID1
+log_must zpool create -f -o cachefile=$MMP_CACHE $MMP_POOL \
+    raidz2 $MMP_DIR/vdev1 $MMP_DIR/vdev2 $MMP_DIR/vdev3 $MMP_DIR/vdev4
+log_must zpool set multihost=on $MMP_POOL
+crash_export_as_other_host
+log_must mv $MMP_DIR/vdev4 $HIDDEN_LEG
+
+#
+# A raidz vdev is required as parity+1 in aggregate rather than one write per
+# member, so an absent member does not raise the requirement.  The claim holds
+# while parity+1 members remain writeable, and offlining one would be a
+# persistent change that buys nothing.
+#
+log_must eval "zhack -d $MMP_DIR mmp reclaim $MMP_POOL >$MMP_ZHACK_LOG 2>&1"
+log_must grep -q "no absent leaves" $MMP_ZHACK_LOG
+log_must rm -f $MMP_ZHACK_LOG
+
+become_third_host
+nums=$(claim_reimport)
+if [[ "$nums" != "3 3" ]]; then
+	log_fail "raidz2 with an absent member counted '$nums', expected '3 3'"
+fi
+log_note "raidz2 with an absent member imports, claim required 3 got 3"
+if zpool status $MMP_POOL | grep -q OFFLINE; then
+	log_fail "a raidz member was offlined"
+fi
+
+log_pass "zhack mmp reclaim recovers a stranded pool and relaxes no further"


### PR DESCRIPTION
Follow-up to #18855, which @behlendorf asked for when he merged it.

## The problem

#18855 made the MMP uberblock claim require a good write to every mirror leg
the pool config still expects to be present. That is what stops a host
claiming a pool under partial visibility, but it leaves one case with no way
out. When a host fails together with the mirror legs attached to it, the
surviving labels still describe those legs as healthy, so every later import
demands writes to legs that nobody can make. The claim can never be satisfied
and the pool cannot be imported again by any host.

@arturpzol hit this on a real two-node HA cluster while testing #18855. Each
mirror there is a local disk plus an iSCSI disk from the peer, so a dead node
takes its legs with it and the config still lists them present. His logs show
`req_writes=6 good_writes=3`, refused. That is the ordinary failover in that
topology, and the fix alone declines it.

## What this adds

`zhack mmp reclaim <pool>` imports the pool once with the claim's required
write count relaxed for the mirror legs this host cannot open, marks those
leaves offline so that the ordinary imports which follow succeed, and exports.

The pool comes back DEGRADED with those legs offline, and `zpool online`
returns each one when the hardware does.

## Design notes

**Offline instead of removed.** Offline persists unconditionally, is already
excluded from the claim by #18855, has `zpool online` as a first class
inverse, and does not overload hotplug semantics. `vdev_not_present`, which is
what a failed open actually sets, is not usable here: it is recomputed on
every import, so the pool would need zhack on every failover rather than once.

**No existing flag covers this.** On the stranded case (2-way mirror, one leg
gone with the peer) `-f`, `-f -o multihost=off`, `-f -o multihost=off -m` and
`-fFX -o multihost=off` all refuse with `req_writes=2 good_writes=1`. Setting
`multihost=off` at import does not help, because
`spa_activity_check_required()` decides from the on-disk uberblock, which
still has MMP active, before the property is applied.

**Why not `ZFS_IMPORT_SKIP_MMP`.** That disables the whole activity check, as
zdb uses it. Here the activity check has to be kept and only the write count
relaxed, so that a competing importer is still caught.

**The relaxation cannot exist in the kernel.** `mmp_claim_relaxed` is declared
under `#ifndef _KERNEL`, and `module/Kbuild.in` builds the module with
`-D_KERNEL`, so the symbol is compiled out of every kernel build. libzpool
does not define `_KERNEL`, so zhack gets it. This follows the
`zfeature_checks_disable` pattern zhack already uses around the same import,
and is stronger, since that flag does exist in the kernel.

**Only mirror legs are forgiven, and exactly those are offlined.** A raidz or
draid vdev is required as parity+1 in aggregate instead of one write per
member, so an absent member does not raise the requirement and is left alone.
The claim holds there while parity+1 members stay writeable; a narrower raidz
that has lost more than that is stranded and out of scope for this tool.

## What this does not do

The relaxed claim still catches a competing importer that shares any
visibility with us, which is the common operator error. It cannot catch a live
peer whose legs are all invisible from here, because the claim write and the
re-read only ever touch reachable legs. That is inherent to any write and read
scheme under disjoint visibility, and no change to this code can close it.

The fencing is therefore load-bearing. This is a manual recovery that assumes
the peer has been confirmed down, and the man page says so.

## Testing

New ZTS test `mmp/mmp_zhack_reclaim`, six scenarios:

1. a stranded pool is recovered and the claim then accepts it
2. a live host sharing one leg with us is still refused
3. both top level vdevs are counted after a recovery
4. a pool without `multihost` is left alone
5. a log vdev leg is not touched
6. a raidz2 member is not touched

Every recovery assertion re-imports as a third hostid on purpose. zhack
exports cleanly under its own hostid, so importing again as the same host
takes the exported-and-matching-hostid path in `spa_activity_check_required()`
and skips the activity check entirely, which would leave the claim
unexercised. The assertions read `req_writes` and `good_writes` from the
claim's own dbgmsg line, which 20176224e added. That is the only observable of
the arithmetic, at the cost of coupling the test to a debug message this
change does not control.

The test commit also fixes `mmp_pool_destroy()`, whose bare `pgrep zhack`
matched the new test's own comm (`mmp_zhack_recla`) and killed it.

Verified on a VM harness with the loaded module's srcversion asserted equal to
the tree's, so the results cannot come from a stale `zfs.ko`. Scenario 6 was
checked against a build with the mirror-only restriction removed, where it
fails as intended. The full mmp group passes, including `mmp_active_import`
and `mmp_concurrent_import`, which share the helper that changed.

**One path is not exercised.** When an absent leaf holds the only copy of some
data, `vdev_offline()` returns EBUSY, and the tool reports the leaf, leaves it
online, warns that a later import from another host will still be refused, and
exits non-zero. I could not stage that state reliably from userspace, so I am
flagging it as untested. The messages and the exit status are static, and the
man page documents the outcome.

## Documentation

@arturpzol asked in #18855 for the recovery flow to be written down.
`man/man1/zhack.1` documents the subcommand, the residual risk, the fencing
requirement, and the degraded aftermath.

Worth calling out separately for release notes: a pool that imported on 2.3.5
after this class of failure will refuse on 2.3.8, and the error text
(`cannot import 'tank': pool is imported on host '<unknown>' (hostid=0).`)
does not point anywhere useful when the truth is that the claim wanted more
writes than it got.
