### PR TITLE
Defer destruction of a snapshot that a mount is holding open

### DIFF
--- a/include/sys/dsl_destroy.h
+++ b/include/sys/dsl_destroy.h
@@ -30,6 +30,7 @@ struct dmu_tx;
 int dsl_destroy_snapshots_nvl(struct nvlist *, boolean_t,
     struct nvlist *);
 int dsl_destroy_snapshot(const char *, boolean_t);
+void dsl_destroy_snapshot_deferred(const char *);
 int dsl_destroy_head(const char *);
 int dsl_destroy_head_check_impl(struct dsl_dataset *, int);
 void dsl_destroy_head_sync_impl(struct dsl_dataset *, struct dmu_tx *);

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -807,6 +807,7 @@ extern int bpobj_enqueue_free_cb(void *arg, const blkptr_t *bp, dmu_tx_t *tx);
 #define	SPA_ASYNC_REBUILD_DONE			0x2000
 #define	SPA_ASYNC_DETACH_SPARE			0x4000
 #define	SPA_ASYNC_REMOVE_BY_USER		0x8000
+#define	SPA_ASYNC_DEFER_DESTROY			0x10000
 
 /* device manipulation */
 extern int spa_vdev_add(spa_t *spa, nvlist_t *nvroot, boolean_t ashift_check);

--- a/include/sys/spa_impl.h
+++ b/include/sys/spa_impl.h
@@ -341,7 +341,7 @@ struct spa {
 	kthread_t	*spa_async_thread;	/* thread doing async task */
 	int		spa_async_suspended;	/* async tasks suspended */
 	kcondvar_t	spa_async_cv;		/* wait for thread_exit() */
-	uint16_t	spa_async_tasks;	/* async task mask */
+	uint32_t	spa_async_tasks;	/* async task mask */
 	uint64_t	spa_missing_tvds;	/* unopenable tvds on load */
 	uint64_t	spa_missing_tvds_allowed; /* allow loading spa? */
 

--- a/module/zfs/dsl_dataset.c
+++ b/module/zfs/dsl_dataset.c
@@ -1025,14 +1025,28 @@ dsl_dataset_rele_flags(dsl_dataset_t *ds, ds_hold_flags_t flags,
 void
 dsl_dataset_disown(dsl_dataset_t *ds, ds_hold_flags_t flags, const void *tag)
 {
+	spa_t *spa = NULL;
+
 	ASSERT3P(ds->ds_owner, ==, tag);
 	ASSERT(ds->ds_dbuf != NULL);
+
+	/*
+	 * A snapshot marked for deferred destruction while it was mounted can
+	 * be destroyed once the mount is gone.  The request has to go in after
+	 * the hold is dropped, or the sweep would find the snapshot still held
+	 * and leave it, so remember the pool while the dataset is still here.
+	 */
+	if (ds->ds_is_snapshot && DS_IS_DEFER_DESTROY(ds))
+		spa = dsl_dataset_get_spa(ds);
 
 	mutex_enter(&ds->ds_lock);
 	ds->ds_owner = NULL;
 	mutex_exit(&ds->ds_lock);
 	dsl_dataset_long_rele(ds, tag);
 	dsl_dataset_rele_flags(ds, flags, tag);
+
+	if (spa != NULL)
+		spa_async_request(spa, SPA_ASYNC_DEFER_DESTROY);
 }
 
 boolean_t

--- a/module/zfs/dsl_destroy.c
+++ b/module/zfs/dsl_destroy.c
@@ -47,8 +47,18 @@ dsl_destroy_snapshot_check_impl(dsl_dataset_t *ds, boolean_t defer)
 	if (!ds->ds_is_snapshot)
 		return (SET_ERROR(EINVAL));
 
-	if (dsl_dataset_long_held(ds))
-		return (SET_ERROR(EBUSY));
+	if (dsl_dataset_long_held(ds)) {
+		/*
+		 * A mounted snapshot can be marked for deferred destruction
+		 * and is destroyed when it is unmounted, the same way a held
+		 * one is destroyed when the last hold is released.  Every
+		 * other long hold belongs to an operation that is on its way
+		 * out already, a send or a diff say, so there is nothing to
+		 * defer to and the caller is asked to come back later.
+		 */
+		if (!defer || !dsl_dataset_has_owner(ds))
+			return (SET_ERROR(EBUSY));
+	}
 
 	/*
 	 * Only allow deferred destroy on pools that support it.
@@ -306,11 +316,11 @@ dsl_destroy_snapshot_sync_impl(dsl_dataset_t *ds, boolean_t defer, dmu_tx_t *tx)
 	rrw_enter(&ds->ds_bp_rwlock, RW_READER, FTAG);
 	ASSERT3U(BP_GET_BIRTH(&dsl_dataset_phys(ds)->ds_bp), <=, tx->tx_txg);
 	rrw_exit(&ds->ds_bp_rwlock, FTAG);
-	ASSERT(zfs_refcount_is_zero(&ds->ds_longholds));
 
 	if (defer &&
 	    (ds->ds_userrefs > 0 ||
-	    dsl_dataset_phys(ds)->ds_num_children > 1)) {
+	    dsl_dataset_phys(ds)->ds_num_children > 1 ||
+	    dsl_dataset_long_held(ds))) {
 		ASSERT(spa_version(dp->dp_spa) >= SPA_VERSION_USERREFS);
 		dmu_buf_will_dirty(ds->ds_dbuf, tx);
 		dsl_dataset_phys(ds)->ds_flags |= DS_FLAG_DEFER_DESTROY;
@@ -318,9 +328,18 @@ dsl_destroy_snapshot_sync_impl(dsl_dataset_t *ds, boolean_t defer, dmu_tx_t *tx)
 			spa_history_log_internal_ds(ds, "defer_destroy", tx,
 			    " ");
 		}
+		/*
+		 * Where the long hold is what stopped us, whatever is holding
+		 * it asks for the same sweep when it lets go.  Ask for one
+		 * here too, in case it has already done so and read the mark
+		 * before this txg put it there.
+		 */
+		if (dsl_dataset_long_held(ds))
+			spa_async_request(dp->dp_spa, SPA_ASYNC_DEFER_DESTROY);
 		return;
 	}
 
+	ASSERT(zfs_refcount_is_zero(&ds->ds_longholds));
 	ASSERT3U(dsl_dataset_phys(ds)->ds_num_children, <=, 1);
 
 	if (zfs_snapshot_history_enabled) {
@@ -634,6 +653,103 @@ dsl_destroy_snapshot(const char *name, boolean_t defer)
 	fnvlist_free(errlist);
 	fnvlist_free(nvl);
 	return (error);
+}
+
+static int
+dsl_destroy_snapshot_deferred_check(void *arg, dmu_tx_t *tx)
+{
+	uint64_t dsobj = *(uint64_t *)arg;
+	dsl_pool_t *dp = dmu_tx_pool(tx);
+	dsl_dataset_t *ds;
+	int error;
+
+	error = dsl_dataset_hold_obj(dp, dsobj, FTAG, &ds);
+	if (error != 0)
+		return (SET_ERROR(ENOENT));
+
+	/*
+	 * The mark is the whole of this destroy's authority and the object is
+	 * where it was left, so a snapshot that no longer carries it, or an
+	 * object that has come back as something else, is not ours to touch.
+	 */
+	if (!ds->ds_is_snapshot || !DS_IS_DEFER_DESTROY(ds))
+		error = SET_ERROR(ENOENT);
+	else
+		error = dsl_destroy_snapshot_check_impl(ds, B_FALSE);
+
+	dsl_dataset_rele(ds, FTAG);
+	return (error);
+}
+
+static void
+dsl_destroy_snapshot_deferred_sync(void *arg, dmu_tx_t *tx)
+{
+	uint64_t dsobj = *(uint64_t *)arg;
+	dsl_pool_t *dp = dmu_tx_pool(tx);
+	char name[ZFS_MAX_DATASET_NAME_LEN];
+	dsl_dataset_t *ds;
+
+	VERIFY0(dsl_dataset_hold_obj(dp, dsobj, FTAG, &ds));
+	dsl_dataset_name(ds, name);
+	dsl_destroy_snapshot_sync_impl(ds, B_FALSE, tx);
+	zvol_remove_minors(dp->dp_spa, name, B_TRUE);
+	dsl_dataset_rele(ds, FTAG);
+}
+
+static int
+dsl_destroy_snapshot_deferred_one(const char *dsname, void *arg)
+{
+	(void) arg;
+	dsl_pool_t *dp;
+	dsl_dataset_t *ds;
+	uint64_t dsobj = 0;
+
+	if (dsl_pool_hold(dsname, FTAG, &dp) != 0)
+		return (0);
+	if (dsl_dataset_hold(dp, dsname, FTAG, &ds) == 0) {
+		if (ds->ds_is_snapshot && DS_IS_DEFER_DESTROY(ds) &&
+		    dsl_destroy_snapshot_check_impl(ds, B_FALSE) == 0)
+			dsobj = ds->ds_object;
+		dsl_dataset_rele(ds, FTAG);
+	}
+	dsl_pool_rele(dp, FTAG);
+
+	/*
+	 * The sync task keys off the object rather than the name it was found
+	 * under, so that a snapshot destroyed and recreated under the same
+	 * name in the meantime is not mistaken for this one.
+	 */
+	if (dsobj != 0) {
+		int error = dsl_sync_task(dsname,
+		    dsl_destroy_snapshot_deferred_check,
+		    dsl_destroy_snapshot_deferred_sync, &dsobj, 0,
+		    ZFS_SPACE_CHECK_DESTROY);
+		/*
+		 * ENOENT is the snapshot having gone by another route, or
+		 * having lost the mark, both of which are ordinary.  Anything
+		 * else leaves the mark in place for the next sweep, and is
+		 * worth a note for whoever wonders where the snapshot went.
+		 */
+		if (error != 0 && error != ENOENT) {
+			zfs_dbgmsg("deferred destroy of %s (obj %llu) failed, "
+			    "error %d", dsname, (u_longlong_t)dsobj, error);
+		}
+	}
+
+	return (0);
+}
+
+/*
+ * Destroy every snapshot in the pool that is marked for deferred destruction
+ * and has nothing keeping it alive any more.  Runs on the async thread when a
+ * mount lets go of one, and once at import for anything a crash or an export
+ * left behind.
+ */
+void
+dsl_destroy_snapshot_deferred(const char *poolname)
+{
+	(void) dmu_objset_find(poolname, dsl_destroy_snapshot_deferred_one,
+	    NULL, DS_FIND_CHILDREN | DS_FIND_SNAPSHOTS);
 }
 
 struct killarg {

--- a/module/zfs/dsl_userhold.c
+++ b/module/zfs/dsl_userhold.c
@@ -414,12 +414,22 @@ dsl_dataset_user_release_check_one(dsl_dataset_user_release_arg_t *ddura,
 	if (DS_IS_DEFER_DESTROY(ds) &&
 	    dsl_dataset_phys(ds)->ds_num_children == 1 &&
 	    ds->ds_userrefs == numholds) {
-		/* we need to destroy the snapshot as well */
-		if (dsl_dataset_long_held(ds)) {
+		/*
+		 * We need to destroy the snapshot as well, unless something
+		 * else is still holding it open.  An owner - a mount, or an
+		 * open snapshot zvol - ends at dsl_dataset_disown(), which
+		 * asks for the sweep that finishes the job, so the release
+		 * can go through and leave the mark where it is rather than
+		 * hand the caller a hold they cannot get rid of.  Every other
+		 * long hold has no such hook, and failing the release is what
+		 * gets the snapshot destroyed on the next try.
+		 */
+		if (!dsl_dataset_long_held(ds)) {
+			fnvlist_add_boolean(ddura->ddura_todelete, snapname);
+		} else if (!dsl_dataset_has_owner(ds)) {
 			fnvlist_free(holds_found);
 			return (SET_ERROR(EBUSY));
 		}
-		fnvlist_add_boolean(ddura->ddura_todelete, snapname);
 	}
 
 	if (numholds != 0) {

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -6329,6 +6329,15 @@ spa_load_impl(spa_t *spa, spa_import_type_t type, const char **ereport)
 		    "Cleaning up temporary userrefs");
 		dsl_pool_clean_tmp_userrefs(spa->spa_dsl_pool);
 
+		/*
+		 * Anything still marked for deferred destruction because a
+		 * mount was holding it was left that way by a crash or an
+		 * export, and nothing is holding it now.  The sweep walks
+		 * every snapshot, so leave it to the async thread rather than
+		 * spending import time on it.
+		 */
+		spa_async_request(spa, SPA_ASYNC_DEFER_DESTROY);
+
 		spa_config_enter(spa, SCL_CONFIG, FTAG, RW_READER);
 		spa_import_progress_set_notes(spa, "Restarting initialize");
 		vdev_initialize_restart(spa->spa_root_vdev);
@@ -9849,7 +9858,7 @@ spa_async_thread(void *arg)
 {
 	spa_t *spa = (spa_t *)arg;
 	dsl_pool_t *dp = spa->spa_dsl_pool;
-	int tasks;
+	uint32_t tasks;
 
 	ASSERT(spa->spa_sync_on);
 
@@ -9995,6 +10004,17 @@ spa_async_thread(void *arg)
 		spa_config_exit(spa, SCL_L2ARC, FTAG);
 		spa_namespace_exit(FTAG);
 	}
+
+	/*
+	 * Finish off snapshots whose deferred destruction was waiting on
+	 * something that has since let go of them.  The destroy is a sync
+	 * task, which a suspended pool would never come back from, and the
+	 * export path waits on this thread, so leave the mark where it is
+	 * and pick it up on the next request or at the next import.
+	 */
+	if ((tasks & SPA_ASYNC_DEFER_DESTROY) && spa_writeable(spa) &&
+	    !spa_suspended(spa))
+		dsl_destroy_snapshot_deferred(spa_name(spa));
 
 	/*
 	 * Let the world know that we're done.

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -216,7 +216,8 @@ tests = ['snapdir_admin_create_destroy', 'snapdir_admin_rename_destroy',
     'snapdir_mount_expire_busy', 'snapdir_mount_no_setuid',
     'snapdir_stat_no_mount', 'snapdir_mount_bind', 'snapdir_mount_move',
     'snapdir_mount_expire_bind', 'snapdir_mount_expire_move',
-    'snapdir_mount_multiple', 'snapdir_mount_fd_hold', 'snapdir_mount_foreign']
+    'snapdir_mount_multiple', 'snapdir_mount_fd_hold', 'snapdir_mount_foreign',
+    'snapdir_mount_destroy_defer']
 tags = ['functional', 'snapdir']
 
 [tests/functional/syncfs:Linux]

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -2246,6 +2246,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/snapdir/snapdir_admin_disabled.ksh \
 	functional/snapdir/snapdir_admin_rename_destroy.ksh \
 	functional/snapdir/snapdir_mount_bind.ksh \
+	functional/snapdir/snapdir_mount_destroy_defer.ksh \
 	functional/snapdir/snapdir_mount_expire_bind.ksh \
 	functional/snapdir/snapdir_mount_expire_busy.ksh \
 	functional/snapdir/snapdir_mount_expire_idle.ksh \

--- a/tests/zfs-tests/tests/functional/snapdir/snapdir_mount_destroy_defer.ksh
+++ b/tests/zfs-tests/tests/functional/snapdir/snapdir_mount_destroy_defer.ksh
@@ -1,0 +1,101 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
+#
+
+#
+# Copyright (c) 2026 by Andrew Mochalskyi. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/snapdir/snapdir.kshlib
+. $STF_SUITE/tests/functional/snapdir/snapdir.cfg
+
+verify_runnable "both"
+
+log_assert "Verify that 'zfs destroy -d' defers a snapshot held open by a mount."
+
+if ! is_linux ; then
+	log_unsupported "EXPIRE_SNAPSHOT tunable only available on Linux"
+fi
+
+save_tunable EXPIRE_SNAPSHOT
+
+typeset -i tail_pid=0
+
+function cleanup
+{
+	# Without this a failure leaves the snapshot mount busy and the pool
+	# cannot be destroyed
+	if ((tail_pid > 0)) ; then
+		kill $tail_pid 2>/dev/null
+		wait $tail_pid 2>/dev/null
+	fi
+	destroy_pool $TESTPOOL
+	restore_tunable EXPIRE_SNAPSHOT
+}
+
+log_onexit cleanup
+
+# Set snapshot expiry time to something we can test sanely.
+log_must set_tunable64 EXPIRE_SNAPSHOT 2
+
+# Create a pool and a snapshot, with a file inside
+create_pool $TESTPOOL $DISKS
+log_must zfs create -o snapdir=visible -o mountpoint=$TESTDIR/fs $TESTPOOL/$TESTFS
+log_must touch $TESTDIR/fs/empty
+log_must zfs snapshot $TESTPOOL/$TESTFS@snap
+
+# Trigger the mount
+log_must ls -l $TESTDIR/fs/$SNAPROOT/snap >/dev/null
+log_must test "$(get_mount_paths $TESTPOOL/$TESTFS@snap)" == "$TESTDIR/fs/$SNAPROOT/snap"
+
+# Open a file in the snapshot and hold it
+tail -f $TESTDIR/fs/$SNAPROOT/snap/empty &
+tail_pid=$!
+
+# Don't go on until it really has the file open, or the destroys below race
+# against it and the mount is not busy when they run
+typeset -i i=0
+while ((i < 50)) && ! ls -l /proc/$tail_pid/fd 2>/dev/null | \
+    grep -q "$SNAPROOT/snap/empty" ; do
+	sleep 0.1
+	((i += 1))
+done
+log_must test $i -lt 50
+
+# A plain destroy has nowhere to put the request, so it fails
+log_mustnot zfs destroy $TESTPOOL/$TESTFS@snap
+log_must datasetexists $TESTPOOL/$TESTFS@snap
+
+# With -d the request is recorded on the snapshot instead
+log_must zfs destroy -d $TESTPOOL/$TESTFS@snap
+log_must datasetexists $TESTPOOL/$TESTFS@snap
+log_must test "$(get_prop defer_destroy $TESTPOOL/$TESTFS@snap)" == "on"
+
+# Let go of the file, which releases the last reference to the mount
+kill $tail_pid
+wait $tail_pid
+typeset -i rc=$?
+tail_pid=0
+
+# tail was still running when we signalled it, so it held the file open for
+# the whole of the above; an earlier exit would show a normal status here
+log_must test $rc -gt 128
+
+# The snapshot goes away on its own once that has happened
+i=0
+while ((i < 30)) && datasetexists $TESTPOOL/$TESTFS@snap ; do
+	sleep 1
+	((i += 1))
+done
+log_mustnot datasetexists $TESTPOOL/$TESTFS@snap
+
+log_pass "'zfs destroy -d' defers a snapshot held open by a mount."


### PR DESCRIPTION
### Motivation and Context

`zfs destroy -d` on a snapshot that is automounted under `.zfs/snapshot` and still
has a file open fails with EBUSY on Linux, the same way the plain destroy does, and
leaves `defer_destroy` off. The `-d` option is documented as marking whatever it
cannot destroy right away, so as things stand there is no way to ask for a snapshot
somebody is reading to go away later.

`dsl_destroy_snapshot_check_impl()` turns away any long-held snapshot before it looks
at the defer flag, and a snapshot is long held while it is mounted. Taking the mount
away first is not an option: `zfsctl_snapshot_unmount()` invalidates the snapdir
dentry, which detaches the mount, but the dataset stays owned until the last open file
goes, and the 20ms it then waits is not enough for a file someone is still reading.
FreeBSD never reaches this, since its `zfsctl_snapshot_unmount()` goes through
`dounmount()` with `MS_FORCE`.

Closes #16339.

### Description

Let the snapshot be marked, and destroy it once whatever was holding it has let go.

Ownership is the dividing line rather than long holds in general. A mount, or an open
snapshot zvol, ends in `dsl_dataset_disown()`, which gives somewhere to pick the
snapshot back up. A send or a diff in flight ends by itself, and a persistent on-disk
mark left for one would have nothing to come back for, so those keep returning EBUSY.

Collection is a sweep for snapshots that are marked and no longer held, driven by a
new `SPA_ASYNC_DEFER_DESTROY`. The disowner asks for it after dropping its hold;
`dsl_destroy_snapshot_sync_impl()` asks for one as well when it marks a held snapshot,
in case the disown ran between the two and read the mark before the txg wrote it; and
it runs once at import, for a mark left behind by a crash or an export while the
snapshot was still mounted. The destroy is keyed on the object rather than the name it
was found under, so a snapshot destroyed and recreated under the same name in the
meantime cannot be mistaken for the marked one.

The sweep is skipped on a pool that is suspended or not writeable. It finishes in a
sync task, which a suspended pool would never come back from, and
`spa_export_common()` waits on the async thread before it does anything else, so a
sweep caught that way would take the export with it. The mark keeps until the next
request or the next import.

`spa_async_tasks` had used all sixteen bits of its `uint16_t`, so it grows to
`uint32_t` to make room for the new task.

The second commit is a separate wart that this makes much easier to hit.
`dsl_dataset_user_release_check_one()` fails the whole release with EBUSY when the
last hold comes off a snapshot that is marked and still long held. That is reachable
today without any of the above: mark one while it is idle with `zfs hold` followed by
`zfs destroy -d`, mount it afterwards by listing `.zfs/snapshot`, and `zfs release`
reports "dataset is busy" and leaves the tag in place, with no way to drop it until
the mount goes. The check was there because the release is what destroys the snapshot,
and destroying one that something still holds is not on; where an owner is what holds
it that is no longer the only way it gets destroyed, so the release can drop the tag
and leave the mark to be collected in the ordinary way. Every other long hold keeps
failing the release as before, since nothing would come back for the mark there and
with the last userref gone it would sit on the snapshot with nothing left to trigger
a destroy, where today the caller retries once the send or the diff is done.

### How Has This Been Tested?

New `snapdir_mount_destroy_defer` case, which fails at the `zfs destroy -d` step
against an unpatched kernel. `functional/snapdir` (21 cases),
`functional/cli_root/zfs_destroy` (24 cases) and `fault/suspend_on_probe_errors` on
Linux, plus `ztest`.

By hand: `destroy -d` during an in-flight send still fails with EBUSY and does not set
the flag; the hold-then-mount-then-release sequence above reports "dataset is busy" on
master and drops the tag with this applied, after which the snapshot is collected once
the mount goes, while the same release with a send in flight instead still reports
"dataset is busy" and the retry after the send finishes destroys the snapshot;
`zpool export` issued immediately behind the collector is clean over repeated runs; a
pool suspended with a marked snapshot on it neither wedges the async thread nor blocks
the export, and the snapshot is collected once `zpool clear` brings the pool back; and
a mark left on disk by resetting the machine with the snapshot still mounted is
collected on the next import.

On the sweep walking every snapshot in the pool: I have left it that way deliberately.
`spa_load_impl()` already solves the same problem the same way five lines above where
this hooks in, walking every dataset with `dmu_objset_find()` to find the
`DS_FLAG_INCONSISTENT` ones, and `DS_FLAG_DEFER_DESTROY` has a per-dataset home just
like that one does. `DMU_POOL_TMP_USERREFS` needs an index because a temporary hold is
a `(dsobj, tag)` pair with nowhere else to live. The walk costs nothing when nothing is
marked, and it runs on the async thread rather than in the import path. If it ever does
turn out to be too slow, the escalation the project has used before is
`dmu_objset_find_dp()` rather than a new on-disk object. Happy to add an index instead
if you would rather, though it would likely want a feature flag for what is otherwise
a bug fix.

There is no FreeBSD counterpart because the hook is in `dsl_dataset_disown()` rather
than in the per-platform `zfs_ctldir.c`; FreeBSD simply never reaches the EBUSY, since
its `zfsctl_snapshot_unmount()` forces the unmount.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [contributing document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/blob/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

