### PR TITLE
spdxcheck: enforce CDDL header boilerplate

### DIFF
--- a/man/man7/dracut.zfs.7
+++ b/man/man7/dracut.zfs.7
@@ -1,4 +1,3 @@
-.\" SPDX-License-Identifier: CDDL-1.0
 .\" SPDX-License-Identifier: 0BSD
 .\"
 .Dd July 13, 2024

--- a/scripts/spdxcheck.pl
+++ b/scripts/spdxcheck.pl
@@ -249,6 +249,9 @@ my %override_file_license_tags = (
 	'OpenSSL-standalone' => [qw(
 		module/icp/asm-x86_64/aes/aes_aesni.S
 	)],
+	'CDDL-1.0 OR MPL-2.0' => [qw(
+		tests/zfs-tests/cmd/renameat2.c
+	)],
 
 	# Legacy inclusions of BSD-2-Clause files in Linux SPL.
 	'BSD-2-Clause' => [qw(

--- a/scripts/spdxcheck.pl
+++ b/scripts/spdxcheck.pl
@@ -414,10 +414,17 @@ for my $file (@git_files) {
 	my $nbytes = read $fh, my $buf, 4096;
 	die "$0: couldn't read $file: $!\n" if !defined $nbytes;
 
-	my ($tag) =
-	    $buf =~ m/\bSPDX-License-Identifier: ([A-Za-z0-9_\-\. ]+)$/smg;
+	my ($tag, @extra) =
+	    map { s{^\s+|\s+$}{}smgr }
+	    $buf =~ m/\bSPDX-License-Identifier: ([A-Za-z0-9_\-\. ]+)/smg;
 
 	close $fh;
+
+	if (@extra) {
+		say "multiple tags: $file";
+		$rc = 1;
+		next;
+	}
 
 	# Decide if the file should have a tag at all
 	my $tagged = file_is_tagged($file);

--- a/scripts/spdxcheck.pl
+++ b/scripts/spdxcheck.pl
@@ -2,8 +2,6 @@
 
 # SPDX-License-Identifier: MIT
 #
-# Copyright (c) 2025, Rob Norris <robn@despairlabs.com>
-#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to
 # deal in the Software without restriction, including without limitation the
@@ -21,6 +19,9 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
+
+# Copyright (c) 2025, Rob Norris <robn@despairlabs.com>
+# Copyright (c) 2026, TrueNAS.
 
 use 5.010;
 use warnings;
@@ -276,6 +277,43 @@ my %override_file_license_tags = (
 	)],
 );
 
+# License boilerplate. Files that match the SPDX tag must include the exact
+# boilerplate text somewhere in their comments.
+#
+# Tags not listed here have no particular boilerplate requirements, and are
+# not checked.
+my %boilerplate = (
+	'CDDL-1.0' => <<END_CDDL,
+This file and its contents are supplied under the terms of the
+Common Development and Distribution License ("CDDL"), version 1.0.
+You may only use this file in accordance with the terms of version
+1.0 of the CDDL.
+
+A full copy of the text of the CDDL should have accompanied this
+source.  A copy of the CDDL is also available via the Internet at
+https://opensource.org/license/CDDL-1.0.
+END_CDDL
+);
+
+# File patterns that are not expected to have license boilerplate at all.
+# These are limited to certain build files.
+my $boilerplate_exclude_patterns = q(
+	autogen.sh
+	Makefile.am
+	*/Makefile.am
+	config/*.m4
+	config/*.am
+);
+
+# Comment prefixes. When searching for license boilerplates, only lines
+# beginning with these sequences are considered, and the prefixes are stripped.
+my @comment_prefixes = (
+    '*',    # C source & headers, assembly
+    '#',    # shell/Python/etc
+    '.\"',  # manpages
+    '--',   # Lua
+);
+
 ##########
 
 sub setup_patterns {
@@ -338,6 +376,21 @@ my %override_tags = map {
 	my $tag = $_;
 	map { $_ => $tag } @{$override_file_license_tags{$_}};
 } keys %override_file_license_tags;
+
+# Regexes for the "flattened" form of the boilerplate - all on one line, all
+# whitespace removed.
+my %boilerplate_re = map {
+	my $flat = $boilerplate{$_} =~ s{\s+}{}smgr;
+	($_ => qr/\Q$flat\E/)
+} keys %boilerplate;
+
+my ($boilerplate_exclude_re, $boilerplate_exclude_files) =
+    setup_patterns($boilerplate_exclude_patterns);
+
+my $comment_prefix_re = do {
+	my $re = join '|', map { quotemeta } @comment_prefixes;
+	qr/(?:$re)/
+};
 
 ##########
 
@@ -416,6 +469,27 @@ for my $file (@git_files) {
 		$rc = 1;
 		next;
 	}
+
+	# Go to next file unless it we need to do a boilerplate check too.
+	next unless exists $boilerplate{$tag};
+
+	# Exclude if on the boilerplate exclusion list
+	next if delete($boilerplate_exclude_files->{$file}) ||
+	    $file =~ $boilerplate_exclude_re;
+
+	# Read the file, take only the text part of comment lines, then
+	# flatten and remove whitespace.
+	open $fh, '<', $file or die "$0: couldn't open $file: $!\n";
+	my $comment = join '',
+	    map { s{\s+}{}smgr }
+	    map { m{^\s*$comment_prefix_re\s*(.*\S)\s*}smg } <$fh>;
+	close $fh;
+
+	# Warn if the boilerplate text is not found in the comment text.
+	unless ($comment =~ $boilerplate_re{$tag}) {
+		say "invalid or missing license boilerplate: $file";
+		$rc = 1;
+	}
 }
 
 ##########
@@ -433,6 +507,10 @@ for my $file (sort keys %$untagged_files) {
 }
 for my $file (sort keys %override_tags) {
 	say "explicitly overridden file not on disk: $file";
+	$rc = 1;
+}
+for my $file (sort keys %$boilerplate_exclude_files) {
+	say "file explicitly exclude from boilerplate check not on disk: $file";
 	$rc = 1;
 }
 

--- a/tests/zfs-tests/cmd/clone_after_trunc.c
+++ b/tests/zfs-tests/cmd/clone_after_trunc.c
@@ -1,4 +1,14 @@
 // SPDX-License-Identifier: CDDL-1.0
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * https://opensource.org/license/CDDL-1.0.
+ */
 
 #include <errno.h>
 #include <fcntl.h>

--- a/tests/zfs-tests/cmd/renameat2.c
+++ b/tests/zfs-tests/cmd/renameat2.c
@@ -1,4 +1,3 @@
-// SPDX-License-Identifier: CDDL-1.0
 /* SPDX-License-Identifier: CDDL-1.0 OR MPL-2.0 */
 /*
  * This file and its contents are supplied under the terms of the

--- a/tests/zfs-tests/tests/functional/block_cloning/block_cloning_after_trunc.ksh
+++ b/tests/zfs-tests/tests/functional/block_cloning/block_cloning_after_trunc.ksh
@@ -1,6 +1,16 @@
 #!/bin/ksh -p
 # SPDX-License-Identifier: CDDL-1.0
-
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
+#
+#
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/block_cloning/block_cloning.kshlib
 

--- a/tests/zfs-tests/tests/functional/cli_root/zhack/zhack_label_repair_001.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zhack/zhack_label_repair_001.ksh
@@ -1,11 +1,14 @@
 #!/bin/ksh
 # SPDX-License-Identifier: CDDL-1.0
-
 #
 # This file and its contents are supplied under the terms of the
 # Common Development and Distribution License ("CDDL"), version 1.0.
 # You may only use this file in accordance with the terms of version
 # 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
 #
 
 #

--- a/tests/zfs-tests/tests/functional/cli_root/zhack/zhack_label_repair_002.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zhack/zhack_label_repair_002.ksh
@@ -1,11 +1,14 @@
 #!/bin/ksh
 # SPDX-License-Identifier: CDDL-1.0
-
 #
 # This file and its contents are supplied under the terms of the
 # Common Development and Distribution License ("CDDL"), version 1.0.
 # You may only use this file in accordance with the terms of version
 # 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
 #
 
 #

--- a/tests/zfs-tests/tests/functional/cli_root/zhack/zhack_label_repair_003.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zhack/zhack_label_repair_003.ksh
@@ -1,11 +1,14 @@
 #!/bin/ksh
 # SPDX-License-Identifier: CDDL-1.0
-
 #
 # This file and its contents are supplied under the terms of the
 # Common Development and Distribution License ("CDDL"), version 1.0.
 # You may only use this file in accordance with the terms of version
 # 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
 #
 
 #

--- a/tests/zfs-tests/tests/functional/cli_root/zhack/zhack_label_repair_004.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zhack/zhack_label_repair_004.ksh
@@ -1,11 +1,14 @@
 #!/bin/ksh
 # SPDX-License-Identifier: CDDL-1.0
-
 #
 # This file and its contents are supplied under the terms of the
 # Common Development and Distribution License ("CDDL"), version 1.0.
 # You may only use this file in accordance with the terms of version
 # 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
 #
 
 #

--- a/tests/zfs-tests/tests/functional/cli_root/zhack/zhack_metaslab_leak.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zhack/zhack_metaslab_leak.ksh
@@ -1,11 +1,14 @@
 #!/bin/ksh
 # SPDX-License-Identifier: CDDL-1.0
-
 #
 # This file and its contents are supplied under the terms of the
 # Common Development and Distribution License ("CDDL"), version 1.0.
 # You may only use this file in accordance with the terms of version
 # 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
 #
 
 #

--- a/tests/zfs-tests/tests/functional/mmp/mmp_zhack_reclaim.ksh
+++ b/tests/zfs-tests/tests/functional/mmp/mmp_zhack_reclaim.ksh
@@ -1,8 +1,6 @@
 #!/bin/ksh -p
 # SPDX-License-Identifier: CDDL-1.0
 #
-# CDDL HEADER START
-#
 # This file and its contents are supplied under the terms of the
 # Common Development and Distribution License ("CDDL"), version 1.0.
 # You may only use this file in accordance with the terms of version
@@ -10,9 +8,7 @@
 #
 # A full copy of the text of the CDDL should have accompanied this
 # source.  A copy of the CDDL is also available via the Internet at
-# http://www.illumos.org/license/CDDL.
-#
-# CDDL HEADER END
+# https://opensource.org/license/CDDL-1.0.
 #
 
 . $STF_SUITE/include/libtest.shlib

--- a/tests/zfs-tests/tests/functional/rsend/send_invalid.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send_invalid.ksh
@@ -1,11 +1,10 @@
 #!/bin/ksh
 # SPDX-License-Identifier: CDDL-1.0
-
 #
 # This file and its contents are supplied under the terms of the
-# Common Development and Distribution License ("CDDL"), version a.0.
+# Common Development and Distribution License ("CDDL"), version 1.0.
 # You may only use this file in accordance with the terms of version
-# a.0 of the CDDL.
+# 1.0 of the CDDL.
 #
 # A full copy of the text of the CDDL should have accompanied this
 # source.  A copy of the CDDL is also available via the Internet at

--- a/tests/zfs-tests/tests/functional/rsend/send_partial_dataset.ksh
+++ b/tests/zfs-tests/tests/functional/rsend/send_partial_dataset.ksh
@@ -3,9 +3,9 @@
 
 #
 # This file and its contents are supplied under the terms of the
-# Common Development and Distribution License ("CDDL"), version a.0.
+# Common Development and Distribution License ("CDDL"), version 1.0.
 # You may only use this file in accordance with the terms of version
-# a.0 of the CDDL.
+# 1.0 of the CDDL.
 #
 # A full copy of the text of the CDDL should have accompanied this
 # source.  A copy of the CDDL is also available via the Internet at


### PR DESCRIPTION
_[Sponsors: TrueNAS]_

### Motivation and Context

After #18904, we now have a standard license boilerplate for CDDL files. Lets enforce it.

### Description

Extends `spdxcheck` to have a list of acceptable boilerplate for each tag (currently only for `CDDL-1.0`).

After determining the tag, if there's a boilerplate for that tag, we extract all the comments in the file, then match the boilerplate on it. If it has something different, it gets reported and `spdxcheck` fails.

To cope with the build files that have a tag but no boilerplate (mostly `*.am` and `*.m4`, there's yet another exclusion table.

Matching is done by removing comment markers, whitespace and newlines within the wanted boilerplate and the file comments, and then searching for the "flattened" boilerplate within the "flattened" comments. This of course means that whitespace differences won't be detected, but that's unlikely and fine anyway.

Following this, a handful of files missed in #18904 get updated headers. They got missed because the differences escaped my manual search, which kind of justifies this entire change!

It also found a file with an apparently missing header (`man/man7/dracut.zfs.7`). On closer inspection it turns out that it actually isn't and was never `CDDL-1.0`, it already had a tag when we added them all in eb9098ed47 and was missed. So `spdxcheck` also gets a check for multiple tags, which also found `tests/zfs-tests/cmd/renameat2.c` was similarly misidentified. Both fixed here too!

### How Has This Been Tested?

Running `spdxcheck` and making changes until quiet. Once complete, full build and `checkstyle` passes.

### Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
