### PR TITLE
Linux: reject mounts without a source

### DIFF
--- a/module/os/linux/zfs/zpl_super.c
+++ b/module/os/linux/zfs/zpl_super.c
@@ -844,6 +844,9 @@ zpl_get_tree(struct fs_context *fc)
 	boolean_t issnap = B_FALSE;
 	int err;
 
+	if (fc->source == NULL)
+		return (-SET_ERROR(EINVAL));
+
 	err = dmu_objset_hold(fc->source, FTAG, &os);
 	if (err)
 		return (-err);

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -170,7 +170,7 @@ tags = ['functional', 'mmp']
 timeout = 1200
 
 [tests/functional/mount:Linux]
-tests = ['umount_unlinked_drain', 'mount_loopback']
+tests = ['umount_unlinked_drain', 'mount_loopback', 'mount_null_source']
 tags = ['functional', 'mount']
 
 [tests/functional/pam:Linux]

--- a/tests/zfs-tests/cmd/.gitignore
+++ b/tests/zfs-tests/cmd/.gitignore
@@ -33,6 +33,7 @@
 /mmap_sync
 /mmapwrite
 /mmap_write_sync
+/mount_null_source
 /nvlist_to_lua
 /randfree_file
 /randwritecomp

--- a/tests/zfs-tests/cmd/Makefile.am
+++ b/tests/zfs-tests/cmd/Makefile.am
@@ -138,6 +138,7 @@ if BUILD_LINUX
 scripts_zfs_tests_bin_PROGRAMS += %D%/getversion
 scripts_zfs_tests_bin_PROGRAMS += %D%/user_ns_exec
 scripts_zfs_tests_bin_PROGRAMS += %D%/makedir
+scripts_zfs_tests_bin_PROGRAMS += %D%/mount_null_source
 scripts_zfs_tests_bin_PROGRAMS += %D%/renameat2
 scripts_zfs_tests_bin_PROGRAMS += %D%/statx
 scripts_zfs_tests_bin_PROGRAMS += %D%/xattrtest

--- a/tests/zfs-tests/cmd/mount_null_source.c
+++ b/tests/zfs-tests/cmd/mount_null_source.c
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: CDDL-1.0
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * https://opensource.org/license/CDDL-1.0.
+ */
+
+#include <sys/mount.h>
+#include <err.h>
+#include <errno.h>
+#include <stdlib.h>
+
+int
+main(int argc, char **argv)
+{
+	if (argc != 2)
+		errx(EXIT_FAILURE, "usage: %s mountpoint", argv[0]);
+
+	if (mount(NULL, argv[1], "zfs", 0, NULL) == 0)
+		errx(EXIT_FAILURE, "mount unexpectedly succeeded");
+
+	if (errno != EINVAL)
+		err(EXIT_FAILURE, "mount");
+
+	return (EXIT_SUCCESS);
+}

--- a/tests/zfs-tests/include/commands.cfg
+++ b/tests/zfs-tests/include/commands.cfg
@@ -219,6 +219,7 @@ export ZFSTEST_FILES_COMMON='badsend
     mmap_sync
     mmapwrite
     mmap_write_sync
+    mount_null_source
     nvlist_to_lua
     zcp_support
     randfree_file

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1837,6 +1837,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/mount/cleanup.ksh \
 	functional/mount/setup.ksh \
 	functional/mount/mount_loopback.ksh \
+	functional/mount/mount_null_source.ksh \
 	functional/mount/umount_001.ksh \
 	functional/mount/umountall_001.ksh \
 	functional/mount/umount_unlinked_drain.ksh \

--- a/tests/zfs-tests/tests/functional/mount/mount_null_source.ksh
+++ b/tests/zfs-tests/tests/functional/mount/mount_null_source.ksh
@@ -1,0 +1,42 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# Verify that mounting ZFS without a source fails with EINVAL.
+#
+# STRATEGY:
+# 1. Create an empty mountpoint.
+# 2. Issue mount(2) with a NULL source using mount_null_source.
+# 3. Verify that mount(2) returns EINVAL.
+#
+
+log_assert "Mounting ZFS without a source fails with EINVAL"
+
+typeset mountpoint="$TEST_BASE_DIR/null-source"
+
+function cleanup
+{
+	if mounted "$mountpoint"; then
+		log_must umount "$mountpoint"
+	fi
+	rm -rf "$mountpoint"
+}
+
+log_onexit cleanup
+log_must mkdir "$mountpoint"
+log_must mount_null_source "$mountpoint"
+
+log_pass "ZFS rejected a mount without a source"


### PR DESCRIPTION
### Motivation and Context
As documented by `mount.zfs(8)`, the first positional argument identifies
the ZFS dataset to mount.

A legacy `mount(2)` request may omit the source argument, leaving
`fc->source` unset. `zpl_get_tree()` previously passed this value to
`dmu_objset_hold()`, and the lookup path subsequently dereferenced it
instead of returning a mount error.

Reproduce:
```c
#include <sys/mount.h>
int main(void) { return mount(NULL, "/mnt/zfs", "zfs", 0, NULL); }
```


BUG: kernel NULL pointer dereference, address: 0000000000000000
  #PF: supervisor read access in kernel mode
  RIP: 0010:strnlen+0x17/0x50 lib/string.c:432
  RDI: 0000000000000000
  Call Trace:
   spa_lookup+0x92/0x2a0
   spa_open_common+0x3b0/0x930   fs/zfs/zfs/spa.c:6441
   spa_open+0x2f/0x50            fs/zfs/zfs/spa.c:6545
   dsl_pool_hold+0x8a/0x130      fs/zfs/zfs/dsl_pool.c:1400
   dmu_objset_hold_flags+0xae/0x1b0 fs/zfs/zfs/dmu_objset.c:751
   dmu_objset_hold+0x2c/0x40     fs/zfs/zfs/dmu_objset.c:772
   zpl_mount_impl                fs/zfs/os/linux/zfs/zpl_super.c:394 [inline]
   zpl_mount+0xb6/0x770          fs/zfs/os/linux/zfs/zpl_super.c:465
   legacy_get_tree+0x112/0x220   fs/fs_context.c:663
   vfs_get_tree+0x9a/0x370
   path_mount+0x5b8/0x1ea0
   __x64_sys_mount+0x282/0x320

### Description
Validate `fc->source` at the beginning of `zpl_get_tree()` and return
`EINVAL` when no source was supplied.

Add a Linux-only ZTS helper which calls `mount(2)` with a NULL source, and
a mount test which verifies that the request fails with `EINVAL`.

### How Has This Been Tested?
- Configured with `--enable-debug`
- `make -j$(nproc)`
- `make check`
- `make checkstyle`
- `make testscheck`
- `./scripts/commitcheck.sh HEAD`
- Applied to Linux 6.18 and built the in-tree ZFS target with `make fs/zfs/built-in.a`
- Verified the generated patch with `git apply --check` and `git am`

The new ZTS case was built and registered, but was not executed because
the updated built-in kernel was not booted in this environment.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
