### PR TITLE
Address repeated small writes leading to memory spike

### DIFF
--- a/include/sys/dbuf.h
+++ b/include/sys/dbuf.h
@@ -375,7 +375,8 @@ void dmu_buf_will_fill_flags(dmu_buf_t *db, dmu_tx_t *tx, boolean_t canfail,
 boolean_t dmu_buf_fill_done(dmu_buf_t *db, dmu_tx_t *tx, boolean_t failed);
 void dbuf_assign_arcbuf(dmu_buf_impl_t *db, arc_buf_t *buf, dmu_tx_t *tx,
     dmu_flags_t flags);
-dbuf_dirty_record_t *dbuf_dirty(dmu_buf_impl_t *db, dmu_tx_t *tx);
+dbuf_dirty_record_t *dbuf_dirty(dmu_buf_impl_t *db, dmu_tx_t *tx,
+    boolean_t recount);
 dbuf_dirty_record_t *dbuf_dirty_lightweight(dnode_t *dn, uint64_t blkid,
     dmu_tx_t *tx);
 boolean_t dbuf_undirty(dmu_buf_impl_t *db, dmu_tx_t *tx);

--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -815,7 +815,8 @@ struct blkptr *dmu_buf_get_blkptr(dmu_buf_t *db);
  * (ie. you've called dmu_tx_hold_object(tx, db->db_object)).
  */
 void dmu_buf_will_dirty(dmu_buf_t *db, dmu_tx_t *tx);
-void dmu_buf_will_dirty_flags(dmu_buf_t *db, dmu_tx_t *tx, dmu_flags_t flags);
+void dmu_buf_will_dirty_flags(dmu_buf_t *db, dmu_tx_t *tx, dmu_flags_t flags,
+    boolean_t recount);
 void dmu_buf_will_rewrite(dmu_buf_t *db, dmu_tx_t *tx);
 boolean_t dmu_buf_is_dirty(dmu_buf_t *db, dmu_tx_t *tx);
 void dmu_buf_set_crypt_params(dmu_buf_t *db_fake, boolean_t byteorder,
@@ -930,7 +931,7 @@ int dmu_write_uio(objset_t *os, uint64_t object, zfs_uio_t *uio, uint64_t size,
 int dmu_write_uio_dbuf(dmu_buf_t *zdb, zfs_uio_t *uio, uint64_t size,
 	dmu_tx_t *tx, dmu_flags_t flags);
 int dmu_write_uio_dnode(dnode_t *dn, zfs_uio_t *uio, uint64_t size,
-	dmu_tx_t *tx, dmu_flags_t flags);
+	dmu_tx_t *tx, dmu_flags_t flags, boolean_t recount);
 #endif
 struct arc_buf *dmu_request_arcbuf(dmu_buf_t *handle, int size);
 void dmu_return_arcbuf(struct arc_buf *buf);

--- a/include/sys/zil.h
+++ b/include/sys/zil.h
@@ -458,6 +458,7 @@ typedef struct itx {
 	size_t		itx_size;	/* allocated itx structure size */
 	uint64_t	itx_oid;	/* object id */
 	uint64_t	itx_gen;	/* gen number for zfs_get_data */
+	uint64_t	itx_coalesce_align;
 	lr_t		itx_lr;		/* common part of log record */
 	uint8_t		itx_lr_data[];	/* type-specific part of lr_xx_t */
 } itx_t;

--- a/module/os/freebsd/zfs/dmu_os.c
+++ b/module/os/freebsd/zfs/dmu_os.c
@@ -103,7 +103,7 @@ dmu_write_pages(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
 				else
 					flags |= DMU_PARTIAL_MORE;
 			}
-			dmu_buf_will_dirty_flags(db, tx, flags);
+			dmu_buf_will_dirty_flags(db, tx, flags, B_FALSE);
 		}
 
 		for (copied = 0; copied < tocpy; copied += PAGESIZE) {

--- a/module/os/freebsd/zfs/zvol_os.c
+++ b/module/os/freebsd/zfs/zvol_os.c
@@ -877,7 +877,7 @@ zvol_cdev_write(struct cdev *dev, struct uio *uio_s, int ioflag)
 			break;
 		}
 		error = dmu_write_uio_dnode(zv->zv_dn, &uio, bytes, tx,
-		    DMU_READ_PREFETCH);
+		    DMU_READ_PREFETCH, B_FALSE);
 		if (error == 0)
 			zvol_log_write(zv, tx, off, bytes, commit);
 		dmu_tx_commit(tx);

--- a/module/os/linux/zfs/zvol_os.c
+++ b/module/os/linux/zfs/zvol_os.c
@@ -255,7 +255,7 @@ zvol_write(zv_request_t *zvr)
 			break;
 		}
 		error = dmu_write_uio_dnode(zv->zv_dn, &uio, bytes, tx,
-		    DMU_READ_PREFETCH);
+		    DMU_READ_PREFETCH, B_FALSE);
 		if (error == 0) {
 			zvol_log_write(zv, tx, off, bytes, sync);
 		}

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -2181,11 +2181,13 @@ dbuf_new_size(dmu_buf_impl_t *db, int size, dmu_tx_t *tx)
 	if (db->db_level == 0)
 		dr->dt.dl.dr_data = buf;
 	ASSERT3U(dr->dr_txg, ==, tx->tx_txg);
-	ASSERT3U(dr->dr_accounted, ==, osize);
-	dr->dr_accounted = size;
+	uint64_t count = dr->dr_accounted / osize;
+	uint64_t oaccounted = dr->dr_accounted;
+	dr->dr_accounted = size * count;
 	mutex_exit(&db->db_mtx);
 
-	dmu_objset_willuse_space(dn->dn_objset, size - osize, tx);
+	dmu_objset_willuse_space(dn->dn_objset, dr->dr_accounted - oaccounted,
+	    tx);
 	DB_DNODE_EXIT(db);
 }
 
@@ -2209,11 +2211,12 @@ dbuf_release_bp(dmu_buf_impl_t *db)
  * dirtied again.
  */
 static void
-dbuf_redirty(dbuf_dirty_record_t *dr)
+dbuf_redirty(dbuf_dirty_record_t *dr, dmu_tx_t *recount_tx)
 {
 	dmu_buf_impl_t *db = dr->dr_dbuf;
 
 	ASSERT(MUTEX_HELD(&db->db_mtx));
+	IMPLY(recount_tx != NULL, DB_DNODE_HELD(db));
 
 	if (db->db_level == 0 && db->db_blkid != DMU_BONUS_BLKID) {
 		/*
@@ -2233,6 +2236,12 @@ dbuf_redirty(dbuf_dirty_record_t *dr)
 		 * modification.
 		 */
 		dr->dt.dl.dr_rewrite = B_FALSE;
+		if (recount_tx) {
+			dnode_t *dn = DB_DNODE(db);
+			dr->dr_accounted += db->db.db_size;
+			dmu_objset_willuse_space(dn->dn_objset, db->db.db_size,
+			    recount_tx);
+		}
 	}
 }
 
@@ -2302,7 +2311,8 @@ dbuf_dirty_lightweight(dnode_t *dn, uint64_t blkid, dmu_tx_t *tx)
 			return (NULL);
 		}
 
-		dbuf_dirty_record_t *parent_dr = dbuf_dirty(parent_db, tx);
+		dbuf_dirty_record_t *parent_dr = dbuf_dirty(parent_db, tx,
+		    B_FALSE);
 		dbuf_rele(parent_db, FTAG);
 		mutex_enter(&parent_dr->dt.di.dr_mtx);
 		ASSERT3U(parent_dr->dr_txg, ==, tx->tx_txg);
@@ -2317,7 +2327,7 @@ dbuf_dirty_lightweight(dnode_t *dn, uint64_t blkid, dmu_tx_t *tx)
 }
 
 dbuf_dirty_record_t *
-dbuf_dirty(dmu_buf_impl_t *db, dmu_tx_t *tx)
+dbuf_dirty(dmu_buf_impl_t *db, dmu_tx_t *tx, boolean_t recount)
 {
 	dnode_t *dn;
 	objset_t *os;
@@ -2370,9 +2380,9 @@ dbuf_dirty(dmu_buf_impl_t *db, dmu_tx_t *tx)
 	    db->db.db_object == DMU_META_DNODE_OBJECT);
 	dr_next = dbuf_find_dirty_lte(db, tx->tx_txg);
 	if (dr_next && dr_next->dr_txg == tx->tx_txg) {
-		DB_DNODE_EXIT(db);
 
-		dbuf_redirty(dr_next);
+		dbuf_redirty(dr_next, recount ? tx : NULL);
+		DB_DNODE_EXIT(db);
 		mutex_exit(&db->db_mtx);
 		return (dr_next);
 	}
@@ -2539,7 +2549,7 @@ dbuf_dirty(dmu_buf_impl_t *db, dmu_tx_t *tx)
 		if (drop_struct_rwlock)
 			rw_exit(&dn->dn_struct_rwlock);
 		ASSERT3U(db->db_level + 1, ==, parent->db_level);
-		di = dbuf_dirty(parent, tx);
+		di = dbuf_dirty(parent, tx, B_FALSE);
 		if (parent_held)
 			dbuf_rele(parent, FTAG);
 
@@ -2705,7 +2715,8 @@ dbuf_undirty(dmu_buf_impl_t *db, dmu_tx_t *tx)
 }
 
 void
-dmu_buf_will_dirty_flags(dmu_buf_t *db_fake, dmu_tx_t *tx, dmu_flags_t flags)
+dmu_buf_will_dirty_flags(dmu_buf_t *db_fake, dmu_tx_t *tx, dmu_flags_t flags,
+    boolean_t recount)
 {
 	dmu_buf_impl_t *db = (dmu_buf_impl_t *)db_fake;
 	boolean_t undirty = B_FALSE;
@@ -2738,7 +2749,13 @@ dmu_buf_will_dirty_flags(dmu_buf_t *db_fake, dmu_tx_t *tx, dmu_flags_t flags)
 				undirty = B_TRUE;
 			} else {
 				/* This dbuf is already dirty and cached. */
-				dbuf_redirty(dr);
+				if (recount) {
+					DB_DNODE_ENTER(db);
+					dbuf_redirty(dr, tx);
+					DB_DNODE_EXIT(db);
+				} else {
+					dbuf_redirty(dr, NULL);
+				}
 				mutex_exit(&db->db_mtx);
 				return;
 			}
@@ -2763,13 +2780,13 @@ dmu_buf_will_dirty_flags(dmu_buf_t *db_fake, dmu_tx_t *tx, dmu_flags_t flags)
 		VERIFY(!dbuf_undirty(db, tx));
 		mutex_exit(&db->db_mtx);
 	}
-	(void) dbuf_dirty(db, tx);
+	(void) dbuf_dirty(db, tx, recount);
 }
 
 void
 dmu_buf_will_dirty(dmu_buf_t *db_fake, dmu_tx_t *tx)
 {
-	dmu_buf_will_dirty_flags(db_fake, tx, DMU_READ_NO_PREFETCH);
+	dmu_buf_will_dirty_flags(db_fake, tx, DMU_READ_NO_PREFETCH, B_FALSE);
 }
 
 void
@@ -2795,7 +2812,7 @@ dmu_buf_will_rewrite(dmu_buf_t *db_fake, dmu_tx_t *tx)
 	 * The dbuf is not dirty, so we need to make it dirty and
 	 * mark it for rewrite (preserve logical birth time).
 	 */
-	dmu_buf_will_dirty_flags(db_fake, tx, DMU_READ_NO_PREFETCH);
+	dmu_buf_will_dirty_flags(db_fake, tx, DMU_READ_NO_PREFETCH, B_FALSE);
 
 	mutex_enter(&db->db_mtx);
 	dbuf_dirty_record_t *dr = dbuf_find_dirty_eq(db, tx->tx_txg);
@@ -2966,7 +2983,7 @@ dmu_buf_will_clone_or_dio(dmu_buf_t *db_fake, dmu_tx_t *tx)
 	mutex_exit(&db->db_mtx);
 
 	dbuf_noread(db, DMU_KEEP_CACHING);
-	(void) dbuf_dirty(db, tx);
+	(void) dbuf_dirty(db, tx, B_FALSE);
 }
 
 void
@@ -2980,7 +2997,7 @@ dmu_buf_will_not_fill(dmu_buf_t *db_fake, dmu_tx_t *tx)
 	mutex_exit(&db->db_mtx);
 
 	dbuf_noread(db, DMU_KEEP_CACHING);
-	(void) dbuf_dirty(db, tx);
+	(void) dbuf_dirty(db, tx, B_FALSE);
 }
 
 void
@@ -3007,7 +3024,7 @@ dmu_buf_will_fill_flags(dmu_buf_t *db_fake, dmu_tx_t *tx, boolean_t canfail,
 		 */
 		if (canfail && dr) {
 			mutex_exit(&db->db_mtx);
-			dmu_buf_will_dirty_flags(db_fake, tx, flags);
+			dmu_buf_will_dirty_flags(db_fake, tx, flags, B_FALSE);
 			return;
 		}
 		/*
@@ -3024,7 +3041,7 @@ dmu_buf_will_fill_flags(dmu_buf_t *db_fake, dmu_tx_t *tx, boolean_t canfail,
 	mutex_exit(&db->db_mtx);
 
 	dbuf_noread(db, flags);
-	(void) dbuf_dirty(db, tx);
+	(void) dbuf_dirty(db, tx, B_FALSE);
 }
 
 void
@@ -3056,7 +3073,7 @@ dmu_buf_set_crypt_params(dmu_buf_t *db_fake, boolean_t byteorder,
 	ASSERT(db->db_objset->os_raw_receive);
 
 	dmu_buf_will_dirty_flags(db_fake, tx,
-	    DMU_READ_NO_PREFETCH | DMU_READ_NO_DECRYPT);
+	    DMU_READ_NO_PREFETCH | DMU_READ_NO_DECRYPT, B_FALSE);
 
 	dr = dbuf_find_dirty_eq(db, tx->tx_txg);
 
@@ -3243,7 +3260,7 @@ dbuf_assign_arcbuf(dmu_buf_impl_t *db, arc_buf_t *buf, dmu_tx_t *tx,
 		 */
 		ASSERT(!arc_is_encrypted(buf));
 		mutex_exit(&db->db_mtx);
-		(void) dbuf_dirty(db, tx);
+		(void) dbuf_dirty(db, tx, B_FALSE);
 		memcpy(db->db.db_data, buf->b_data, db->db.db_size);
 		arc_buf_destroy(buf, db);
 		return;
@@ -3283,7 +3300,7 @@ dbuf_assign_arcbuf(dmu_buf_impl_t *db, arc_buf_t *buf, dmu_tx_t *tx,
 	db->db_state = DB_FILL;
 	DTRACE_SET_STATE(db, "filling assigned arcbuf");
 	mutex_exit(&db->db_mtx);
-	(void) dbuf_dirty(db, tx);
+	(void) dbuf_dirty(db, tx, B_FALSE);
 	dmu_buf_fill_done(&db->db, tx, B_FALSE);
 }
 

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -1474,7 +1474,7 @@ dmu_write_impl(dmu_buf_t **dbp, int numbufs, uint64_t offset, uint64_t size,
 				else
 					flags |= DMU_PARTIAL_MORE;
 			}
-			dmu_buf_will_dirty_flags(db, tx, flags);
+			dmu_buf_will_dirty_flags(db, tx, flags, B_FALSE);
 		}
 
 		ASSERT(db->db_data != NULL);
@@ -1665,7 +1665,7 @@ dmu_read_uio(objset_t *os, uint64_t object, zfs_uio_t *uio, uint64_t size,
 
 int
 dmu_write_uio_dnode(dnode_t *dn, zfs_uio_t *uio, uint64_t size, dmu_tx_t *tx,
-    dmu_flags_t flags)
+    dmu_flags_t flags, boolean_t recount)
 {
 	dmu_buf_t **dbp;
 	int numbufs;
@@ -1732,7 +1732,7 @@ top:
 				else
 					flags |= DMU_PARTIAL_MORE;
 			}
-			dmu_buf_will_dirty_flags(db, tx, flags);
+			dmu_buf_will_dirty_flags(db, tx, flags, recount);
 		}
 
 		ASSERT(db->db_data != NULL);
@@ -1785,7 +1785,7 @@ dmu_write_uio_dbuf(dmu_buf_t *zdb, zfs_uio_t *uio, uint64_t size,
 		return (0);
 
 	DB_DNODE_ENTER(db);
-	err = dmu_write_uio_dnode(DB_DNODE(db), uio, size, tx, flags);
+	err = dmu_write_uio_dnode(DB_DNODE(db), uio, size, tx, flags, B_TRUE);
 	DB_DNODE_EXIT(db);
 
 	return (err);
@@ -1810,7 +1810,7 @@ dmu_write_uio(objset_t *os, uint64_t object, zfs_uio_t *uio, uint64_t size,
 	if (err)
 		return (err);
 
-	err = dmu_write_uio_dnode(dn, uio, size, tx, flags);
+	err = dmu_write_uio_dnode(dn, uio, size, tx, flags, B_FALSE);
 
 	dnode_rele(dn, FTAG);
 

--- a/module/zfs/dnode.c
+++ b/module/zfs/dnode.c
@@ -1906,7 +1906,7 @@ dnode_setdirty(dnode_t *dn, dmu_tx_t *tx)
 	ASSERT3U(dn->dn_dirtycnt, <=, 3);
 	mutex_exit(&dn->dn_mtx);
 
-	(void) dbuf_dirty(dn->dn_dbuf, tx);
+	(void) dbuf_dirty(dn->dn_dbuf, tx, B_FALSE);
 
 	dsl_dataset_dirty(os->os_dsl_dataset, tx);
 }
@@ -2015,7 +2015,7 @@ dnode_set_nlevels_impl(dnode_t *dn, int new_nlevels, dmu_tx_t *tx)
 	/* dirty the left indirects */
 	db = dbuf_hold_level(dn, old_nlevels, 0, FTAG);
 	ASSERT(db != NULL);
-	new = dbuf_dirty(db, tx);
+	new = dbuf_dirty(db, tx, B_FALSE);
 	dbuf_rele(db, FTAG);
 
 	/* transfer the dirty records to the new indirect */

--- a/module/zfs/dsl_pool.c
+++ b/module/zfs/dsl_pool.c
@@ -816,7 +816,7 @@ dsl_pool_sync(dsl_pool_t *dp, uint64_t txg)
 
 	/*
 	 * We have written all of the accounted dirty data, so our
-	 * dp_space_towrite should now be zero. However, some seldom-used
+	 * dp_dirty_pertxg should now be zero. However, some seldom-used
 	 * code paths do not adhere to this (e.g. dbuf_undirty()). Shore up
 	 * the accounting of any dirtied space now.
 	 *

--- a/module/zfs/zfs_log.c
+++ b/module/zfs/zfs_log.c
@@ -660,6 +660,14 @@ zfs_log_write(zilog_t *zilog, dmu_tx_t *tx, int txtype,
 			}
 		}
 
+		if (wr_state == WR_NEED_COPY || wr_state == WR_INDIRECT) {
+			DB_DNODE_ENTER(db);
+			uint64_t maxblkid = DB_DNODE(db)->dn_maxblkid;
+			DB_DNODE_EXIT(db);
+			if (maxblkid > 0)
+				itx->itx_coalesce_align = blocksize;
+		}
+
 		log_size += itx->itx_size;
 		if (wr_state == WR_NEED_COPY)
 			log_size += len;

--- a/module/zfs/zil.c
+++ b/module/zfs/zil.c
@@ -2552,6 +2552,7 @@ zil_itx_create(uint64_t txtype, size_t olrsize)
 	itx->itx_callback = NULL;
 	itx->itx_callback_data = NULL;
 	itx->itx_size = itxsize;
+	itx->itx_coalesce_align = 0;
 
 	return (itx);
 }
@@ -2759,6 +2760,47 @@ zil_itx_assign(zilog_t *zilog, itx_t *itx, dmu_tx_t *tx)
 			    offsetof(itx_t, itx_node));
 			ian->ia_foid = foid;
 			avl_insert(t, ian, where);
+		}
+
+		/*
+		 * This logic controls ITX tail coalescing. This is an
+		 * optimization that was introduced to help improve performance
+		 * on the common append case. Without this optimization, each
+		 * append could create an entire separate ZIO if the object is
+		 * fsync'ed, which means we have to take that into account in
+		 * the dirty data limits. That results in significantly more
+		 * frequent and less efficient TXG syncs.
+		 *
+		 * This optimization specifically only helps with multiple
+		 * consecutive writes to the same blocks, but other
+		 * optimizations could be added if the data indicates that they
+		 * would be helpful.
+		 */
+		itx_t *cur_tail = list_tail(&ian->ia_list);
+		if (cur_tail && cur_tail->itx_coalesce_align &&
+		    itx->itx_coalesce_align &&
+		    cur_tail->itx_lr.lrc_txtype == itx->itx_lr.lrc_txtype) {
+			ASSERT3U(itx->itx_lr.lrc_txtype, ==, TX_WRITE);
+			ASSERT3U(cur_tail->itx_lr.lrc_txtype, ==, TX_WRITE);
+			ASSERT3U(cur_tail->itx_coalesce_align, ==,
+			    itx->itx_coalesce_align);
+			lr_write_t *new_lr = (lr_write_t *)(&itx->itx_lr);
+			lr_write_t *tail_lr = (lr_write_t *)(&cur_tail->itx_lr);
+			ASSERT3U(new_lr->lr_foid, ==, tail_lr->lr_foid);
+
+			uint64_t coal = itx->itx_coalesce_align;
+			uint64_t start = tail_lr->lr_offset;
+			uint64_t end = new_lr->lr_offset + new_lr->lr_length -
+			    1;
+			if (start / coal == end / coal && new_lr->lr_offset ==
+			    tail_lr->lr_offset + tail_lr->lr_length &&
+			    dmu_tx_get_txg(tx) == cur_tail->itx_lr.lrc_txg) {
+				tail_lr->lr_length += new_lr->lr_length;
+				zil_itx_destroy(itx, 0);
+				itx = cur_tail;
+				list_remove(&ian->ia_list, cur_tail);
+			}
+
 		}
 		list_insert_tail(&ian->ia_list, itx);
 	}

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -698,6 +698,10 @@ tags = ['functional', 'compression']
 tests = ['cp_files_001_pos', 'cp_files_002_pos', 'cp_stress']
 tags = ['functional', 'cp_files']
 
+[tests/functional/fsync]
+tests = ['many_fsync_001_pos']
+tags = ['functional', 'fsync']
+
 [tests/functional/zap_shrink]
 tests = ['zap_shrink_001_pos']
 tags = ['functional', 'zap_shrink']

--- a/tests/zfs-tests/cmd/.gitignore
+++ b/tests/zfs-tests/cmd/.gitignore
@@ -10,6 +10,7 @@
 /dir_rd_update
 /draid
 /file_fadvise
+/file_fsync
 /file_append
 /file_check
 /file_trunc

--- a/tests/zfs-tests/cmd/Makefile.am
+++ b/tests/zfs-tests/cmd/Makefile.am
@@ -51,7 +51,7 @@ scripts_zfs_tests_bin_PROGRAMS += %D%/draid
 %C%_draid_LDADD += $(ZLIB_LIBS)
 
 dist_noinst_DATA += %D%/file/file_common.h
-scripts_zfs_tests_bin_PROGRAMS += %D%/file_append %D%/file_check %D%/file_trunc %D%/file_write %D%/largest_file %D%/randfree_file %D%/randwritecomp
+scripts_zfs_tests_bin_PROGRAMS += %D%/file_append %D%/file_check %D%/file_trunc %D%/file_write %D%/largest_file %D%/randfree_file %D%/randwritecomp %D%/file_fsync
 %C%_file_append_SOURCES   = %D%/file/file_append.c
 %C%_file_check_SOURCES    = %D%/file/file_check.c
 %C%_file_trunc_SOURCES    = %D%/file/file_trunc.c
@@ -59,7 +59,7 @@ scripts_zfs_tests_bin_PROGRAMS += %D%/file_append %D%/file_check %D%/file_trunc 
 %C%_largest_file_SOURCES  = %D%/file/largest_file.c
 %C%_randfree_file_SOURCES = %D%/file/randfree_file.c
 %C%_randwritecomp_SOURCES = %D%/file/randwritecomp.c
-
+%C%_file_fsync_SOURCES    = %D%/file/file_fsync.c
 
 scripts_zfs_tests_bin_PROGRAMS += %D%/libzfs_input_check
 %C%_libzfs_input_check_LDADD = \

--- a/tests/zfs-tests/cmd/file/file_fsync.c
+++ b/tests/zfs-tests/cmd/file/file_fsync.c
@@ -1,0 +1,648 @@
+// SPDX-License-Identifier: CDDL-1.0
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * https://opensource.org/license/CDDL-1.0.
+ */
+
+/*
+ * Copyright (c) 2026, Klara, Inc.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <string.h>
+#include <getopt.h>
+#include <errno.h>
+
+/*
+ * SI Conversions
+ *
+ * These translate values to kibibytes, mebibytes, and so forth; the
+ * power-of-two version of the SI units.  KiB(1) will yield 1024, for
+ * example, not 1000.
+ */
+#define	KiB(_x) ((_x) << 10)
+#define	MiB(_x) ((_x) << 20)
+#define	GiB(_x) ((_x) << 30)
+#define	TiB(_x) ((_x) << 40)
+#define	PiB(_x) ((_x) << 50)
+
+/*
+ * Option Data
+ *
+ * Command line options and global defaults are stored here.
+ */
+enum {
+	WRITE_APPEND,
+	WRITE_RANDOM,
+	WRITE_CYCLIC
+};
+
+#define	MAX_VERBOSITY (10)
+
+struct {
+	const char	*path;
+	size_t	 file_size;
+	uint64_t write_count;
+	size_t	 write_size;
+	int	 write_type;
+	uint64_t cycle_size;
+	uint64_t progress_step;
+	uint64_t sparse_fsync;
+	bool	 close_on_write;
+	bool	 do_fsync;
+	bool	 use_o_sync;
+	bool	 delete_file;
+	int	 verbosity;
+} options =
+{
+	.path		= "fsync-test.data",
+	.file_size	= MiB(33),
+	.write_count	= KiB(1),
+	.write_size	= 1,
+	.write_type	= WRITE_APPEND,
+	.cycle_size	= 0,
+	.progress_step	= 64,
+	.sparse_fsync	= 1,
+	.close_on_write = false,
+	.do_fsync	= true,
+	.use_o_sync	= false,
+	.delete_file	= true,
+	.verbosity	= 1,
+};
+
+/*
+ * Print Usage & Exit
+ *
+ * This function is invoked when a command line error is encountered, or if the
+ * user explicitly asks for help.
+ *
+ * Arguments:
+ *
+ * ret -- the value to hand to exit()
+ * fmt -- the printf()-style format string to be printed before the usage text,
+ *	  or NULL
+ * ... -- arguments for the format string
+ */
+static void
+usage(int ret, const char *fmt, ...)
+{
+	if (fmt) {
+		va_list arglist;
+		va_start(arglist, fmt);
+		vprintf(fmt, arglist);
+		va_end(arglist);
+	}
+
+	printf("Usage: many-fsync-test [arguments]\n"
+	    "    Test writing a series of values to a file with fsync() between"
+	    " each\n write.\n"
+	    "\n"
+	    "  Arguments:\n");
+	printf(
+	    "    -h                 -- print this help text and quit.\n"
+	    "    -q                 -- reduce verbosity one step\n");
+	printf(
+	    "    -v                 -- increase verbosity one step\n"
+	    "                          default verbosity is %d\n",
+	    options.verbosity);
+	printf(
+	    "    --path string      -- specify the path to the test file\n"
+	    "                          default is \"%s\"\n", options.path);
+	printf(
+	    "    --size int         -- specify the byte size of the file\n"
+	    "                          can use k, m, g or t as suffixes\n"
+	    "                          default is %lu bytes\n",
+	    options.file_size);
+	printf(
+	    "    --no-delete        -- do not remove the test file once the"
+	    " test completes\n"
+	    "                          default is %s delete the file\n",
+	    options.do_fsync ? "to" : "to not");
+	printf(
+	    "    --no-fsync         -- do not fsync() between writes\n"
+	    "                          default is %sfsync() between writes\n",
+	    options.do_fsync ? "" : "no ");
+	printf(
+	    "    --sparse-fsync int -- fsync() only every [arg] writes\n"
+	    "                          default is fsync() every write\n");
+	printf(
+	    "    --o-sync           -- use O_SYNC instead of fsync()\n"
+	    "                          default is O_SYNC %s\n",
+	    options.use_o_sync ? "on" : "off");
+	printf(
+	    "    --close-on-write   -- open, write, close the file for each"
+	    " write\n"
+	    "                          default is %s close between writes\n",
+	    options.close_on_write ? "do" : "do not");
+	printf(
+	    "    --write-count int  -- specify the number of writes to append\n"
+	    "                          can use k, m, g or t as suffixes\n"
+	    "                          default is %lu bytes\n",
+	    options.write_count);
+	printf(
+	    "    --write-size int   -- specify the size of the test writes\n"
+	    "                          default is %lu bytes\n",
+	    options.write_size);
+	printf(
+	    "    --cycle-modify int -- specify the offsets at which to modify"
+	    " the test\n"
+	    "                          file; writes occur starting at multiples"
+	    " of this\n"
+	    "                          offset, so (for example) with a test"
+	    " file size\n"
+	    "                          of 33M, a write size of 1 and a"
+	    " cycle-modify of 16M,\n"
+	    "                          the first write will be at 33M+1, the"
+	    " second at 0,\n"
+	    "                          the third at 16M, then 32M, 33M+2, 1,"
+	    " 16M+1, 32M+1...\n"
+	    "                          can use k, m, g or t as suffixes\n"
+	    "                          default is %s cycle\n",
+	    (options.write_type == WRITE_CYCLIC) ? "do" : "do not");
+	printf(
+	    "    --random-write     -- randomize write offsets; each write will"
+	    " seek to a\n"
+	    "                          random offset before writing\n"
+	    "                          default is %s randomize writes\n",
+	    (options.write_type == WRITE_APPEND) ? "do" : "do not");
+
+	exit(ret);
+}
+
+/*
+ * Parse a Number with a Possible SI Suffix
+ *
+ * This is intended for command line argument parsing; it converts strings to
+ * unsigned integer values.  If it encounters one of `kmgp` as a suffix, it
+ * multiplies the value by the appropriate power of two.
+ *
+ * Arguments:
+ *
+ * str -- the string to parse
+ *
+ * Returns:
+ *
+ * A uint64_t value.  In the event of a parse failure, this function will print
+ * usage and exit the program with an error.
+ */
+static uint64_t
+parse_number(const char *str)
+{
+	char *end;
+	uint64_t val = strtoul(str, &end, 10);
+
+	/*
+	 * If we've got invalid characters as far as strtol() is concerned, it
+	 * may be a size suffix.
+	 */
+	if (end[0]) {
+		if (end[1]) usage(1, "Couldn't parse integer \"%s\"\n\n", str);
+
+		switch (end[0]) {
+		case 'K':
+		case 'k':
+			val = KiB(val);
+			break;
+
+		case 'M':
+		case 'm':
+			val = MiB(val);
+			break;
+
+		case 'G':
+		case 'g':
+			val = GiB(val);
+			break;
+
+		case 'P':
+		case 'p':
+			val = PiB(val);
+			break;
+
+		default:
+			usage(1, "Couldn't parse integer \"%s\"\n\n", str);
+			break; // Unreached.
+		}
+	}
+
+	return (val);
+}
+
+/*
+ * Parse Command Line Arguments
+ *
+ * This function fills out the Option structure, overriding defaults in
+ * response to command line directives.	 If the command line does not parse
+ * cleanly, this function displays usage and exits with an error.
+ */
+enum {
+	ARG_NONE,
+	ARG_HELP,
+	ARG_PATH,
+	ARG_SIZE,
+	ARG_NO_FSYNC,
+	ARG_O_SYNC,
+	ARG_SPARSE_FSYNC,
+	ARG_NO_DELETE,
+	ARG_CLOSE_ON_WRITE,
+	ARG_WRITE_COUNT,
+	ARG_WRITE_SIZE,
+	ARG_CYCLE_MODIFY,
+	ARG_RANDOM_WRITE,
+};
+
+#define	OPT_FLAG(_str, _sym) { _str, no_argument, NULL, _sym }
+#define	OPT_1ARG(_str, _sym) { _str, required_argument, NULL, _sym }
+
+struct option long_opts[] =
+{
+	OPT_FLAG("help",		ARG_HELP),
+	OPT_1ARG("path",		ARG_PATH),
+	OPT_1ARG("size",		ARG_SIZE),
+	OPT_FLAG("no-fsync",		ARG_NO_FSYNC),
+	OPT_FLAG("o-sync",		ARG_O_SYNC),
+	OPT_1ARG("sparse-fsync",	ARG_SPARSE_FSYNC),
+	OPT_FLAG("no-delete",		ARG_NO_DELETE),
+	OPT_FLAG("close-on-write",	ARG_CLOSE_ON_WRITE),
+	OPT_1ARG("write-count",		ARG_WRITE_COUNT),
+	OPT_1ARG("write-size",		ARG_WRITE_SIZE),
+	OPT_1ARG("cycle-modify",	ARG_CYCLE_MODIFY),
+	OPT_FLAG("random-write",	ARG_RANDOM_WRITE),
+	{0, 0, 0, 0}
+};
+
+static void
+parse_args(int argc, char **argv)
+{
+	int lindex = 0;
+	bool done = false;
+
+	while (!done) {
+		int o = getopt_long(argc, argv, "hqv", long_opts, &lindex);
+
+		switch (o) {
+		case -1:
+			done = true;
+			break;
+
+		case '?':
+			usage(1, "");
+			break; /* Unreached. */
+
+		case 'q':
+			if (options.verbosity > 0) {
+				options.verbosity--;
+			}
+			break;
+
+		case 'v':
+			if (options.verbosity < MAX_VERBOSITY) {
+				options.verbosity++;
+			}
+			break;
+
+		case 'h':
+		case ARG_HELP:
+			usage(0, "");
+			break; /* Unreached. */
+
+		case ARG_PATH:
+			options.path = strdup(optarg);
+			break;
+
+		case ARG_SIZE:
+			options.file_size = parse_number(optarg);
+			break;
+
+		case ARG_NO_FSYNC:
+			options.do_fsync = false;
+			break;
+
+		case ARG_O_SYNC:
+			options.do_fsync = false;
+			options.use_o_sync = true;
+			break;
+
+		case ARG_SPARSE_FSYNC:
+			options.sparse_fsync = parse_number(optarg);
+
+			if (!options.sparse_fsync) {
+				options.do_fsync = false;
+			}
+			break;
+
+		case ARG_NO_DELETE:
+			options.delete_file = false;
+			break;
+
+		case ARG_CLOSE_ON_WRITE:
+			options.close_on_write = true;
+			break;
+
+		case ARG_WRITE_COUNT:
+			options.write_count = parse_number(optarg);
+			break;
+
+		case ARG_WRITE_SIZE:
+			options.write_size = parse_number(optarg);
+			break;
+
+		case ARG_CYCLE_MODIFY:
+			options.cycle_size = parse_number(optarg);
+			options.write_type = WRITE_CYCLIC;
+			break;
+
+		case ARG_RANDOM_WRITE:
+			options.write_type = WRITE_RANDOM;
+			break;
+
+		default:
+			printf("Unknown argument.\n");
+			usage(1, "");
+			break; /* Unreached. */
+		}
+	}
+
+	if (options.verbosity > 2) {
+		printf("%s\n", argv[0]);
+		printf("  Path:		    \"%s\"\n", options.path);
+		printf("  File Size:	    %"PRIu64"\n",
+		    (uint64_t)options.file_size);
+		printf("  Write Count:	    %"PRIu64"\n",
+		    options.write_count);
+		printf("  Write Size:	    %"PRIu64"b\n",
+		    (uint64_t)options.write_size);
+		printf("  Delete File	    %s\n",
+		    options.delete_file ? "Yes" : "No");
+		printf("  Close on Write:   %s\n",
+		    options.close_on_write ? "Yes" : "No");
+		printf("  fsync() on Write: %s\n",
+		    options.do_fsync ? "Yes" : "No");
+		printf("  Use O_SYNC:	    %s\n",
+		    options.use_o_sync ? "Yes" : "No");
+		printf("  Write Type:	    ");
+
+		switch (options.write_type) {
+		case WRITE_APPEND:
+			printf("Append\n");
+			break;
+
+		case WRITE_CYCLIC:
+			printf("Cyclic\n");
+			printf("    Size:	    %"PRIu64"b\n",
+			    options.cycle_size);
+			break;
+
+		case WRITE_RANDOM:
+			printf("Random\n");
+			break;
+
+		default:
+			printf("UNKNOWN?\n");
+			break;
+		}
+
+		printf("  Verbosity:	    %u\n", options.verbosity);
+	}
+}
+
+/*
+ * Create the Test File
+ *
+ * This function creates the file which will be used to test incremental writes
+ * with fsync().
+ *
+ * Arguments:
+ *
+ * path -- the full path of the file, including name
+ * size -- the byte size of the file
+ *
+ * Returns:
+ *
+ * Success (`true`) or failure (`false`).  On failure, the reason for the
+ * failure is printed to stderr.
+ */
+static bool
+make_test_file(const char *path, size_t size)
+{
+	FILE *f = fopen(path, "w");
+	size_t chunk = KiB(128);
+	size_t i;
+
+	if (chunk > size)
+		chunk = size;
+
+	if (!f) {
+		fprintf(stderr,
+		    "\nCouldn't fopen(\"%s\", \"w\"),"
+		    " the OS said:\n\t\"%s\"\n\n", path, strerror(errno));
+		return (false);
+	}
+
+	uint8_t *fill = malloc(chunk);
+
+	if (!fill) {
+		fprintf(stderr,
+		    "\nCouldn't malloc(%lu), the OS said:\n\t\"%s\"\n\n",
+		    chunk, strerror(errno));
+		return (false);
+	}
+
+	for (i = 0; i < chunk; i++) {
+		fill[i] = (i & 0xFFull);
+	}
+
+	for (i = 0; i < size; i += chunk) {
+		size_t write_size = chunk;
+		if ((i + chunk) > size) write_size = size - i;
+
+		fwrite(fill, write_size, 1, f);
+	}
+
+	free(fill);
+	fclose(f);
+	return (true);
+}
+
+/*
+ * Open File With Error Reporting
+ */
+static int
+open_file(const char *path)
+{
+	int flags = (O_WRONLY |
+	    (options.use_o_sync ? O_SYNC : 0) |
+	    (options.write_type == WRITE_APPEND ? O_APPEND : 0));
+
+	int f = open(path, flags);
+
+	if (f < 0) {
+		fprintf(stderr, "\nUnable to open %s for writing.\n\n",
+		    options.path);
+	}
+
+	return (f);
+}
+
+/*
+ * Run Test
+ */
+static bool
+run_fsync_test(void)
+{
+	uint64_t progress = 0;
+	uint64_t cycle	  = 0;
+	uint64_t offset;
+	uint8_t *data = calloc(1, options.write_size);
+	int	 file = -1;
+
+	if (!data) {
+		fprintf(stderr, "\nUnable to allocate %lu bytes.\n\n",
+		    options.write_size);
+		return (false);
+	}
+
+	data[0] = 0xFF; /* Flag the beginning. */
+
+	if (!options.close_on_write) {
+		if (0 > (file = open_file(options.path))) {
+			return (false);
+		}
+	}
+
+	for (uint64_t i = 0; i < options.write_count; i++) {
+		/* Open if necessary... */
+
+		if (options.close_on_write) {
+			if (0 > (file = open_file(options.path))) {
+				return (false);
+			}
+		}
+
+		/* Position the file pointer. */
+
+		switch (options.write_type) {
+		case WRITE_APPEND:
+			/* File opened with O_APPEND, nothing to do. */
+			break;
+
+		case WRITE_CYCLIC:
+			offset = cycle;
+			cycle = (offset + options.cycle_size +
+			    options.write_size) % options.file_size;
+			if (options.verbosity > 4) {
+				printf("Offset: %"PRIu64"\n", offset);
+			}
+			lseek(file, offset, SEEK_SET);
+			break;
+
+		case WRITE_RANDOM:
+			offset = (uint64_t)(drand48() *
+			    (double)options.file_size);
+			if (options.verbosity > 4) {
+				printf("Offset: %"PRIu64"\n", offset);
+			}
+			lseek(file, offset, SEEK_SET);
+			break;
+		}
+
+		/* Write options.size bytes. */
+
+		ssize_t res = write(file, data, options.write_size);
+
+		if (res != options.write_size && options.verbosity > 0) {
+			fprintf(stderr,
+			    "Incomplete write() returned %d, \"%s\"\n",
+			    errno, strerror(errno));
+		}
+
+		/* fsync() if necessary. */
+
+		if (options.do_fsync && !(i % options.sparse_fsync)) {
+			int err = fsync(file);
+
+			if (err && options.verbosity > 0) {
+				fprintf(stderr,
+				    "fsync(\"%s\") returned %d, \"%s\"\n",
+				    options.path, err, strerror(err));
+			}
+		}
+
+		/* close() if necessary. */
+
+		if (options.close_on_write) {
+			close(file);
+		}
+
+		/* Progress. */
+
+		if (options.verbosity > 2 && i >= progress) {
+			progress += options.progress_step;
+			printf("Done: %3"PRIu64"%% (%"PRIu64"/%"PRIu64")\n",
+			    (i * 100) / options.write_count,
+			    i, options.write_count);
+		}
+	}
+
+	if (options.verbosity > 2) {
+		printf("Done: 100%% (%"PRIu64"/%"PRIu64")\n",
+		    options.write_count, options.write_count);
+	}
+
+	if (!options.close_on_write) {
+		close(file);
+	}
+
+	free(data);
+
+	return (true);
+}
+
+/*
+ * Entry Point
+ *
+ * Execution starts here.
+ *
+ * Arguments:
+ *
+ * argc -- the size of the argument vector
+ * argv -- an array of argument strings
+ *
+ * Returns:
+ *
+ * Success (0) or failure (nonzero).
+ */
+int
+main(int argc, char **argv)
+{
+	int result = 0;
+
+	parse_args(argc, argv);
+
+	if (!make_test_file(options.path, options.file_size)) {
+		return (1);
+	}
+
+	if (!run_fsync_test()) {
+		result = 1;
+	}
+
+	if (options.delete_file) {
+		unlink(options.path);
+	}
+
+	return (result);
+}

--- a/tests/zfs-tests/include/commands.cfg
+++ b/tests/zfs-tests/include/commands.cfg
@@ -197,6 +197,7 @@ export ZFSTEST_FILES_COMMON='badsend
     file_fadvise
     file_append
     file_check
+    file_fsync
     file_trunc
     file_uncached
     file_unlink_fh

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1816,6 +1816,9 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/longname/setup.ksh \
 	functional/log_spacemap/log_spacemap_flushall.ksh \
 	functional/log_spacemap/log_spacemap_import_logs.ksh \
+	functional/fsync/cleanup.ksh \
+	functional/fsync/many_fsync_001_pos.ksh \
+	functional/fsync/setup.ksh \
 	functional/migration/cleanup.ksh \
 	functional/migration/migration_001_pos.ksh \
 	functional/migration/migration_002_pos.ksh \

--- a/tests/zfs-tests/tests/functional/fsync/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/fsync/cleanup.ksh
@@ -1,0 +1,25 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
+#
+
+#
+# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2013 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+default_cleanup

--- a/tests/zfs-tests/tests/functional/fsync/many_fsync_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/fsync/many_fsync_001_pos.ksh
@@ -1,0 +1,57 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
+#
+
+#
+# Copyright (c) 2026 Klara Systems, Inc. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# Verify that fsync() does not unduly multiply write sizes.  With
+# a large `recordsize` and fsync(), repeated small writes could
+# be multiplied by `recordsize` to consume a great deal of memory
+# and bandwidth.
+#
+# STRATEGY:
+#
+# 1. Create a dataset with `compression=off recordsize=16MiB logbias=throughput`
+# 2. Create a 33MiB file
+# 3. Examine `zpool get write_bytes fs vdev`
+# 4. Append 1 byte to the end of the file, 1024 times
+# 5. Examine `zpool get write_bytes fs vdev` again
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	zfs destroy $TESTPOOL/$TESTFS1
+}
+
+log_onexit cleanup
+log_assert "large recordsize does not take undue storage/bandwith with fsync()"
+DISK=${DISKS%% *}
+
+log_must zfs create -o compression=off -o recordsize=16MiB -o logbias=throughput $TESTPOOL/$TESTFS1
+
+INITIAL=$(zpool get -pH write_bytes $TESTPOOL $DISK | awk '{print $3}')
+mntpnt=$(get_prop mountpoint $TESTPOOL/$TESTFS1)
+log_must file_fsync -vvv --sparse-fsync 100 --path $mntpnt/test.data
+
+FINAL=$(zpool get -pH write_bytes $TESTPOOL $DISK | awk '{print $3}')
+let "RESULT = $FINAL - $INITIAL"
+log_must test $RESULT -lt $((3 * 1024 * 1024 * 1024))
+
+log_pass

--- a/tests/zfs-tests/tests/functional/fsync/setup.ksh
+++ b/tests/zfs-tests/tests/functional/fsync/setup.ksh
@@ -1,0 +1,26 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
+#
+
+#
+# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2013 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+DISK=${DISKS%% *}
+default_setup $DISK


### PR DESCRIPTION
Sponsored by: _Klara, Inc.; Wasabi
Test utility written by Todd Showalter

### Motivation and Context
When a write comes into ZFS, we create an ITX for it in the ZIL. This is true for both async and sync writes; the difference is that for sync writes, we add the ITX to a "sync list" and immediately create the relevant ZIOs, while for async writes the ITX is not acted on just yet. The basic reason for this design is that if fsync is called, we want to be able to convert only the necessary writes to sync, rather than having to force the whole TXG sync process when only a few writes might need to be issued.  The problem is that if we do end up calling fsync or syncfs, we create a ZIO for each ITX in the async list (of the relevant object(s). This is true even if there are several ITXs for a single dbuf.  This causes a problem because we did our dirty data limit math assuming that there would be approximately one logical IO per dirty dbuf, but in this case there can be more than one. If the writes were appends to a logfile with a large recordsize, there could be a lot more than one; potentially thousands of writes of a single dirty dbuf. This can cause us to blow past our dirty data limits, slowing down or even causing TXGs to hang when we run out of memory to allocate ABDs.

We saw this happen in practice on a customer system, and were able to reproduce it internally with a relatively simple test setup.

### Description
This PR contains two main changes. The first is to attempt to prevent the problem in general. When we redirty a dbuf from the ZIL code, if we are doing so on behalf of an async write that could get upgraded to a sync write via fsync/syncfs, we increase the amount of dirty data that the dbuf is responsible for in the relevant TXG. This prevents us from unexpectedly blowing past our memory limits when we call fsync.

The downside to this is that it is a performance regression in many cases; if we never call fsync, we will have counted these writes too aggressively. Ideally, we would simply not create multiple ZIOs for a single dirty dbuf, rather than accepting that we might create many and handling it. That is complicated in the general case, but we can improve in at least one simple case without too much code. The second change is the solution to this. We coalesce ITXs together if they are adjacent in the async list and if they are adjacent writes to the object in question. This way, log file appends will usually coalesce together, since we primarily update at the end of the file. We only do this in certain cases for simplicity, but the funcionality can be expanded to cover more cases and reduce any performance regressions that people see in practice.

The final piece of this PR is a new test utility to help this particular failure mode. It does repeated small writes to a file with large recordsizes and is capable of calling fsync in various patterns. We used this to verify the fix internally, and added a small wrapper around it to use it in the test suite.

### How Has This Been Tested?
In addition to manual testing, the new test utility mentioned above was used to verify the patch. Without this change, the utility will use very large amounts of memory to sync out TXGs; with it, the memory stays much more controlled. dbgmsg output was also used in testing to verify the functionality of merging the ITXs. Finally, the code was tested with the existing test suite and ztest.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
