### PR TITLE
zfs-mount-generator: don't unmount manually mounted encrypted datasets

### DIFF
--- a/etc/systemd/system-generators/zfs-mount-generator.c
+++ b/etc/systemd/system-generators/zfs-mount-generator.c
@@ -240,7 +240,7 @@ line_worker(char *line, const char *cachefile)
 	/* Minimal pre-requisites to mount a ZFS dataset */
 	const char *after = "zfs-import.target";
 	const char *wants = "zfs-import.target";
-	const char *bindsto = NULL;
+	const char *keyloadrequires = NULL;
 	char *wantedby = NULL;
 	char *requiredby = NULL;
 	bool noauto = false;
@@ -385,8 +385,18 @@ line_worker(char *line, const char *cachefile)
 			(void) fclose(keyloadunit_f);
 		}
 
-		/* Update dependencies for the mount file to want this */
-		bindsto = keyloadunit;
+		/*
+		 * Update dependencies for the mount file to require this.
+		 *
+		 * Requires=, not BindsTo=: with After= on the same unit,
+		 * BindsTo= only lets the mount stay active while the key-load
+		 * service is active, so a mount created by a manual
+		 * `zfs mount` after a manual `zfs load-key` (service never
+		 * started) is unmounted again right away.  Requires= still
+		 * fails the mount when the key-load service fails at boot,
+		 * and still unmounts when it is explicitly stopped.
+		 */
+		keyloadrequires = keyloadunit;
 		if (after[0] == '\0')
 			after = keyloadunit;
 		else if (asprintf(&toktmp, "%s %s", after, keyloadunit) != -1)
@@ -652,8 +662,8 @@ line_worker(char *line, const char *cachefile)
 
 	fprintf(mountfile_f, "Wants=%s\n", wants);
 
-	if (bindsto)
-		fprintf(mountfile_f, "BindsTo=%s\n", bindsto);
+	if (keyloadrequires)
+		fprintf(mountfile_f, "Requires=%s\n", keyloadrequires);
 	if (p_systemd_requires)
 		fprintf(mountfile_f, "Requires=%s\n", p_systemd_requires);
 	if (p_systemd_requiresmountsfor)

--- a/man/man8/zfs-mount-generator.8.in
+++ b/man/man8/zfs-mount-generator.8.in
@@ -23,7 +23,7 @@
 .\" OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 .\" WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 .\"
-.Dd November 30, 2021
+.Dd August 9, 2026
 .Dt ZFS-MOUNT-GENERATOR 8
 .Os
 .
@@ -62,7 +62,7 @@ Used to generate mount options equivalent to
 .Nm zfs Cm mount .
 .
 .It Sy encroot Ns = , Sy keylocation Ns =
-If the dataset is an encryption root, its mount unit will bind to
+If the dataset is an encryption root, its mount unit will require
 .Sy zfs-load-key@ Ns Ar root Ns Sy .service ,
 with additional dependencies as follows:
 .Bl -tag -compact -offset Ds -width "keylocation=https://URL (et al.)"


### PR DESCRIPTION
### Motivation and Context
With zfs-mount-generator enabled, mounting an encrypted dataset by
hand fails silently: `zfs load-key` + `zfs mount` return 0 and the
filesystem is gone a moment later. The generated .mount unit carries
BindsTo=zfs-load-key@<encroot>.service together with After= on the
same unit, and that combination makes systemd stop the mount whenever
the key-load service is not active — which it never is after a manual
`zfs load-key`. The journal shows the enforcement directly: "Unit is
bound to inactive unit... Stopping, too." People in the thread work
around it by masking the generated unit or starting the key-load
service instead of using zfs at all. Issue #12418.

### Description
Emit Requires= instead of BindsTo=. The two things BindsTo= was added
for in #10477 both survive: a key-load failure at boot still fails the
mount as a dependency (Requires= plus After=), and an explicit stop or
restart of the key-load service still propagates to the mount, so
stopping the service still unmounts before the key is unloaded. What
goes away is only the state invariant that treated an externally
created mount as a violation. The one dropped propagation — a
spontaneous transition to failed with no stop job — is unreachable for
a oneshot RemainAfterExit=yes unit with no lingering process.

### How Has This Been Tested?
systemd 259 VM, encrypted dataset with a file key and canmount=noauto
in zfs-list.cache. With the old unit the manual sequence reproduces
the report exactly (exit 0, unmounted within a second). With
Requires=: the manual mount stays; systemctl stop of the key-load unit
unmounts and unloads the key; starting the mount unit pulls the
key-load service in and mounts; with the key file missing the mount
fails as a dependency and nothing is mounted.

### Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs_core, libnvpair and libzfsbootenv)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).