### PR TITLE
dmu_objset_open_impl: unregister prop callbacks on error

### DIFF
--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -638,6 +638,7 @@ dmu_objset_open_impl(spa_t *spa, dsl_dataset_t *ds, blkptr_t *bp,
 			}
 		}
 		if (err != 0) {
+			dsl_prop_unregister_all(ds, os);
 			arc_buf_destroy(os->os_phys_buf, &os->os_phys_buf);
 			kmem_free(os, sizeof (objset_t));
 			return (err);


### PR DESCRIPTION
If dsl_prop_register() fails after some callbacks have already been registered, the current error path frees the objset without calling dsl_prop_unregister_all().

That leaves dangling callback records pointing at the freed objset. Later eviction or property-notify paths can then reach those records and dereference freed memory.

Call dsl_prop_unregister_all(ds, os) before destroying the objset so partially registered callbacks are removed on failure.

### Motivation and Context

This fixes an objset-open error path that can leave registered dataset property callbacks behind after the objset has already been freed.

`dmu_objset_open_impl()` registers several property callbacks onto the objset during open. If one of the later `dsl_prop_register()` calls fails, the current error path frees the `objset_t` immediately without unregistering any callbacks that were already registered.

That leaves dangling callback records associated with the freed objset, creating a use-after-free risk for later eviction or property-notify paths that walk those callback lists.

### Description

Add `dsl_prop_unregister_all(ds, os)` to the `err != 0` error path in `dmu_objset_open_impl()` before `arc_buf_destroy()` and `kmem_free()`.

This ensures that any callbacks registered before the failure are removed before the objset is destroyed.

### How Has This Been Tested?

Built OpenZFS from a clean source tree and loaded the resulting in-tree kernel modules on:

- Debian 13.6, kernel 6.12.101+deb13-amd64
- Ubuntu 24.04.4 LTS, kernel: 6.8.0-137-generic
- FreeBSD 15.1-RELEASE-p2, kernel: releng/15.1-n283596-aadd58dddcbc

All three systems loaded the build identified as `2.4.99-917_g65f083afc`.

Ran the following focused ZFS Test Suite smoke profile on all three systems:

- `tests/functional/cli_root/zpool_import/zpool_import_001_pos.ksh`
- `tests/functional/dedup/dedup_legacy_create.ksh`
- `tests/functional/features/large_dnode/large_dnode_001_pos.ksh`
- `tests/functional/vdev_zaps/vdev_zaps_001_pos.ksh`
- `tests/functional/log_spacemap/log_spacemap_import_logs.ksh`
- `tests/functional/raidz/raidz_002_pos.ksh`

Result: 6/6 selected tests passed on each system (18/18 total selected test runs).

Validation performed:
- rebased/cherry-picked cleanly onto current `upstream/master`
- verified patch scope is limited to `module/zfs/dmu_objset.c`
- verified the current `master` error path still frees the objset without calling `dsl_prop_unregister_all()`
- verified normal objset teardown still unregisters callbacks in `dmu_objset_evict()`

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [X] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [X] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
