### PR TITLE
zhack: add mosleak scan/reclaim for leaked MOS objects

### DIFF
--- a/cmd/zhack.c
+++ b/cmd/zhack.c
@@ -124,7 +124,12 @@ usage(void)
 	    "    mos scan <pool>\n"
 	    "        identify reclaimable leaked MOS objects\n"
 	    "    mos reclaim [-w] <pool>\n"
-	    "        reclaim safe leaked MOS objects; dry-run unless -w\n");
+	    "        reclaim safe leaked MOS objects; dry-run unless -w\n"
+	    "    mos leak [-w] [-c count] [-s count] <pool>\n"
+	    "        create leaked MOS objects for testing\n"
+	    "        -c <count> leaked DSL clone maps to create (default 1)\n"
+	    "        -s <count> leaked SPA space maps to create (default 1)\n"
+	    "        dry-run unless -w\n");
 	exit(1);
 }
 
@@ -1176,6 +1181,35 @@ zhack_leak_reclaim_sync(void *arg, dmu_tx_t *tx)
 	    (u_longlong_t)report->zlr_spacemaps.zv_len);
 }
 
+typedef struct zhack_mos_leak_arg {
+	uint64_t zli_clone_count;
+	uint64_t zli_spacemap_count;
+	uint64_t *zli_clone_objs;
+	uint64_t *zli_spacemap_objs;
+} zhack_mos_leak_arg_t;
+
+static void
+zhack_mos_leak_sync(void *arg, dmu_tx_t *tx)
+{
+	zhack_mos_leak_arg_t *inject = arg;
+	spa_t *spa = dmu_tx_pool(tx)->dp_spa;
+	objset_t *mos = spa->spa_meta_objset;
+
+	for (uint64_t i = 0; i < inject->zli_clone_count; i++) {
+		inject->zli_clone_objs[i] = zap_create(mos, DMU_OT_DSL_CLONES,
+		    DMU_OT_NONE, 0, tx);
+	}
+	for (uint64_t i = 0; i < inject->zli_spacemap_count; i++) {
+		inject->zli_spacemap_objs[i] = space_map_alloc(mos,
+		    SPA_MINBLOCKSIZE, tx);
+	}
+
+	spa_history_log_internal(spa, "zhack mos leak", tx,
+	    "clones=%llu spacemaps=%llu",
+	    (u_longlong_t)inject->zli_clone_count,
+	    (u_longlong_t)inject->zli_spacemap_count);
+}
+
 static int
 zhack_do_mos_scan(int argc, char **argv)
 {
@@ -1271,6 +1305,123 @@ zhack_do_mos_reclaim(int argc, char **argv)
 }
 
 static int
+zhack_do_mos_leak(int argc, char **argv)
+{
+	zhack_mos_leak_arg_t inject = {
+		.zli_clone_count = 1,
+		.zli_spacemap_count = 1,
+		.zli_clone_objs = NULL,
+		.zli_spacemap_objs = NULL
+	};
+	spa_t *spa;
+	char *target, *tmp;
+	int c;
+	boolean_t do_write = B_FALSE;
+
+	optind = 1;
+	while ((c = getopt(argc, argv, "+c:s:w")) != -1) {
+		switch (c) {
+		case 'c':
+			if (optarg[0] == '-') {
+				(void) fprintf(stderr, "error: invalid clone "
+				    "count: %s\n", optarg);
+				usage();
+			}
+			inject.zli_clone_count = strtoull(optarg, &tmp, 0);
+			if (*tmp != '\0') {
+				(void) fprintf(stderr, "error: invalid clone "
+				    "count: %s\n", optarg);
+				usage();
+			}
+			break;
+		case 's':
+			if (optarg[0] == '-') {
+				(void) fprintf(stderr, "error: invalid space "
+				    "map count: %s\n", optarg);
+				usage();
+			}
+			inject.zli_spacemap_count = strtoull(optarg, &tmp, 0);
+			if (*tmp != '\0') {
+				(void) fprintf(stderr, "error: invalid space "
+				    "map count: %s\n", optarg);
+				usage();
+			}
+			break;
+		case 'w':
+			do_write = B_TRUE;
+			break;
+		default:
+			usage();
+			break;
+		}
+	}
+	argc -= optind;
+	argv += optind;
+
+	if (argc < 1) {
+		(void) fprintf(stderr, "error: missing pool name\n");
+		usage();
+	}
+	target = argv[0];
+
+	if (inject.zli_clone_count == 0 && inject.zli_spacemap_count == 0) {
+		(void) printf("nothing requested to leak\n");
+		return (0);
+	}
+
+	if (!do_write) {
+		zhack_spa_open(target, B_TRUE, FTAG, &spa);
+		spa_close(spa, FTAG);
+		(void) printf("dry run: would create %llu leaked DSL clone "
+		    "map(s) and %llu leaked SPA space map(s)\n",
+		    (u_longlong_t)inject.zli_clone_count,
+		    (u_longlong_t)inject.zli_spacemap_count);
+		(void) printf("(re-run with -w to apply)\n");
+		return (0);
+	}
+
+	zhack_spa_open(target, B_FALSE, FTAG, &spa);
+
+	if (inject.zli_clone_count != 0) {
+		inject.zli_clone_objs = calloc(inject.zli_clone_count,
+		    sizeof (*inject.zli_clone_objs));
+		if (inject.zli_clone_objs == NULL)
+			fatal(spa, FTAG, "out of memory");
+	}
+	if (inject.zli_spacemap_count != 0) {
+		inject.zli_spacemap_objs = calloc(inject.zli_spacemap_count,
+		    sizeof (*inject.zli_spacemap_objs));
+		if (inject.zli_spacemap_objs == NULL)
+			fatal(spa, FTAG, "out of memory");
+	}
+
+	VERIFY0(dsl_sync_task(spa_name(spa), NULL, zhack_mos_leak_sync,
+	    &inject, 5, ZFS_SPACE_CHECK_NORMAL));
+
+	for (uint64_t i = 0; i < inject.zli_clone_count; i++) {
+		(void) printf("leaked: object %" PRIu64
+		    " type=DSL dir clones entries=0\n",
+		    inject.zli_clone_objs[i]);
+	}
+	for (uint64_t i = 0; i < inject.zli_spacemap_count; i++) {
+		(void) printf("leaked: object %" PRIu64
+		    " type=SPA space map smp_alloc=0x0 smp_length=0x0\n",
+		    inject.zli_spacemap_objs[i]);
+	}
+	(void) printf("leaked summary: clones=%llu spacemaps=%llu "
+	    "total=%llu\n",
+	    (u_longlong_t)inject.zli_clone_count,
+	    (u_longlong_t)inject.zli_spacemap_count,
+	    (u_longlong_t)(inject.zli_clone_count +
+	    inject.zli_spacemap_count));
+
+	free(inject.zli_clone_objs);
+	free(inject.zli_spacemap_objs);
+	spa_close(spa, FTAG);
+	return (0);
+}
+
+static int
 zhack_do_mos(int argc, char **argv)
 {
 	char *subcommand;
@@ -1288,6 +1439,8 @@ zhack_do_mos(int argc, char **argv)
 		return (zhack_do_mos_scan(argc, argv));
 	} else if (strcmp(subcommand, "reclaim") == 0) {
 		return (zhack_do_mos_reclaim(argc, argv));
+	} else if (strcmp(subcommand, "leak") == 0) {
+		return (zhack_do_mos_leak(argc, argv));
 	} else {
 		(void) fprintf(stderr, "error: unknown subcommand: %s\n",
 		    subcommand);

--- a/cmd/zhack.c
+++ b/cmd/zhack.c
@@ -44,6 +44,8 @@
 #include <sys/zfeature.h>
 #include <sys/dmu_tx.h>
 #include <sys/backtrace.h>
+#include <sys/dsl_dir.h>
+#include <sys/space_map.h>
 #include <zfeature_common.h>
 #include <libzutil.h>
 #include <sys/metaslab_impl.h>
@@ -53,6 +55,13 @@ static importargs_t g_importargs;
 static char *g_pool;
 static boolean_t g_readonly;
 static boolean_t g_dump_dbgmsg;
+
+/*
+ * In readonly imports, metaslab space maps are not opened unless this is set.
+ * We temporarily enable it for leak scan/dry-run so referenced space maps are
+ * accounted for accurately.
+ */
+extern boolean_t spa_mode_readable_spacemaps;
 
 typedef enum {
 	ZHACK_REPAIR_OP_UNKNOWN  = 0,
@@ -110,7 +119,12 @@ usage(void)
 	    "        live host whose legs are all invisible from here\n"
 	    "\n"
 	    "    metaslab leak <pool>\n"
-	    "        apply allocation map from zdb to specified pool\n");
+	    "        apply allocation map from zdb to specified pool\n"
+	    "\n"
+	    "    mos scan <pool>\n"
+	    "        identify reclaimable leaked MOS objects\n"
+	    "    mos reclaim [-w] <pool>\n"
+	    "        reclaim safe leaked MOS objects; dry-run unless -w\n");
 	exit(1);
 }
 
@@ -797,6 +811,490 @@ static boolean_t
 strstarts(const char *a, const char *b)
 {
 	return (strncmp(a, b, strlen(b)) == 0);
+}
+
+typedef struct zhack_objvec {
+	uint64_t *zv_objs;
+	size_t zv_len;
+	size_t zv_cap;
+} zhack_objvec_t;
+
+typedef struct zhack_leak_report {
+	zhack_objvec_t zlr_clones;
+	zhack_objvec_t zlr_spacemaps;
+	uint64_t zlr_unref_clones;
+	uint64_t zlr_unref_nonempty_clones;
+	uint64_t zlr_unref_spacemaps;
+	uint64_t zlr_unref_nonempty_spacemaps;
+} zhack_leak_report_t;
+
+static void
+zhack_objvec_add(zhack_objvec_t *vec, uint64_t obj)
+{
+	if (vec->zv_len == vec->zv_cap) {
+		size_t new_cap = vec->zv_cap == 0 ? 16 : vec->zv_cap * 2;
+		uint64_t *new_objs = realloc(vec->zv_objs,
+		    new_cap * sizeof (*new_objs));
+		if (new_objs == NULL)
+			fatal(NULL, FTAG, "out of memory");
+		vec->zv_objs = new_objs;
+		vec->zv_cap = new_cap;
+	}
+	vec->zv_objs[vec->zv_len++] = obj;
+}
+
+static void
+zhack_objvec_fini(zhack_objvec_t *vec)
+{
+	free(vec->zv_objs);
+	vec->zv_objs = NULL;
+	vec->zv_len = 0;
+	vec->zv_cap = 0;
+}
+
+static void
+zhack_leak_report_fini(zhack_leak_report_t *report)
+{
+	zhack_objvec_fini(&report->zlr_clones);
+	zhack_objvec_fini(&report->zlr_spacemaps);
+}
+
+static void
+zhack_mos_refd_once(zfs_range_tree_t *refd_objs, uint64_t object)
+{
+	if (object == 0 || zfs_range_tree_contains(refd_objs, object, 1))
+		return;
+
+	zfs_range_tree_add(refd_objs, object, 1);
+}
+
+static void
+zhack_collect_dd_clones_refs(objset_t *mos, zfs_range_tree_t *clones_refd_objs)
+{
+	uint64_t object = 0;
+
+	while (dmu_object_next(mos, &object, B_FALSE, 0) == 0) {
+		dmu_object_info_t doi;
+		dmu_buf_t *db = NULL;
+		int error;
+
+		error = dmu_object_info(mos, object, &doi);
+		if (error != 0 || doi.doi_bonus_type != DMU_OT_DSL_DIR)
+			continue;
+
+		error = dmu_bonus_hold(mos, object, FTAG, &db);
+		if (error != 0) {
+			(void) fprintf(stderr, "warning: object %" PRIu64
+			    " bonus hold failed: %s\n", object,
+			    strerror(error));
+			continue;
+		}
+
+		if (db->db_size >= offsetof(dsl_dir_phys_t, dd_clones) +
+		    sizeof (((dsl_dir_phys_t *)0)->dd_clones)) {
+			dsl_dir_phys_t *dd = db->db_data;
+			zhack_mos_refd_once(clones_refd_objs, dd->dd_clones);
+		}
+		dmu_buf_rele(db, FTAG);
+	}
+}
+
+static void
+zhack_collect_dtl_sm_refs(vdev_t *vd, zfs_range_tree_t *spacemap_refd_objs)
+{
+	if (vd->vdev_ops->vdev_op_leaf) {
+		space_map_t *sm = vd->vdev_dtl_sm;
+
+		if (sm != NULL &&
+		    sm->sm_dbuf->db_size == sizeof (space_map_phys_t))
+			zhack_mos_refd_once(spacemap_refd_objs,
+			    space_map_object(sm));
+		return;
+	}
+
+	for (uint64_t c = 0; c < vd->vdev_children; c++) {
+		zhack_collect_dtl_sm_refs(vd->vdev_child[c],
+		    spacemap_refd_objs);
+	}
+}
+
+static void
+zhack_collect_metaslab_sm_refs(vdev_t *vd, zfs_range_tree_t *spacemap_refd_objs)
+{
+	if (vd->vdev_top == vd) {
+		for (uint64_t m = 0; m < vd->vdev_ms_count; m++) {
+			space_map_t *sm = vd->vdev_ms[m]->ms_sm;
+
+			if (sm != NULL &&
+			    sm->sm_dbuf->db_size == sizeof (space_map_phys_t))
+				zhack_mos_refd_once(spacemap_refd_objs,
+				    space_map_object(sm));
+		}
+	}
+
+	for (uint64_t c = 0; c < vd->vdev_children; c++) {
+		zhack_collect_metaslab_sm_refs(vd->vdev_child[c],
+		    spacemap_refd_objs);
+	}
+}
+
+static void
+zhack_collect_obsolete_sm_refs(vdev_t *vd, zfs_range_tree_t *spacemap_refd_objs)
+{
+	uint64_t obsolete_sm_object;
+
+	VERIFY0(vdev_obsolete_sm_object(vd, &obsolete_sm_object));
+	if (vd->vdev_top == vd && obsolete_sm_object != 0) {
+		dmu_object_info_t doi;
+
+		if (dmu_object_info(vd->vdev_spa->spa_meta_objset,
+		    obsolete_sm_object, &doi) == 0 &&
+		    doi.doi_bonus_size == sizeof (space_map_phys_t)) {
+			zhack_mos_refd_once(spacemap_refd_objs,
+			    obsolete_sm_object);
+		}
+	}
+
+	for (uint64_t c = 0; c < vd->vdev_children; c++) {
+		zhack_collect_obsolete_sm_refs(vd->vdev_child[c],
+		    spacemap_refd_objs);
+	}
+}
+
+static void
+zhack_collect_prev_obsolete_sm_refs(spa_t *spa,
+    zfs_range_tree_t *spacemap_refd_objs)
+{
+	uint64_t prev_obj =
+	    spa->spa_condensing_indirect_phys.scip_prev_obsolete_sm_object;
+
+	if (prev_obj != 0) {
+		dmu_object_info_t doi;
+
+		if (dmu_object_info(spa->spa_meta_objset, prev_obj,
+		    &doi) == 0 &&
+		    doi.doi_bonus_size == sizeof (space_map_phys_t)) {
+			zhack_mos_refd_once(spacemap_refd_objs, prev_obj);
+		}
+	}
+}
+
+static void
+zhack_collect_checkpoint_sm_refs(vdev_t *vd,
+    zfs_range_tree_t *spacemap_refd_objs)
+{
+	if (vd->vdev_top == vd && vd->vdev_top_zap != 0) {
+		uint64_t checkpoint_sm_obj;
+		int error = zap_lookup(spa_meta_objset(vd->vdev_spa),
+		    vd->vdev_top_zap, VDEV_TOP_ZAP_POOL_CHECKPOINT_SM,
+		    sizeof (checkpoint_sm_obj), 1, &checkpoint_sm_obj);
+		if (error == 0)
+			zhack_mos_refd_once(spacemap_refd_objs,
+			    checkpoint_sm_obj);
+	}
+
+	for (uint64_t c = 0; c < vd->vdev_children; c++) {
+		zhack_collect_checkpoint_sm_refs(vd->vdev_child[c],
+		    spacemap_refd_objs);
+	}
+}
+
+static void
+zhack_collect_log_sm_refs(spa_t *spa, zfs_range_tree_t *spacemap_refd_objs)
+{
+	for (spa_log_sm_t *sls = avl_first(&spa->spa_sm_logs_by_txg);
+	    sls != NULL;
+	    sls = AVL_NEXT(&spa->spa_sm_logs_by_txg, sls)) {
+		zhack_mos_refd_once(spacemap_refd_objs, sls->sls_sm_obj);
+	}
+}
+
+static void
+zhack_collect_spacemap_refs(spa_t *spa, zfs_range_tree_t *spacemap_refd_objs)
+{
+	zhack_collect_dtl_sm_refs(spa->spa_root_vdev, spacemap_refd_objs);
+	zhack_collect_metaslab_sm_refs(spa->spa_root_vdev, spacemap_refd_objs);
+	zhack_collect_obsolete_sm_refs(spa->spa_root_vdev, spacemap_refd_objs);
+	zhack_collect_prev_obsolete_sm_refs(spa, spacemap_refd_objs);
+	zhack_collect_checkpoint_sm_refs(spa->spa_root_vdev,
+	    spacemap_refd_objs);
+	zhack_collect_log_sm_refs(spa, spacemap_refd_objs);
+}
+
+static void
+zhack_collect_mos_leak_report(spa_t *spa, zhack_leak_report_t *report,
+    boolean_t print_details)
+{
+	objset_t *mos = spa->spa_meta_objset;
+	zfs_range_tree_t *clones_refd_objs = zfs_range_tree_create_flags(
+	    NULL, ZFS_RANGE_SEG64, NULL, 0, 0, 0,
+	    "zhack_collect_mos_leak_report:clones_refd_objs");
+	zfs_range_tree_t *spacemap_refd_objs = zfs_range_tree_create_flags(
+	    NULL, ZFS_RANGE_SEG64, NULL, 0, 0, 0,
+	    "zhack_collect_mos_leak_report:spacemap_refd_objs");
+	uint64_t object = 0;
+
+	spa_config_enter(spa, SCL_VDEV | SCL_ALLOC, FTAG, RW_READER);
+	zhack_collect_spacemap_refs(spa, spacemap_refd_objs);
+	spa_config_exit(spa, SCL_VDEV | SCL_ALLOC, FTAG);
+
+	zhack_collect_dd_clones_refs(mos, clones_refd_objs);
+
+	while (dmu_object_next(mos, &object, B_FALSE, 0) == 0) {
+		dmu_object_info_t doi;
+		int error = dmu_object_info(mos, object, &doi);
+		if (error != 0)
+			continue;
+
+		if (doi.doi_type == DMU_OT_DSL_CLONES &&
+		    !zfs_range_tree_contains(clones_refd_objs, object, 1)) {
+			uint64_t entries = 0;
+
+			report->zlr_unref_clones++;
+			error = zap_count(mos, object, &entries);
+			if (error == 0 && entries == 0) {
+				zhack_objvec_add(&report->zlr_clones, object);
+				if (print_details) {
+					(void) printf("candidate: object %"
+					    PRIu64 " type=DSL dir clones "
+					    "entries=0\n", object);
+				}
+			} else {
+				report->zlr_unref_nonempty_clones++;
+				if (print_details) {
+					if (error != 0) {
+						(void) printf("skip: object %"
+						    PRIu64 " type=DSL dir "
+						    "clones (count failed: "
+						    "%s)\n", object,
+						    strerror(error));
+					} else {
+						(void) printf("skip: object %"
+						    PRIu64 " type=DSL dir "
+						    "clones entries=%" PRIu64
+						    "\n", object, entries);
+					}
+				}
+			}
+			continue;
+		}
+
+		if (doi.doi_type == DMU_OT_SPACE_MAP &&
+		    doi.doi_bonus_size == sizeof (space_map_phys_t) &&
+		    !zfs_range_tree_contains(spacemap_refd_objs, object, 1)) {
+			dmu_buf_t *db = NULL;
+			uint64_t smp_alloc = 0;
+			uint64_t smp_length = 0;
+
+			report->zlr_unref_spacemaps++;
+			error = dmu_bonus_hold(mos, object, FTAG, &db);
+			if (error == 0) {
+				space_map_phys_t *smp = db->db_data;
+				smp_alloc = smp->smp_alloc;
+				smp_length = smp->smp_length;
+				dmu_buf_rele(db, FTAG);
+			}
+
+			if (error == 0 && smp_alloc == 0 && smp_length == 0) {
+				zhack_objvec_add(&report->zlr_spacemaps,
+				    object);
+				if (print_details) {
+					(void) printf("candidate: object %"
+					    PRIu64 " type=SPA space map "
+					    "smp_alloc=0x%llx "
+					    "smp_length=0x%llx\n",
+					    object, (u_longlong_t)smp_alloc,
+					    (u_longlong_t)smp_length);
+				}
+			} else {
+				report->zlr_unref_nonempty_spacemaps++;
+				if (print_details) {
+					if (error != 0) {
+						(void) printf("skip: object "
+						    "%" PRIu64 " type=SPA "
+						    "space map (bonus hold "
+						    "failed: %s)\n", object,
+						    strerror(error));
+					} else {
+						(void) printf("skip: object "
+						    "%" PRIu64 " type=SPA "
+						    "space map "
+						    "smp_alloc=0x%llx "
+						    "smp_length=0x%llx\n",
+						    object,
+						    (u_longlong_t)smp_alloc,
+						    (u_longlong_t)smp_length);
+					}
+				}
+			}
+		}
+	}
+
+	zfs_range_tree_vacate(clones_refd_objs, NULL, NULL);
+	zfs_range_tree_destroy(clones_refd_objs);
+	zfs_range_tree_vacate(spacemap_refd_objs, NULL, NULL);
+	zfs_range_tree_destroy(spacemap_refd_objs);
+}
+
+static void
+zhack_print_mos_leak_summary(const zhack_leak_report_t *report)
+{
+	(void) printf("summary:\n");
+	(void) printf("\tunreferenced DSL dir clones: %" PRIu64
+	    " (reclaimable=%llu skipped=%" PRIu64 ")\n",
+	    report->zlr_unref_clones,
+	    (u_longlong_t)report->zlr_clones.zv_len,
+	    report->zlr_unref_nonempty_clones);
+	(void) printf("\tunreferenced SPA space maps: %" PRIu64
+	    " (reclaimable=%llu skipped=%" PRIu64 ")\n",
+	    report->zlr_unref_spacemaps,
+	    (u_longlong_t)report->zlr_spacemaps.zv_len,
+	    report->zlr_unref_nonempty_spacemaps);
+	(void) printf("\ttotal reclaimable objects: %llu\n",
+	    (u_longlong_t)(report->zlr_clones.zv_len +
+	    report->zlr_spacemaps.zv_len));
+}
+
+static void
+zhack_leak_reclaim_sync(void *arg, dmu_tx_t *tx)
+{
+	zhack_leak_report_t *report = arg;
+	spa_t *spa = dmu_tx_pool(tx)->dp_spa;
+	objset_t *mos = spa->spa_meta_objset;
+
+	for (size_t i = 0; i < report->zlr_clones.zv_len; i++) {
+		VERIFY0(zap_destroy(mos, report->zlr_clones.zv_objs[i], tx));
+	}
+
+	for (size_t i = 0; i < report->zlr_spacemaps.zv_len; i++) {
+		space_map_free_obj(mos, report->zlr_spacemaps.zv_objs[i], tx);
+	}
+
+	spa_history_log_internal(spa, "zhack mos reclaim", tx,
+	    "clones=%llu spacemaps=%llu",
+	    (u_longlong_t)report->zlr_clones.zv_len,
+	    (u_longlong_t)report->zlr_spacemaps.zv_len);
+}
+
+static int
+zhack_do_mos_scan(int argc, char **argv)
+{
+	zhack_leak_report_t report = { 0 };
+	spa_t *spa;
+	char *target;
+	boolean_t readable_spacemaps_saved;
+
+	argc--;
+	argv++;
+	if (argc < 1) {
+		(void) fprintf(stderr, "error: missing pool name\n");
+		usage();
+	}
+	target = argv[0];
+
+	readable_spacemaps_saved = spa_mode_readable_spacemaps;
+	spa_mode_readable_spacemaps = B_TRUE;
+	zhack_spa_open(target, B_TRUE, FTAG, &spa);
+	spa_mode_readable_spacemaps = readable_spacemaps_saved;
+
+	zhack_collect_mos_leak_report(spa, &report, B_TRUE);
+	zhack_print_mos_leak_summary(&report);
+	zhack_leak_report_fini(&report);
+	spa_close(spa, FTAG);
+
+	return (0);
+}
+
+static int
+zhack_do_mos_reclaim(int argc, char **argv)
+{
+	zhack_leak_report_t report = { 0 };
+	spa_t *spa;
+	char *target;
+	int c;
+	boolean_t do_write = B_FALSE;
+	boolean_t readable_spacemaps_saved;
+
+	optind = 1;
+	while ((c = getopt(argc, argv, "+w")) != -1) {
+		switch (c) {
+		case 'w':
+			do_write = B_TRUE;
+			break;
+		default:
+			usage();
+			break;
+		}
+	}
+	argc -= optind;
+	argv += optind;
+
+	if (argc < 1) {
+		(void) fprintf(stderr, "error: missing pool name\n");
+		usage();
+	}
+	target = argv[0];
+
+	readable_spacemaps_saved = spa_mode_readable_spacemaps;
+	if (!do_write)
+		spa_mode_readable_spacemaps = B_TRUE;
+	zhack_spa_open(target, !do_write, FTAG, &spa);
+	spa_mode_readable_spacemaps = readable_spacemaps_saved;
+
+	zhack_collect_mos_leak_report(spa, &report, B_TRUE);
+	zhack_print_mos_leak_summary(&report);
+
+	if (report.zlr_clones.zv_len == 0 && report.zlr_spacemaps.zv_len == 0) {
+		(void) printf("nothing to reclaim\n");
+		zhack_leak_report_fini(&report);
+		spa_close(spa, FTAG);
+		return (0);
+	}
+
+	if (!do_write) {
+		(void) printf("dry run: no changes made "
+		    "(re-run with -w to reclaim)\n");
+		zhack_leak_report_fini(&report);
+		spa_close(spa, FTAG);
+		return (0);
+	}
+
+	VERIFY0(dsl_sync_task(spa_name(spa), NULL, zhack_leak_reclaim_sync,
+	    &report, 5, ZFS_SPACE_CHECK_NORMAL));
+	(void) printf("reclaimed %llu leaked MOS objects\n",
+	    (u_longlong_t)(report.zlr_clones.zv_len +
+	    report.zlr_spacemaps.zv_len));
+	zhack_leak_report_fini(&report);
+	spa_close(spa, FTAG);
+
+	return (0);
+}
+
+static int
+zhack_do_mos(int argc, char **argv)
+{
+	char *subcommand;
+
+	argc--;
+	argv++;
+	if (argc == 0) {
+		(void) fprintf(stderr,
+		    "error: no mos operation specified\n");
+		usage();
+	}
+
+	subcommand = argv[0];
+	if (strcmp(subcommand, "scan") == 0) {
+		return (zhack_do_mos_scan(argc, argv));
+	} else if (strcmp(subcommand, "reclaim") == 0) {
+		return (zhack_do_mos_reclaim(argc, argv));
+	} else {
+		(void) fprintf(stderr, "error: unknown subcommand: %s\n",
+		    subcommand);
+		usage();
+	}
+
+	return (0);
 }
 
 static void
@@ -1540,6 +2038,8 @@ main(int argc, char **argv)
 		rv = zhack_do_feature(argc, argv);
 	} else if (strcmp(subcommand, "mmp") == 0) {
 		rv = zhack_do_mmp(argc, argv);
+	} else if (strcmp(subcommand, "mos") == 0) {
+		rv = zhack_do_mos(argc, argv);
 	} else if (strcmp(subcommand, "label") == 0) {
 		return (zhack_do_label(argc, argv));
 	} else if (strcmp(subcommand, "metaslab") == 0) {

--- a/man/man1/zhack.1
+++ b/man/man1/zhack.1
@@ -13,7 +13,7 @@
 .\"
 .\" lint-ok: WARNING: sections out of conventional order: Sh SYNOPSIS
 .\"
-.Dd August 3, 2026
+.Dd August 9, 2026
 .Dt ZHACK 1
 .Os
 .
@@ -170,6 +170,37 @@ The
 flag forces the profile to apply even if the vdevs in the
 .Ar pool
 don't have the same number of metaslabs as the fragmentation profile.
+.
+.It Xo
+.Nm zhack
+.Cm mos scan
+.Ar pool
+.Xc
+Scan the pool MOS for leaked objects and report reclaim candidates.
+An object is a candidate only if it is both unreferenced and empty:
+a DSL dir clones ZAP with zero entries that no DSL directory references,
+or a space map object with no allocations that no DTL, metaslab,
+obsolete, checkpoint, or log space map consumer references.
+Unreferenced but non-empty objects are reported and skipped.
+This subcommand is read-only and works on imported pools.
+.
+.It Xo
+.Nm zhack
+.Cm mos reclaim
+.Op Fl w
+.Ar pool
+.Xc
+Reclaim the leaked MOS objects that
+.Cm mos scan
+identifies as candidates.
+Without
+.Fl w
+this is a dry run and no changes are made.
+With
+.Fl w
+the candidate objects are freed in syncing context and the action is
+recorded in the pool history.
+The pool must be exported.
 .
 .El
 .

--- a/man/man1/zhack.1
+++ b/man/man1/zhack.1
@@ -202,6 +202,30 @@ the candidate objects are freed in syncing context and the action is
 recorded in the pool history.
 The pool must be exported.
 .
+.It Xo
+.Nm zhack
+.Cm mos leak
+.Op Fl w
+.Op Fl c Ar count
+.Op Fl s Ar count
+.Ar pool
+.Xc
+Create synthetic leaked MOS objects for testing
+.Cm mos scan
+and
+.Cm mos reclaim
+on disposable pools.
+The
+.Fl c
+and
+.Fl s
+flags set the number of leaked DSL clone maps and leaked space maps to
+inject, one of each by default.
+Without
+.Fl w
+this is a dry run and no changes are made.
+The pool must be exported.
+.
 .El
 .
 .Sh GLOBAL OPTIONS

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -392,7 +392,8 @@ tags = ['functional', 'cli_root', 'zfs_wait']
 
 [tests/functional/cli_root/zhack]
 tests = ['zhack_label_repair_001', 'zhack_label_repair_002',
-    'zhack_label_repair_003', 'zhack_label_repair_004', 'zhack_metaslab_leak']
+    'zhack_label_repair_003', 'zhack_label_repair_004', 'zhack_metaslab_leak',
+    'zhack_mos_scan_reclaim']
 pre =
 post =
 tags = ['functional', 'cli_root', 'zhack']

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1083,6 +1083,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zhack/zhack_label_repair_002.ksh \
 	functional/cli_root/zhack/zhack_label_repair_003.ksh \
 	functional/cli_root/zhack/zhack_label_repair_004.ksh \
+	functional/cli_root/zhack/zhack_mos_scan_reclaim.ksh \
 	functional/cli_root/zhack/zhack_metaslab_leak.ksh \
 	functional/cli_root/zpool_add/add_nested_replacing_spare.ksh \
 	functional/cli_root/zpool_add/add-o_ashift.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zhack/zhack_mos_scan_reclaim.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zhack/zhack_mos_scan_reclaim.ksh
@@ -1,0 +1,197 @@
+#!/bin/ksh
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
+#
+
+#
+# Description:
+#
+# Verify zhack mos leak and mos reclaim behavior.
+#
+# Strategy:
+#
+# 1. Create a test pool and confirm leak scan baseline is empty.
+# 2. Verify leak inject dry-run does not modify leak scan counts.
+# 3. Inject a known number of leaked clone maps and space maps.
+# 4. Verify scan reports exactly the injected reclaimable objects.
+# 5. Verify leak reclaim dry-run does not modify scan counts.
+# 6. Reclaim leaked objects and verify scan baseline is restored.
+# 7. Verify reclaim is idempotent by running it again.
+#
+
+. "$STF_SUITE"/include/libtest.shlib
+
+verify_runnable "global"
+
+function cleanup
+{
+	poolexists "$TESTPOOL" && destroy_pool "$TESTPOOL"
+	[[ -n "$SCAN_BEFORE" ]] && rm -f "$SCAN_BEFORE"
+	[[ -n "$SCAN_DRY_INJECT" ]] && rm -f "$SCAN_DRY_INJECT"
+	[[ -n "$SCAN_AFTER_INJECT" ]] && rm -f "$SCAN_AFTER_INJECT"
+	[[ -n "$SCAN_DRY_RECLAIM" ]] && rm -f "$SCAN_DRY_RECLAIM"
+	[[ -n "$SCAN_FINAL" ]] && rm -f "$SCAN_FINAL"
+	[[ -n "$INJECT_DRY" ]] && rm -f "$INJECT_DRY"
+	[[ -n "$INJECT_WRITE" ]] && rm -f "$INJECT_WRITE"
+	[[ -n "$RECLAIM_DRY" ]] && rm -f "$RECLAIM_DRY"
+	[[ -n "$RECLAIM_WRITE" ]] && rm -f "$RECLAIM_WRITE"
+	[[ -n "$RECLAIM_WRITE_SECOND" ]] && rm -f "$RECLAIM_WRITE_SECOND"
+}
+
+function get_reclaimable_count
+{
+	typeset output_file="$1"
+	typeset category="$2"
+	typeset line=
+	typeset count=
+
+	line="$(grep -F "$category" "$output_file")"
+	[[ -n "$line" ]] || log_fail "missing summary line: $category"
+
+	count="${line#*reclaimable=}"
+	count="${count%% *}"
+	echo "$count"
+}
+
+function get_total_count
+{
+	typeset output_file="$1"
+	typeset line=
+
+	line="$(grep -F "total reclaimable objects:" "$output_file")"
+	[[ -n "$line" ]] || log_fail "missing total reclaimable summary"
+	echo "${line##*: }"
+}
+
+function assert_count_eq
+{
+	typeset expected="$1"
+	typeset actual="$2"
+	typeset message="$3"
+
+	[[ "$expected" == "$actual" ]] || log_fail \
+	    "$message: expected $expected, got $actual"
+}
+
+log_assert "zhack mos leak/reclaim should be observable and reversible"
+log_onexit cleanup
+
+typeset -r CLONE_INJECT=3
+typeset -r SPACEMAP_INJECT=2
+typeset -r TOTAL_INJECT=$((CLONE_INJECT + SPACEMAP_INJECT))
+
+typeset SCAN_BEFORE="$(mktemp)"
+typeset SCAN_DRY_INJECT="$(mktemp)"
+typeset SCAN_AFTER_INJECT="$(mktemp)"
+typeset SCAN_DRY_RECLAIM="$(mktemp)"
+typeset SCAN_FINAL="$(mktemp)"
+typeset INJECT_DRY="$(mktemp)"
+typeset INJECT_WRITE="$(mktemp)"
+typeset RECLAIM_DRY="$(mktemp)"
+typeset RECLAIM_WRITE="$(mktemp)"
+typeset RECLAIM_WRITE_SECOND="$(mktemp)"
+
+log_must zpool create "$TESTPOOL" $DISKS
+
+log_must eval "zhack mos scan $TESTPOOL > $SCAN_BEFORE"
+before_clones="$(get_reclaimable_count "$SCAN_BEFORE" \
+    "unreferenced DSL dir clones:")"
+before_spacemaps="$(get_reclaimable_count "$SCAN_BEFORE" \
+    "unreferenced SPA space maps:")"
+before_total="$(get_total_count "$SCAN_BEFORE")"
+
+assert_count_eq 0 "$before_clones" "baseline leaked clone count"
+assert_count_eq 0 "$before_spacemaps" "baseline leaked space map count"
+assert_count_eq 0 "$before_total" "baseline total leaked object count"
+
+log_must eval "zhack mos leak -c $CLONE_INJECT -s $SPACEMAP_INJECT \
+    $TESTPOOL > $INJECT_DRY"
+log_must grep -F \
+    "dry run: would create $CLONE_INJECT leaked DSL clone map(s) and $SPACEMAP_INJECT leaked SPA space map(s)" \
+    "$INJECT_DRY"
+
+log_must eval "zhack mos scan $TESTPOOL > $SCAN_DRY_INJECT"
+dry_clones="$(get_reclaimable_count "$SCAN_DRY_INJECT" \
+    "unreferenced DSL dir clones:")"
+dry_spacemaps="$(get_reclaimable_count "$SCAN_DRY_INJECT" \
+    "unreferenced SPA space maps:")"
+dry_total="$(get_total_count "$SCAN_DRY_INJECT")"
+
+assert_count_eq "$before_clones" "$dry_clones" \
+    "post-dry-run leaked clone count"
+assert_count_eq "$before_spacemaps" "$dry_spacemaps" \
+    "post-dry-run leaked space map count"
+assert_count_eq "$before_total" "$dry_total" \
+    "post-dry-run total leaked object count"
+
+log_must zpool export "$TESTPOOL"
+log_must eval "zhack mos leak -w -c $CLONE_INJECT -s $SPACEMAP_INJECT \
+    $TESTPOOL > $INJECT_WRITE"
+log_must zpool import "$TESTPOOL"
+log_must grep -F \
+    "leaked summary: clones=$CLONE_INJECT spacemaps=$SPACEMAP_INJECT total=$TOTAL_INJECT" \
+    "$INJECT_WRITE"
+
+log_must eval "zhack mos scan $TESTPOOL > $SCAN_AFTER_INJECT"
+after_clones="$(get_reclaimable_count "$SCAN_AFTER_INJECT" \
+    "unreferenced DSL dir clones:")"
+after_spacemaps="$(get_reclaimable_count "$SCAN_AFTER_INJECT" \
+    "unreferenced SPA space maps:")"
+after_total="$(get_total_count "$SCAN_AFTER_INJECT")"
+
+assert_count_eq "$CLONE_INJECT" "$after_clones" \
+    "post-inject leaked clone count"
+assert_count_eq "$SPACEMAP_INJECT" "$after_spacemaps" \
+    "post-inject leaked space map count"
+assert_count_eq "$TOTAL_INJECT" "$after_total" \
+    "post-inject total leaked object count"
+
+log_must eval "zhack mos reclaim $TESTPOOL > $RECLAIM_DRY"
+log_must grep -F "dry run: no changes made (re-run with -w to reclaim)" \
+    "$RECLAIM_DRY"
+
+log_must eval "zhack mos scan $TESTPOOL > $SCAN_DRY_RECLAIM"
+dry_reclaim_clones="$(get_reclaimable_count "$SCAN_DRY_RECLAIM" \
+    "unreferenced DSL dir clones:")"
+dry_reclaim_spacemaps="$(get_reclaimable_count "$SCAN_DRY_RECLAIM" \
+    "unreferenced SPA space maps:")"
+dry_reclaim_total="$(get_total_count "$SCAN_DRY_RECLAIM")"
+
+assert_count_eq "$after_clones" "$dry_reclaim_clones" \
+    "post-reclaim-dry-run leaked clone count"
+assert_count_eq "$after_spacemaps" "$dry_reclaim_spacemaps" \
+    "post-reclaim-dry-run leaked space map count"
+assert_count_eq "$after_total" "$dry_reclaim_total" \
+    "post-reclaim-dry-run total leaked object count"
+
+log_must zpool export "$TESTPOOL"
+log_must eval "zhack mos reclaim -w $TESTPOOL > $RECLAIM_WRITE"
+log_must zpool import "$TESTPOOL"
+log_must grep -F "reclaimed $TOTAL_INJECT leaked MOS objects" \
+    "$RECLAIM_WRITE"
+
+log_must zpool export "$TESTPOOL"
+log_must eval "zhack mos reclaim -w $TESTPOOL > $RECLAIM_WRITE_SECOND"
+log_must zpool import "$TESTPOOL"
+log_must grep -F "nothing to reclaim" "$RECLAIM_WRITE_SECOND"
+
+log_must eval "zhack mos scan $TESTPOOL > $SCAN_FINAL"
+final_clones="$(get_reclaimable_count "$SCAN_FINAL" \
+    "unreferenced DSL dir clones:")"
+final_spacemaps="$(get_reclaimable_count "$SCAN_FINAL" \
+    "unreferenced SPA space maps:")"
+final_total="$(get_total_count "$SCAN_FINAL")"
+
+assert_count_eq 0 "$final_clones" "post-reclaim leaked clone count"
+assert_count_eq 0 "$final_spacemaps" "post-reclaim leaked space map count"
+assert_count_eq 0 "$final_total" "post-reclaim total leaked object count"
+
+log_pass "zhack mos leak/reclaim behaved correctly"


### PR DESCRIPTION
Add `zhack mosleak scan|reclaim|inject` to identify and reclaim MOS objects leaked by old bugs on existing pools. The bugs that created these leaks were fixed years ago, but pools that ran the affected code carry the leaked objects forever; no cleanup tool has existed until now.

### Motivation and Context

OpenZFS 9847 (#7979, fixed in 0.8.0) stopped `dsl_dir_destroy_sync()` from leaking `dd_clones` ZAP objects, and #18808 is fixing the DTL space map leak from `zpool split` (#5599), but neither cleans up pools already damaged. A pool created in 2012 that ran pre-0.8.0 code for years still reports every one of those leaks in `zdb` today.

While the space involved is small, the leaked objects generate warnings in `zdb`, complicate leak detection for developers (real new leaks are buried in historical noise), and are simply garbage that can never be freed by normal operation.

### Description

- `zhack mosleak scan <pool>`: read-only; walks the MOS and reports reclaim candidates. An object is a candidate only if it is BOTH unreferenced AND provably empty:
  - `DMU_OT_DSL_CLONES` ZAPs not referenced by any DSL dir's `dd_clones`, with zero entries.
  - `DMU_OT_SPACE_MAP` objects not referenced by any DTL, metaslab, obsolete, prev-obsolete, checkpoint, or log spacemap consumer, with `smp_alloc == 0 && smp_length == 0`.
  Unreferenced but non-empty objects are reported and skipped.
- `zhack mosleak reclaim [-w] <pool>`: dry-run by default; with `-w`, frees the candidates in a `dsl_sync_task` using `zap_destroy()` and `space_map_free_obj()` (the same primitive #18808 uses for the split-time cleanup), and logs the action to pool history.
- `zhack mosleak inject [-w] [-c N] [-s N] <pool>`: creates synthetic leaked objects on disposable pools so scan/reclaim behavior is testable; prints injected object IDs.
- New ZTS test `zhack_mosleak_scan_reclaim` covering the full inject -> scan -> reclaim -> idempotent-reclaim flow, including dry-run invariance.

Known limitation: unreferenced space maps with non-zero contents (e.g. DTL space maps leaked by old `zpool split`) are reported but not reclaimed. They are unreferenced garbage and could be freed with `space_map_free_obj()` regardless of content, but this first version stays strictly conservative; an opt-in flag could follow.

### How Has This Been Tested?

Built from a clean tree; ZTS `-T zhack` group (label repair, metaslab leak, and the new mosleak test) passes 6/6 on:

- Debian 13.6, kernel 6.12.101+deb13-amd64
- Ubuntu 24.04.4, kernel 6.8.0-137-generic
- FreeBSD 15.1-RELEASE-p2

Ran `zhack mosleak scan` (read-only) against a production pool created in 2012 that ran pre-0.8.0 code for years and has since seen a vdev removal (pool has an indirect vdev). The scan correctly accounted all referenced space maps (including obsolete/indirect) and found the expected OpenZFS 9847-era damage:

```
candidate: object 288 type=DSL dir clones entries=0
candidate: object 463 type=SPA space map smp_alloc=0x0 smp_length=0x0
[...]
summary:
        unreferenced DSL dir clones: 174 (reclaimable=174 skipped=0)
        unreferenced SPA space maps: 4 (reclaimable=4 skipped=0)
        total reclaimable objects: 178
```

The leaked object IDs cluster in three dense bands matching distinct eras of clone create/destroy activity while the pre-fix code was in use. Two full `zdb -dd` runs taken several hours apart report a byte-identical leaked-object list: exactly the same 174 DSL dir clones ZAPs and 4 SPA space maps this scan identifies, and nothing else.

### Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [X] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist

- [X] My code follows the OpenZFS code style requirements.
- [X] I have updated the documentation accordingly.
- [X] I have read the contributing document.
- [X] I have added tests to cover my changes.
- [X] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain `Signed-off-by`.
