### PR TITLE
Keep the local key where a raw receive brings a foreign one

### DIFF
--- a/module/zfs/dsl_crypt.c
+++ b/module/zfs/dsl_crypt.c
@@ -2325,7 +2325,51 @@ dsl_crypto_recv_raw_key_sync(dsl_dataset_t *ds, nvlist_t *nvl, dmu_tx_t *tx)
 
 		rddobj = dd->dd_object;
 	} else {
+		dsl_dir_t *rdd;
+		boolean_t foreign = B_FALSE;
+
 		VERIFY0(dsl_dir_get_encryption_root_ddobj(dd, &rddobj));
+
+		/*
+		 * The key in the stream is wrapped by the wrapping key of the
+		 * sender's encryption root and is about to be filed under
+		 * ours. Where we are that root the two are the same thing, as
+		 * the parameters below are written along with the key. Where
+		 * we inherit instead, the root has to be using the wrapping
+		 * key the sender used, which is what the keyformat, salt and
+		 * iteration count describe; a root of our own making has a
+		 * salt of its own and would leave us with a key nothing on
+		 * this pool can unwrap. Such a dataset keeps working until
+		 * its key is unloaded and then never loads again, so keep the
+		 * copy we have instead: dsl_crypto_recv_raw_key_check() has
+		 * already confirmed that both protect the same master key.
+		 *
+		 * The key objects are compared rather than the dsl dirs
+		 * themselves because an incremental receive lands on the
+		 * hidden %recv clone, which has a dsl dir of its own but
+		 * shares the key object of the dataset it is swapped into.
+		 */
+		VERIFY0(dsl_dir_hold_obj(dp, rddobj, NULL, FTAG, &rdd));
+		if (rdd->dd_crypto_obj != dd->dd_crypto_obj) {
+			uint64_t rkeyformat, rsalt, riters;
+
+			VERIFY0(zap_lookup(mos, rdd->dd_crypto_obj,
+			    zfs_prop_to_name(ZFS_PROP_KEYFORMAT), 8, 1,
+			    &rkeyformat));
+			VERIFY0(zap_lookup(mos, rdd->dd_crypto_obj,
+			    zfs_prop_to_name(ZFS_PROP_PBKDF2_SALT), 8, 1,
+			    &rsalt));
+			VERIFY0(zap_lookup(mos, rdd->dd_crypto_obj,
+			    zfs_prop_to_name(ZFS_PROP_PBKDF2_ITERS), 8, 1,
+			    &riters));
+
+			foreign = (keyformat != rkeyformat || salt != rsalt ||
+			    iters != riters);
+		}
+		dsl_dir_rele(rdd, FTAG);
+
+		if (foreign)
+			return;
 	}
 
 	/* sync the key data to the ZAP object on disk */

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -1025,7 +1025,7 @@ tests = ['recv_dedup', 'recv_dedup_encrypted_zvol', 'rsend_001_pos',
     'send_large_blocks_incremental', 'send_large_blocks_initial',
     'send_large_microzap_incremental', 'send_large_microzap_transitive',
     'send_doall', 'send_raw_spill_block', 'send_raw_ashift',
-    'send_raw_large_blocks', 'send_leak_keymaps']
+    'send_raw_large_blocks', 'send_raw_inherited_key', 'send_leak_keymaps']
 tags = ['functional', 'rsend']
 
 [tests/functional/scrub_mirror]

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -2184,6 +2184,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/rsend/send_mixed_raw.ksh \
 	functional/rsend/send_partial_dataset.ksh \
 	functional/rsend/send_raw_ashift.ksh \
+	functional/rsend/send_raw_inherited_key.ksh \
 	functional/rsend/send_raw_spill_block.ksh \
 	functional/rsend/send_raw_large_blocks.ksh \
 	functional/rsend/send_realloc_dnode_mixed.ksh \

--- a/tests/zfs-tests/tests/functional/rsend/send_raw_inherited_key.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send_raw_inherited_key.ksh
@@ -1,0 +1,126 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2026 by Andrew Mochalskyi. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/rsend/rsend.kshlib
+. $STF_SUITE/tests/functional/cli_root/zfs_load-key/zfs_load-key_common.kshlib
+
+#
+# DESCRIPTION:
+# A raw incremental receive leaves the key of a filesystem alone where the
+# encryption root it inherits from holds a wrapping key of its own
+# (issue #12614), and hands the sending side's key over where it does not.
+#
+# STRATEGY:
+# 1. Raw send an encrypted filesystem to a pool whose encryption root uses
+#    a different passphrase and inherit the key there with 'change-key -i'
+# 2. Raw send an incremental snapshot on top of it
+# 3. Unload the keys and load them again from the receiving encryption root
+# 4. Verify the received filesystem still mounts and holds both files
+# 5. Verify a filesystem received as an encryption root of its own does
+#    still follow a key change made on the sending side
+# 6. Verify a filesystem which inherits from a received encryption root
+#    follows that key change as well
+#
+
+verify_runnable "both"
+
+function cleanup
+{
+	log_must cleanup_pool $POOL
+	log_must cleanup_pool $POOL2
+	log_must cleanup_pool $POOL3
+	log_must setup_test_model $POOL
+}
+
+log_assert "Raw incremental receives do not overwrite an inherited key"
+log_onexit cleanup
+
+log_must cleanup_pool $POOL
+log_must cleanup_pool $POOL2
+log_must cleanup_pool $POOL3
+
+log_must eval "echo $PASSPHRASE1 | zfs create -o encryption=on" \
+	"-o keyformat=passphrase $POOL/send"
+log_must zfs create $POOL/send/fs
+log_must eval "echo $PASSPHRASE2 | zfs create -o encryption=on" \
+	"-o keyformat=passphrase $POOL2/recv"
+
+log_must dd if=/dev/urandom of=/$POOL/send/fs/file1 bs=1M count=1
+log_must zfs snapshot -r $POOL/send@snap1
+
+log_must eval "zfs send -w $POOL/send/fs@snap1 | zfs receive $POOL2/recv/fs"
+
+# The filesystem arrives as an encryption root of its own, holding the key
+# of the sending side. Hand it over to the receiving one.
+log_must verify_encryption_root $POOL2/recv/fs $POOL2/recv/fs
+log_must eval "echo $PASSPHRASE1 | zfs load-key $POOL2/recv/fs"
+log_must zfs change-key -i $POOL2/recv/fs
+log_must verify_encryption_root $POOL2/recv/fs $POOL2/recv
+
+log_must dd if=/dev/urandom of=/$POOL/send/fs/file2 bs=1M count=1
+log_must zfs snapshot $POOL/send/fs@snap2
+
+log_must eval "zfs send -w -i @snap1 $POOL/send/fs@snap2 |" \
+	"zfs receive $POOL2/recv/fs"
+log_must verify_encryption_root $POOL2/recv/fs $POOL2/recv
+
+# The master key stays cached until it is unloaded, so the damage a receive
+# used to do to the copy on disk only showed up here.
+log_must zfs unmount -u $POOL2/recv
+log_must eval "echo $PASSPHRASE2 | zfs mount -l $POOL2/recv"
+log_must zfs mount $POOL2/recv/fs
+
+log_must cmp_xxh128 /$POOL/send/fs/file1 /$POOL2/recv/fs/file1
+log_must cmp_xxh128 /$POOL/send/fs/file2 /$POOL2/recv/fs/file2
+
+# A filesystem received as an encryption root of its own still follows the
+# sending side, key changes included.
+log_must eval "zfs send -w $POOL/send@snap1 | zfs receive $POOL2/root"
+log_must verify_encryption_root $POOL2/root $POOL2/root
+log_must eval "echo $PASSPHRASE1 | zfs load-key $POOL2/root"
+log_must zfs unload-key $POOL2/root
+
+log_must eval "echo $PASSPHRASE | zfs change-key $POOL/send"
+log_must zfs snapshot $POOL/send@snap3
+log_must eval "zfs send -w -i @snap1 $POOL/send@snap3 |" \
+	"zfs receive $POOL2/root"
+
+log_mustnot eval "echo $PASSPHRASE1 | zfs load-key $POOL2/root"
+log_must eval "echo $PASSPHRASE | zfs load-key $POOL2/root"
+
+# So does one which inherits from a received encryption root: the wrapping
+# key there is the sending side's own, so its key has to keep up too.
+log_must zfs snapshot -r $POOL/send@tree1
+log_must eval "zfs send -Rw $POOL/send@tree1 | zfs receive -d -F $POOL3"
+log_must verify_encryption_root $POOL3/send $POOL3/send
+log_must verify_encryption_root $POOL3/send/fs $POOL3/send
+
+log_must eval "echo $PASSPHRASE1 | zfs change-key $POOL/send"
+log_must zfs snapshot -r $POOL/send@tree2
+log_must eval "zfs send -Rw -I @tree1 $POOL/send@tree2 |" \
+	"zfs receive -d $POOL3"
+
+log_must eval "echo $PASSPHRASE1 | zfs load-key $POOL3/send"
+log_must zfs mount $POOL3/send
+log_must zfs mount $POOL3/send/fs
+log_must cmp_xxh128 /$POOL/send/fs/file2 /$POOL3/send/fs/file2
+
+log_pass "Raw incremental receives do not overwrite an inherited key"


### PR DESCRIPTION
### Motivation and Context
A raw receive writes the DSL Crypto Key carried in the stream over the one on
disk, but the encryption root that key is filed under is left as it is. The
key in the stream is wrapped by the wrapping key of the *sender's* encryption
root, so this only holds together while ours is the same one.

Where the receiving filesystem inherits from a root with a wrapping key of its
own, which is what a replica has once `zfs change-key -i` hands it to a locally
keyed dataset, the two stop agreeing: the wrapped master key becomes the
sender's while `DSL_CRYPTO_KEY_ROOT_DDOBJ` still names the local root, and
nothing on the receiving pool can unwrap it.

The unwrapped key stays cached in the keystore, so the receive and every use
after it look fine. The next `zfs load-key` on the root succeeds, `keystatus`
reports `available`, and the filesystem then refuses to mount with `Permission
denied`. Recovering it takes the sending pool's wrapping key and a hand built
encryption hierarchy, which is why people in the thread ended up rebuilding
backups instead. Issue #12614, with #12123 reporting the same thing.

`zdb` on the replica's key object across the incremental receive, from the
reproducer in the issue:

| field | after `change-key -i` | after the incremental | sender |
|---|---|---|---|
| `DSL_CRYPTO_MASTER_KEY_1` | `c420f21e…` | `42a2ab3f…` | `42a2ab3f…` |
| `pbkdf2salt` | `-5321890128408176241` | `-2778956606581889264` | `-2778956606581889264` |
| `DSL_CRYPTO_ROOT_DDOBJ` | 64 (local root) | 64, unchanged | 264 |
| `DSL_CRYPTO_GUID` | `2394831139723616302` | unchanged | same |

### Description
The keyformat, salt and iteration count travel with the key and describe the
wrapping key it was wrapped with. Where the receiving filesystem inherits,
they are compared against those of its encryption root and the copy on disk is
kept when they differ. Nothing is lost by keeping it: the guid shows both
copies protect the same master key, and `dsl_crypto_recv_raw_key_check()`
enforces that.

A filesystem which is its own encryption root still follows the sending side,
key changes included. So does one whose encryption root is itself a replica of
that same sender, which is what `send -Rw | recv -d` leaves behind after
libzfs force-inherits the children: there the root's wrapping key is the
sender's, the parameters match, and the key has to keep up or the child is
stranded the next time the sender rekeys. An earlier version of this change
skipped the write whenever the filesystem was not its own encryption root and
broke exactly that; the third case in the new test is what catches it.

The comparison is made between DSL Crypto Key objects rather than dsl dirs. An
incremental receive lands on the hidden `%recv` clone, which has a dsl dir of
its own but shares the key object of the filesystem it will be swapped into,
so comparing `dd_object` against the root ddobj matches on nothing at all.

One gap I would like your view on: a root keyed with `keyformat=raw` or `hex`
has salt 0 and iters 0, exactly like the sender's, so the comparison cannot
tell the two apart and a replica keyed that way is still exposed. Closing it
needs something on disk that names the wrapping key, say a flag on the root's
key object set by a raw receive and cleared by
`spa_keystore_change_key_sync_impl()`. That is an on-disk addition, so I did
not want to make the call alone; happy to add it here if you would rather have
the complete fix in one go.

This stops the damage from being done and does not repair datasets that are
already in this state; those still need the `force_inherit` procedure worked
out in the thread. Two related things left alone: a filesystem that is its own
encryption root and was rekeyed locally still takes the sender's key, which is
the documented behaviour of a raw receive and stays recoverable with the
sender's passphrase, and `keystatus` still reports `available` for a dataset
whose own wrapped key cannot be unwrapped, since it only looks at the
encryption root.

### How Has This Been Tested?
The reproducer from the issue, on 300M file vdevs: a raw send of
`src/encrypted/a` into `replica/encrypted/a`, `change-key -i` there, then an
incremental `send -RwI`. Before the change the replica mounts until its key is
unloaded and then fails with `Permission denied`, and `zdb` shows the sender's
wrapped key and salt sitting under the local encryption root. After it, the
key object is untouched and both files read back with the checksums they had
on the source.

The other two directions were checked the same way. With a replica received as
an encryption root of its own, a `zfs change-key` on the sender followed by an
incremental raw send leaves the old passphrase rejected and the new one
accepted. With a `send -Rw | recv -d` hierarchy, the same sender-side key
change still reaches the inheriting child, which loads and mounts afterwards.

New `rsend/send_raw_inherited_key` covers all three. It fails on master at the
mount that follows the incremental receive. The `rsend` group passes with no
unexpected results, as do the `zfs_change-key`, `zfs_load-key`,
`zfs_unload-key`, `zfs_receive` and `zfs_send` groups. Linux, aarch64,
`--enable-debug`.

### Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs_core, libnvpair and libzfsbootenv)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
