### PR TITLE
dmu_send: a meta-dnode range does not start where an object does

### DIFF
--- a/module/zfs/dmu_send.c
+++ b/module/zfs/dmu_send.c
@@ -1248,6 +1248,17 @@ send_range_after(const struct send_range *from, const struct send_range *to)
 	cmp = TREE_CMP(to->type == OBJECT, from->type == OBJECT);
 	if (unlikely(cmp))
 		return (cmp);
+	/*
+	 * A meta-dnode range and an ordinary object's range express their
+	 * blkids in different units, dnode blocks against that object's data
+	 * blocks, so the blkid comparisons below cannot be applied to them.
+	 * Reaching here means their object ranges overlap; the meta-dnode
+	 * range sorts before the ranges of every object it covers, which is
+	 * the order send_range_start_compare() also establishes.
+	 */
+	cmp = TREE_CMP(to->object == 0, from->object == 0);
+	if (unlikely(cmp))
+		return (cmp);
 	if (from->end_blkid <= to->start_blkid)
 		return (-1);
 	if (from->start_blkid >= to->end_blkid)
@@ -1335,6 +1346,17 @@ send_range_start_compare(struct send_range *r1, struct send_range *r2)
 	if (unlikely(cmp))
 		return (cmp);
 	cmp = TREE_CMP(r2->type == OBJECT, r1->type == OBJECT);
+	if (unlikely(cmp))
+		return (cmp);
+	/*
+	 * A meta-dnode range covering dnode block b has the same objequiv as
+	 * the first block of object b * DNODES_PER_BLOCK, but the two do not
+	 * start at the same place: their blkids count different things.  The
+	 * merge in find_next_range() may only treat ranges as starting
+	 * together when they genuinely share an object and a block, so order
+	 * the meta-dnode range first rather than reporting them equal.
+	 */
+	cmp = TREE_CMP(r2->object == 0, r1->object == 0);
 	if (unlikely(cmp))
 		return (cmp);
 
@@ -1433,6 +1455,7 @@ find_next_range(struct send_range **ranges, bqueue_t **qs, uint64_t *out_mask)
 	for (i = 0; i < NUM_THREADS; i++) {
 		if (i == idx || (bmask & (1 << i)) == 0)
 			continue;
+		ASSERT3U(ranges[i]->object, ==, ranges[idx]->object);
 		ASSERT3U(first_change, >, ranges[i]->start_blkid);
 		ranges[i]->start_blkid = first_change;
 		ASSERT3U(ranges[i]->start_blkid, <=, ranges[i]->end_blkid);

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -913,7 +913,7 @@ tags = ['functional', 'quota']
 tests = ['redacted_compressed', 'redacted_contents', 'redacted_deleted',
     'redacted_disabled_feature', 'redacted_embedded', 'redacted_holes',
     'redacted_incrementals', 'redacted_largeblocks', 'redacted_max_blkid',
-    'redacted_many_clones',
+    'redacted_many_clones', 'redacted_meta_dnode',
     'redacted_mixed_recsize', 'redacted_mounts', 'redacted_negative',
     'redacted_origin', 'redacted_panic', 'redacted_props', 'redacted_resume',
     'redacted_size', 'redacted_volume']

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -2000,6 +2000,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/redacted_send/redacted_largeblocks.ksh \
 	functional/redacted_send/redacted_max_blkid.ksh \
 	functional/redacted_send/redacted_many_clones.ksh \
+	functional/redacted_send/redacted_meta_dnode.ksh \
 	functional/redacted_send/redacted_mixed_recsize.ksh \
 	functional/redacted_send/redacted_mounts.ksh \
 	functional/redacted_send/redacted_negative.ksh \

--- a/tests/zfs-tests/tests/functional/redacted_send/redacted_meta_dnode.ksh
+++ b/tests/zfs-tests/tests/functional/redacted_send/redacted_meta_dnode.ksh
@@ -1,0 +1,154 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/redacted_send/redacted.kshlib
+
+#
+# DESCRIPTION:
+#	A redacted send must not confuse a meta-dnode range with the ranges of
+#	the objects it covers.  The two count blocks in different units, and
+#	the send merge used to treat them as starting at the same place.
+#
+# STRATEGY:
+#	A meta-dnode range covering dnode block b is positioned, for sorting,
+#	at object b * DNODES_PER_BLOCK.  That is the same position as the
+#	first block of that object, so a redaction entry for exactly that
+#	object ties with the meta-dnode range covering it.  Build that tie:
+#	free a whole aligned dnode block in the sending snapshot while a
+#	redaction list holds an entry for the first object in it.
+#
+#	1. An incremental send carrying the redaction list on --redact.
+#	2. An incremental send from the redaction bookmark itself, which is
+#	   the documented workflow and resolves the tie the other way round.
+#
+#	The construction is asserted rather than assumed: if no aligned dnode
+#	block can be filled and freed, the test fails instead of passing
+#	without having built the case it exists to cover.
+#
+
+verify_runnable "both"
+
+# Slots per dnode block.  The search below wants an aligned run of this many
+# consecutive object numbers, which holds only while a dnode occupies a single
+# slot, so the sending dataset is created with dnodesize=legacy rather than
+# inheriting a larger one from the pool.
+typeset -ri DNODES_PER_BLOCK=32
+typeset -ri NFILES=800
+
+typeset sendfs="$POOL/$FS"
+typeset clone="$POOL/${FS}_clone"
+typeset stream=$(mktemp -t meta_dnode.XXXX)
+typeset inodes=$(mktemp -t meta_dnode_inodes.XXXX)
+
+function cleanup
+{
+	redacted_cleanup $sendfs $clone
+	rm -f $stream $inodes
+}
+
+log_onexit cleanup
+
+log_assert "a meta-dnode hole and a redaction entry for the object it covers"
+
+log_must zfs create -o dnodesize=legacy $sendfs
+typeset mntpnt=$(get_prop mountpoint $sendfs)
+
+#
+# Enough small files that some aligned dnode block is filled entirely by
+# them.  Object numbers are allocated in chunks, so this is not guaranteed
+# for any particular block; the search below finds one that worked.
+#
+typeset -i i=0
+while (( i < NFILES )); do
+	echo "$i" >$mntpnt/f$i
+	(( i = i + 1 ))
+done
+log_must sync_pool $POOL
+
+#
+# Find an aligned block whose every slot belongs to one of our files.  A
+# file's inode number is its object number.
+#
+log_must eval "ls -i $mntpnt >$inodes"
+typeset -i blk=$(awk -v n=$DNODES_PER_BLOCK '
+	{ seen[$1] = 1 }
+	END {
+		for (k = 1; k < 100000; k++) {
+			ok = 1
+			for (j = 0; j < n; j++)
+				if (!((k * n + j) in seen)) { ok = 0; break }
+			if (ok) { print k; exit }
+		}
+		print 0
+	}' $inodes)
+
+if (( blk == 0 )); then
+	log_fail "no aligned dnode block was filled by these files, so the " \
+	    "meta-dnode tie this test exists to build was never constructed"
+fi
+
+typeset -ri boundary_obj=$(( blk * DNODES_PER_BLOCK ))
+typeset -ri last_obj=$(( boundary_obj + DNODES_PER_BLOCK - 1 ))
+log_note "using dnode block $blk, objects $boundary_obj..$last_obj"
+
+typeset boundary_file=$(awk -v b=$boundary_obj '$1 == b { print $2 }' \
+    $inodes)
+typeset block_files=$(awk -v lo=$boundary_obj -v hi=$last_obj \
+    '$1 >= lo && $1 <= hi { print $2 }' $inodes)
+
+if [[ -z $boundary_file ]]; then
+	log_fail "no file owns object $boundary_obj"
+fi
+if (( $(echo "$block_files" | wc -l) != DNODES_PER_BLOCK )); then
+	log_fail "expected $DNODES_PER_BLOCK files in the block, found " \
+	    "$(echo "$block_files" | wc -l)"
+fi
+
+log_must zfs snapshot $sendfs@snap1
+
+#
+# The redaction list gets an entry for the boundary object, and only that
+# object, by deleting just that file in the clone.
+#
+log_must zfs clone $sendfs@snap1 $clone
+typeset clone_mnt=$(get_prop mountpoint $clone)
+log_must rm -f $clone_mnt/$boundary_file
+log_must zfs snapshot $clone@red
+log_must zfs redact $sendfs@snap1 book $clone@red
+
+log_must zfs snapshot $sendfs@snap2
+
+#
+# Free the whole dnode block after the incremental source, so the sending
+# snapshot has a meta-dnode hole covering exactly the objects the redaction
+# list refers to.
+#
+typeset f
+for f in $block_files; do
+	log_must rm -f $mntpnt/$f
+done
+log_must sync_pool $POOL
+log_must zfs snapshot $sendfs@snap3
+
+# 1. the redaction list arrives on the REDACT queue
+log_must eval "zfs send --redact book -i $sendfs@snap2 $sendfs@snap3 >$stream"
+log_must test -s $stream
+
+# 2. the redaction list arrives on the FROM queue instead, which orders the
+#    tie the other way and is the documented incremental workflow
+log_must eval "zfs send -i $sendfs#book $sendfs@snap3 >$stream"
+log_must test -s $stream
+
+log_pass "a meta-dnode hole and a redaction entry for the object it covers"


### PR DESCRIPTION
### Motivation and Context

Fixes #18365, reported by @h4ssi with a reproducer built from the commands they
had originally run.

`send_range_start_compare()` positions a meta-dnode range, whose blkids count
dnode blocks, at the object its first dnode block covers: `objequiv` becomes
`start_blkid * DNODES_PER_BLOCK` and `l0equiv` is forced to zero. That orders it
correctly against the objects it covers, but it also makes it compare *equal* to
the first block of the object at that exact boundary, since both sides then have
the same objequiv and an l0equiv of zero. The two do not start at the same
place — their blkids are not in the same units.

`find_next_range()` relies on that comparison meaning what it says. The loop
which computes `first_change` skips `DMU_META_DNODE_OBJECT`, so a meta-dnode
range never lowers it; the loop which then advances every range that starts
alongside the one being returned does not skip it, and applies an
object-relative blkid to a range counting dnode blocks.

The ordering has behaved this way since 30af21b025 (2019).

### Description

Two commits:

1. **dmu_send** — order a meta-dnode range before the block ranges of the objects
   it covers instead of reporting them equal, so ranges compare equal only when
   they genuinely share an object and a block. The `OBJECT`/`OBJECT_RANGE`
   tiebreaks above it are unchanged. The same distinction is applied in
   `send_range_after()`, plus an invariant assert in `find_next_range()`.
2. **ZTS** — a test that builds the collision deliberately rather than waiting
   for it, covering both orderings of the tie.

`send_range_after()` is reached only from an `ASSERT3S()` in
`get_next_range_nofree()`, so it and the new invariant assert take effect on
debug builds only. The production change is the `send_range_start_compare()`
ordering alone.

Guarding the update loop instead does not work: it leaves the tie broken by
queue index, which resolves one way when the redaction list is on the redact
queue and the other when it arrives from a bookmark on the from queue, and the
second ordering then fails the merged-record assertion in
`get_next_range_nofree()`.

### What this does on a production build

The assertion is compiled out there, but the assignment below it still runs, so
the range continues through the merge with a `start_blkid` it does not own.
Whether that changes the emitted stream depends on where the objects land, and
that varies between runs of the same script — which is consistent with the
reporter seeing the panic on turn 2 or 3 and no later than 9.

In one run of the reporter's scenario the streams differ. Same pool and
snapshots, same production build, only the module changing, with the send
repeated first to confirm its output is byte-reproducible:

```
with this change                          master
FREEOBJECTS firstobj = 37  numobjs = 123  FREEOBJECTS firstobj = 37 numobjs = 91
FREEOBJECTS firstobj = 160 numobjs = 96   FREEOBJECTS firstobj = 32 numobjs = 224
```

Object 32 is dnode block 1, the block the range was rewound to.

I have not been able to turn that into a demonstrated data-loss path, and would
rather say so than imply one:

- In that dataset nothing in objects 32..36 is live — its only objects are 2 and
  256 — so the extra coverage frees nothing that exists.
- Another run of the same script, where the object landed at 128 instead, gives
  byte-identical streams with and without the change.
- The larger layout the new test builds, which does provoke the collision (a
  debug build is KILLED there without the fix), also gives byte-identical
  streams.
- 60 runs of the reporter's script on a production build produced no crash, no
  hang and no unparseable stream, with or without the fix.

So what is established is that the ordering is wrong, that it fires the
assertion the issue is filed under, and that it can change the records a send
emits. A production data-loss path is not established.

I also make no claim about the NULL dereference @h4ssi saw on their server. That
backtrace is in `dnode_undirty_dbufs()` via `dnode_sync`/`sync_dnodes_task`, a
different path, and they said themselves they were not convinced it was related
to redaction.

### How Has This Been Tested?

On a QEMU VM, x86_64, against master at a51591820. Unless stated otherwise the
runs below are `--enable-debug` builds, which is where the assertion exists.

- Both flavours of the reproducer, 15/15 each: `send --redact` on an incremental,
  and an incremental from the redaction bookmark.
- `redacted_send` 22/22, `rsend` 81 PASS / 1 pre-existing SKIP.
- The new test is KILLED without the fix and passes with it, on a debug build.
  On a production build it passes either way: its check is that the send
  completes and emits a stream, and without the assertion there is nothing for
  it to catch in this layout. It asserts its own construction, so if no aligned
  dnode block can be filled and freed it fails rather than passing without
  having built the case.
- Production-build differential above, with a determinism control.
- Branch coverage, via temporary counters on the two new comparisons (removed
  again afterwards). Hits/calls for `send_range_after` and
  `send_range_start_compare` respectively:

  | workload | `send_range_after` | `send_range_start_compare` |
  | --- | --- | --- |
  | reproducer, `--redact` flavour | 22 / 166 | 22 / 61,977 |
  | reproducer, bookmark flavour | 18 / 318 | 36 / 103,936 |
  | `redacted_send` group | 3 / 423,638 | 4 / 535,680 |
  | `rsend` group | **0** / 748,245 | **0** / 4,278,031 |

  Neither branch ever changes an outcome across five million comparisons of
  ordinary send traffic, so the change acts only at the boundary.
- The test forces `dnodesize=legacy` on its dataset. Its search wants an aligned
  run of 32 consecutive object numbers, which only holds while a dnode occupies
  one slot; measured object-number spacing is 1 at `legacy` and 2/4/8 at
  `auto`/`2k`/`4k`, where the search would otherwise find nothing.
- `make checkstyle` clean; `commitcheck.sh` clean on both commits.

`zloop` was run but cannot exercise this change either way: ztest issues no
sends (`grep -cE 'dmu_send|dmu_recv|zfs_send' cmd/ztest.c` is 0), and the three
functions touched here are static to `dmu_send.c` with no caller outside it, so
they are unreachable from the ztest binary.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly. (no user-visible behaviour change)
- [x] I have read the [contributing document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
