### PR TITLE
zfs destroy: fix kernel panic and add option to delete multiple bookmarks, also recursively

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -62,6 +62,7 @@
 
 #include <libzfs.h>
 #include <libzfs_core.h>
+#include <zfs_namecheck.h>
 #include <zfs_prop.h>
 #include <zfs_deleg.h>
 #include <libzutil.h>
@@ -296,7 +297,8 @@ get_usage(zfs_help_t idx)
 		return (gettext("\tdestroy [-fnpRrv] <filesystem|volume>\n"
 		    "\tdestroy [-dnpRrv] "
 		    "<filesystem|volume>@<snap>[%<snap>][,...]\n"
-		    "\tdestroy <filesystem|volume>#<bookmark>\n"));
+		    "\tdestroy [-r] "
+		    "<filesystem|volume>#<bookmark>[,<bookmark>]...\n"));
 	case HELP_GET:
 		return (gettext("\tget [-rHp] [-j [--json-int]] [-d max] "
 		    "[-o \"all\" | field[,...]]\n"
@@ -1712,6 +1714,99 @@ destroy_clones(destroy_cbdata_t *cb)
 	return (0);
 }
 
+static void
+bookmark_name_casefold(const char *name, char *folded)
+{
+	char c;
+
+	/* Matches the bookmark ZAP's U8_TEXTPREP_TOUPPER normalization. */
+	do {
+		c = *name++;
+		if (c >= 'a' && c <= 'z')
+			c -= 'a' - 'A';
+		*folded++ = c;
+	} while (c != '\0');
+}
+
+typedef struct destroy_bookmark_cbdata {
+	nvlist_t *dbcb_names;
+	nvlist_t *dbcb_folded_names;
+	nvlist_t *dbcb_targets;
+	boolean_t dbcb_recurse;
+} destroy_bookmark_cbdata_t;
+
+/*
+ * Gather fully qualified bookmark targets for this dataset and, if requested,
+ * its descendants. The legacy destroy ioctl needs stored spellings on
+ * case-insensitive datasets to prevent a kernel panic in
+ * dsl_bookmark_destroy_sync_impl() when a requested name is a case-folding
+ * alias rather than the bookmark's stored name. Alias resolution therefore
+ * lists bookmarks, compares them with requested names, and adds matching stored
+ * names to the batched destroy request so the legacy ioctl receives each actual
+ * bookmark exactly once. On case-sensitive datasets, the requested spelling
+ * identifies only that bookmark, so the callback skips the (slow) listing and
+ * constructs each target directly as <dataset>#<requested-name>, which is
+ * faster. Qualified names that are too long are omitted because those bookmarks
+ * cannot exist.
+ */
+static int
+gather_bookmark_targets(zfs_handle_t *zhp, void *arg)
+{
+	destroy_bookmark_cbdata_t *cb = arg;
+	const char *dataset = zfs_get_name(zhp);
+	nvlist_t *bookmarks = NULL;
+	boolean_t insensitive = zfs_get_type(zhp) == ZFS_TYPE_FILESYSTEM &&
+	    zfs_prop_get_int(zhp, ZFS_PROP_CASE) == ZFS_CASE_INSENSITIVE;
+	int err = 0;
+
+	if (insensitive) {
+		/*
+		 * Resolve aliases to the exact stored spelling required by
+		 * destroy.
+		 */
+		nvlist_t *props = fnvlist_alloc();
+
+		err = lzc_get_bookmarks(dataset, props, &bookmarks);
+		fnvlist_free(props);
+		if (err != 0)
+			goto out;
+	}
+
+	nvlist_t *names = insensitive ? bookmarks : cb->dbcb_names;
+	for (nvpair_t *pair = nvlist_next_nvpair(names, NULL);
+	    pair != NULL; pair = nvlist_next_nvpair(names, pair)) {
+		const char *name = nvpair_name(pair);
+
+		if (insensitive) {
+			char folded[ZFS_MAX_DATASET_NAME_LEN];
+			bookmark_name_casefold(name, folded);
+			/* Don't delete unrelated existing bookmark. */
+			if (!fnvlist_lookup_boolean(cb->dbcb_folded_names,
+			    folded))
+				continue;
+		}
+
+		char bookmark[ZFS_MAX_DATASET_NAME_LEN];
+		int len = snprintf(bookmark, sizeof (bookmark), "%s#%s",
+		    dataset, name);
+		if (len < 0 || (size_t)len >= sizeof (bookmark))
+			continue;
+		fnvlist_add_boolean(cb->dbcb_targets, bookmark);
+	}
+	fnvlist_free(bookmarks);
+	bookmarks = NULL;
+
+	if (cb->dbcb_recurse) {
+		err = zfs_iter_filesystems_v2(zhp, ZFS_ITER_SIMPLE,
+		    gather_bookmark_targets, cb);
+	}
+
+out:
+	fnvlist_free(bookmarks);
+	zfs_close(zhp);
+	return (err);
+}
+
 static int
 zfs_do_destroy(int argc, char **argv)
 {
@@ -1837,9 +1932,6 @@ zfs_do_destroy(int argc, char **argv)
 		if (err != 0)
 			rv = 1;
 	} else if (pound != NULL) {
-		int err;
-		nvlist_t *nvl;
-
 		if (cb.cb_dryrun) {
 			(void) fprintf(stderr,
 			    "dryrun is not supported with bookmark\n");
@@ -1852,37 +1944,115 @@ zfs_do_destroy(int argc, char **argv)
 			return (-1);
 		}
 
-		if (cb.cb_recurse) {
+		if (cb.cb_doclones) {
 			(void) fprintf(stderr,
-			    "recursive is not supported with bookmark\n");
+			    "-R is not supported with bookmark\n");
 			return (-1);
 		}
 
-		/*
-		 * Unfortunately, zfs_bookmark() doesn't honor the
-		 * casesensitivity setting.  However, we can't simply
-		 * remove this check, because lzc_destroy_bookmarks()
-		 * ignores non-existent bookmarks, so this is necessary
-		 * to get a proper error message.
-		 */
-		if (!zfs_bookmark_exists(argv[0])) {
-			(void) fprintf(stderr, gettext("bookmark '%s' "
-			    "does not exist.\n"), argv[0]);
+		if (!cb.cb_recurse && strchr(pound + 1, ',') == NULL) {
+			nvlist_t *nvl;
+
+			/*
+			 * Unfortunately, zfs_bookmark() doesn't honor the
+			 * casesensitivity setting.  However, we can't simply
+			 * remove this check, because lzc_destroy_bookmarks()
+			 * ignores non-existent bookmarks, so this is necessary
+			 * to get a proper error message.
+			 */
+			if (!zfs_bookmark_exists(argv[0])) {
+				(void) fprintf(stderr, gettext("bookmark '%s' "
+				    "does not exist.\n"), argv[0]);
+				return (1);
+			}
+
+			nvl = fnvlist_alloc();
+			fnvlist_add_boolean(nvl, argv[0]);
+
+			err = lzc_destroy_bookmarks(nvl, NULL);
+			if (err != 0) {
+				(void) zfs_standard_error(g_zfs, err,
+				    "cannot destroy bookmark");
+			}
+
+			nvlist_free(nvl);
+
+			return (err);
+		}
+
+		destroy_bookmark_cbdata_t bookmark_cb = { 0 };
+		nvlist_t *names = fnvlist_alloc();
+		nvlist_t *folded_names = fnvlist_alloc();
+		nvlist_t *targets = fnvlist_alloc();
+		char *spec = pound + 1;
+		char *name;
+		char folded[ZFS_MAX_DATASET_NAME_LEN];
+
+		*pound = '\0';
+		while ((name = strsep(&spec, ",")) != NULL) {
+			if (zfs_component_namecheck(name, NULL, NULL) != 0 ||
+			    strcmp(name, ".") == 0 || strcmp(name, "..") == 0) {
+				(void) fprintf(stderr,
+				    gettext("invalid bookmark name "
+				    "'%s'\n"), name);
+				fnvlist_free(targets);
+				fnvlist_free(folded_names);
+				fnvlist_free(names);
+				return (1);
+			}
+			fnvlist_add_boolean(names, name);
+			bookmark_name_casefold(name, folded);
+			fnvlist_add_boolean(folded_names, folded);
+		}
+
+		zhp = zfs_open(g_zfs, argv[0],
+		    ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME);
+		if (zhp == NULL) {
+			fnvlist_free(targets);
+			fnvlist_free(folded_names);
+			fnvlist_free(names);
 			return (1);
 		}
 
-		nvl = fnvlist_alloc();
-		fnvlist_add_boolean(nvl, argv[0]);
+		bookmark_cb.dbcb_names = names;
+		bookmark_cb.dbcb_folded_names = folded_names;
+		bookmark_cb.dbcb_targets = targets;
+		bookmark_cb.dbcb_recurse = cb.cb_recurse;
+		err = gather_bookmark_targets(zhp, &bookmark_cb);
+		zhp = NULL;
+		if (err == 0) {
+			nvlist_t *errlist = NULL;
 
-		err = lzc_destroy_bookmarks(nvl, NULL);
-		if (err != 0) {
-			(void) zfs_standard_error(g_zfs, err,
-			    "cannot destroy bookmark");
+			err = lzc_destroy_bookmarks(targets, &errlist);
+			if (err != 0) {
+				if (errlist == NULL || nvlist_empty(errlist)) {
+					(void) zfs_standard_error(g_zfs, err,
+					    "cannot destroy bookmarks");
+				} else {
+					for (nvpair_t *pair =
+					    nvlist_next_nvpair(errlist, NULL);
+					    pair != NULL; pair =
+					    nvlist_next_nvpair(errlist, pair)) {
+						char errbuf[1024];
+
+						(void) snprintf(errbuf,
+						    sizeof (errbuf), gettext(
+						    "cannot destroy bookmark "
+						    "%s"),
+						    nvpair_name(pair));
+						(void) zfs_standard_error(g_zfs,
+						    fnvpair_value_int32(pair),
+						    errbuf);
+					}
+				}
+			}
+			nvlist_free(errlist);
 		}
 
-		nvlist_free(nvl);
-
-		return (err);
+		fnvlist_free(targets);
+		fnvlist_free(folded_names);
+		fnvlist_free(names);
+		return (err != 0);
 	} else {
 		/* Open the given dataset */
 		if ((zhp = zfs_open(g_zfs, argv[0], type)) == NULL)

--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -1714,77 +1714,27 @@ destroy_clones(destroy_cbdata_t *cb)
 	return (0);
 }
 
-static void
-bookmark_name_casefold(const char *name, char *folded)
-{
-	char c;
-
-	/* Matches the bookmark ZAP's U8_TEXTPREP_TOUPPER normalization. */
-	do {
-		c = *name++;
-		if (c >= 'a' && c <= 'z')
-			c -= 'a' - 'A';
-		*folded++ = c;
-	} while (c != '\0');
-}
-
 typedef struct destroy_bookmark_cbdata {
 	nvlist_t *dbcb_names;
-	nvlist_t *dbcb_folded_names;
 	nvlist_t *dbcb_targets;
 	boolean_t dbcb_recurse;
 } destroy_bookmark_cbdata_t;
 
 /*
  * Gather fully qualified bookmark targets for this dataset and, if requested,
- * its descendants. The legacy destroy ioctl needs stored spellings on
- * case-insensitive datasets to prevent a kernel panic in
- * dsl_bookmark_destroy_sync_impl() when a requested name is a case-folding
- * alias rather than the bookmark's stored name. Alias resolution therefore
- * lists bookmarks, compares them with requested names, and adds matching stored
- * names to the batched destroy request so the legacy ioctl receives each actual
- * bookmark exactly once. On case-sensitive datasets, the requested spelling
- * identifies only that bookmark, so the callback skips the (slow) listing and
- * constructs each target directly as <dataset>#<requested-name>, which is
- * faster. Qualified names that are too long are omitted because those bookmarks
- * cannot exist.
+ * its descendants. Qualified names that are too long are omitted because
+ * those bookmarks cannot meaningfully exist.
  */
 static int
 gather_bookmark_targets(zfs_handle_t *zhp, void *arg)
 {
 	destroy_bookmark_cbdata_t *cb = arg;
 	const char *dataset = zfs_get_name(zhp);
-	nvlist_t *bookmarks = NULL;
-	boolean_t insensitive = zfs_get_type(zhp) == ZFS_TYPE_FILESYSTEM &&
-	    zfs_prop_get_int(zhp, ZFS_PROP_CASE) == ZFS_CASE_INSENSITIVE;
 	int err = 0;
 
-	if (insensitive) {
-		/*
-		 * Resolve aliases to the exact stored spelling required by
-		 * destroy.
-		 */
-		nvlist_t *props = fnvlist_alloc();
-
-		err = lzc_get_bookmarks(dataset, props, &bookmarks);
-		fnvlist_free(props);
-		if (err != 0)
-			goto out;
-	}
-
-	nvlist_t *names = insensitive ? bookmarks : cb->dbcb_names;
-	for (nvpair_t *pair = nvlist_next_nvpair(names, NULL);
-	    pair != NULL; pair = nvlist_next_nvpair(names, pair)) {
+	for (nvpair_t *pair = nvlist_next_nvpair(cb->dbcb_names, NULL);
+	    pair != NULL; pair = nvlist_next_nvpair(cb->dbcb_names, pair)) {
 		const char *name = nvpair_name(pair);
-
-		if (insensitive) {
-			char folded[ZFS_MAX_DATASET_NAME_LEN];
-			bookmark_name_casefold(name, folded);
-			/* Don't delete unrelated existing bookmark. */
-			if (!fnvlist_lookup_boolean(cb->dbcb_folded_names,
-			    folded))
-				continue;
-		}
 
 		char bookmark[ZFS_MAX_DATASET_NAME_LEN];
 		int len = snprintf(bookmark, sizeof (bookmark), "%s#%s",
@@ -1793,16 +1743,12 @@ gather_bookmark_targets(zfs_handle_t *zhp, void *arg)
 			continue;
 		fnvlist_add_boolean(cb->dbcb_targets, bookmark);
 	}
-	fnvlist_free(bookmarks);
-	bookmarks = NULL;
 
 	if (cb->dbcb_recurse) {
 		err = zfs_iter_filesystems_v2(zhp, ZFS_ITER_SIMPLE,
 		    gather_bookmark_targets, cb);
 	}
 
-out:
-	fnvlist_free(bookmarks);
 	zfs_close(zhp);
 	return (err);
 }
@@ -1982,11 +1928,9 @@ zfs_do_destroy(int argc, char **argv)
 
 		destroy_bookmark_cbdata_t bookmark_cb = { 0 };
 		nvlist_t *names = fnvlist_alloc();
-		nvlist_t *folded_names = fnvlist_alloc();
 		nvlist_t *targets = fnvlist_alloc();
 		char *spec = pound + 1;
 		char *name;
-		char folded[ZFS_MAX_DATASET_NAME_LEN];
 
 		*pound = '\0';
 		while ((name = strsep(&spec, ",")) != NULL) {
@@ -1996,26 +1940,21 @@ zfs_do_destroy(int argc, char **argv)
 				    gettext("invalid bookmark name "
 				    "'%s'\n"), name);
 				fnvlist_free(targets);
-				fnvlist_free(folded_names);
 				fnvlist_free(names);
 				return (1);
 			}
 			fnvlist_add_boolean(names, name);
-			bookmark_name_casefold(name, folded);
-			fnvlist_add_boolean(folded_names, folded);
 		}
 
 		zhp = zfs_open(g_zfs, argv[0],
 		    ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME);
 		if (zhp == NULL) {
 			fnvlist_free(targets);
-			fnvlist_free(folded_names);
 			fnvlist_free(names);
 			return (1);
 		}
 
 		bookmark_cb.dbcb_names = names;
-		bookmark_cb.dbcb_folded_names = folded_names;
 		bookmark_cb.dbcb_targets = targets;
 		bookmark_cb.dbcb_recurse = cb.cb_recurse;
 		err = gather_bookmark_targets(zhp, &bookmark_cb);
@@ -2023,7 +1962,7 @@ zfs_do_destroy(int argc, char **argv)
 		if (err == 0) {
 			nvlist_t *errlist = NULL;
 
-			err = lzc_destroy_bookmarks(targets, &errlist);
+			err = lzc_destroy_bookmarks2(targets, &errlist);
 			if (err != 0) {
 				if (errlist == NULL || nvlist_empty(errlist)) {
 					(void) zfs_standard_error(g_zfs, err,
@@ -2050,7 +1989,6 @@ zfs_do_destroy(int argc, char **argv)
 		}
 
 		fnvlist_free(targets);
-		fnvlist_free(folded_names);
 		fnvlist_free(names);
 		return (err != 0);
 	} else {

--- a/include/libzfs_core.h
+++ b/include/libzfs_core.h
@@ -55,6 +55,7 @@ _LIBZFS_CORE_H int lzc_bookmark(nvlist_t *, nvlist_t **);
 _LIBZFS_CORE_H int lzc_get_bookmarks(const char *, nvlist_t *, nvlist_t **);
 _LIBZFS_CORE_H int lzc_get_bookmark_props(const char *, nvlist_t **);
 _LIBZFS_CORE_H int lzc_destroy_bookmarks(nvlist_t *, nvlist_t **);
+_LIBZFS_CORE_H int lzc_destroy_bookmarks2(nvlist_t *, nvlist_t **);
 _LIBZFS_CORE_H int lzc_load_key(const char *, boolean_t, uint8_t *, uint_t);
 _LIBZFS_CORE_H int lzc_unload_key(const char *);
 _LIBZFS_CORE_H int lzc_change_key(const char *, uint64_t, nvlist_t *, uint8_t *,

--- a/include/sys/dsl_bookmark.h
+++ b/include/sys/dsl_bookmark.h
@@ -128,7 +128,7 @@ int dsl_bookmark_destroy(nvlist_t *, nvlist_t *);
 int dsl_bookmark_lookup(struct dsl_pool *, const char *,
     struct dsl_dataset *, zfs_bookmark_phys_t *);
 int dsl_bookmark_lookup_impl(dsl_dataset_t *, const char *,
-    zfs_bookmark_phys_t *);
+    zfs_bookmark_phys_t *, char *, int);
 int dsl_redaction_list_hold_obj(struct dsl_pool *, uint64_t, const void *,
     redaction_list_t **);
 void dsl_redaction_list_rele(redaction_list_t *, const void *);

--- a/include/sys/dsl_synctask.h
+++ b/include/sys/dsl_synctask.h
@@ -91,7 +91,7 @@ typedef struct dsl_sync_task {
 	txg_node_t dst_node;
 	struct dsl_pool *dst_pool;
 	uint64_t dst_txg;
-	int dst_space;
+	uint64_t dst_space;
 	zfs_space_check_t dst_space_check;
 	dsl_checkfunc_t *dst_checkfunc;
 	dsl_syncfunc_t *dst_syncfunc;

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -1606,7 +1606,7 @@ typedef enum {
  */
 typedef enum zfs_ioc {
 	/*
-	 * Core features - 89/128 numbers reserved.
+	 * Core features - 92/128 numbers reserved.
 	 */
 #ifdef __FreeBSD__
 	ZFS_IOC_FIRST =	0,
@@ -1705,6 +1705,7 @@ typedef enum zfs_ioc {
 	ZFS_IOC_POOL_PREFETCH,			/* 0x5a58 */
 	ZFS_IOC_DDT_PRUNE,			/* 0x5a59 */
 	ZFS_IOC_POOL_CONDENSE,			/* 0x5a5a */
+	ZFS_IOC_DESTROY_BOOKMARKS2,		/* 0x5a5b */
 
 	/*
 	 * Per-platform (Optional) - 8/128 numbers reserved.

--- a/lib/libzfs/libzfs.abi
+++ b/lib/libzfs/libzfs.abi
@@ -6616,6 +6616,7 @@
       <enumerator name='ZFS_IOC_POOL_PREFETCH' value='23128'/>
       <enumerator name='ZFS_IOC_DDT_PRUNE' value='23129'/>
       <enumerator name='ZFS_IOC_POOL_CONDENSE' value='23130'/>
+      <enumerator name='ZFS_IOC_DESTROY_BOOKMARKS2' value='23131'/>
       <enumerator name='ZFS_IOC_PLATFORM' value='23168'/>
       <enumerator name='ZFS_IOC_EVENTS_NEXT' value='23169'/>
       <enumerator name='ZFS_IOC_EVENTS_CLEAR' value='23170'/>

--- a/lib/libzfs_core/libzfs_core.abi
+++ b/lib/libzfs_core/libzfs_core.abi
@@ -194,6 +194,7 @@
     <elf-symbol name='lzc_ddt_prune' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='lzc_destroy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='lzc_destroy_bookmarks' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='lzc_destroy_bookmarks2' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='lzc_destroy_snaps' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='lzc_exists' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='lzc_get_bookmark_props' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -2704,6 +2705,7 @@
       <enumerator name='ZFS_IOC_POOL_PREFETCH' value='23128'/>
       <enumerator name='ZFS_IOC_DDT_PRUNE' value='23129'/>
       <enumerator name='ZFS_IOC_POOL_CONDENSE' value='23130'/>
+      <enumerator name='ZFS_IOC_DESTROY_BOOKMARKS2' value='23131'/>
       <enumerator name='ZFS_IOC_PLATFORM' value='23168'/>
       <enumerator name='ZFS_IOC_EVENTS_NEXT' value='23169'/>
       <enumerator name='ZFS_IOC_EVENTS_CLEAR' value='23170'/>
@@ -4208,6 +4210,11 @@
       <return type-id='95e97e5e'/>
     </function-decl>
     <function-decl name='lzc_destroy_bookmarks' mangled-name='lzc_destroy_bookmarks' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_destroy_bookmarks'>
+      <parameter type-id='5ce45b60' name='bmarks'/>
+      <parameter type-id='857bb57e' name='errlist'/>
+      <return type-id='95e97e5e'/>
+    </function-decl>
+    <function-decl name='lzc_destroy_bookmarks2' mangled-name='lzc_destroy_bookmarks2' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='lzc_destroy_bookmarks2'>
       <parameter type-id='5ce45b60' name='bmarks'/>
       <parameter type-id='857bb57e' name='errlist'/>
       <return type-id='95e97e5e'/>

--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -1596,8 +1596,9 @@ lzc_get_bookmark_props(const char *bookmark, nvlist_t **props)
  * entry for each bookmarks that failed.  The value in the errlist will be
  * the (int32) error code.
  */
-int
-lzc_destroy_bookmarks(nvlist_t *bmarks, nvlist_t **errlist)
+static int
+lzc_destroy_bookmarks_impl(zfs_ioc_t ioc, nvlist_t *bmarks,
+    nvlist_t **errlist)
 {
 	nvpair_t *elem;
 	int error;
@@ -1610,9 +1611,28 @@ lzc_destroy_bookmarks(nvlist_t *bmarks, nvlist_t **errlist)
 	(void) strlcpy(pool, nvpair_name(elem), sizeof (pool));
 	pool[strcspn(pool, "/#")] = '\0';
 
-	error = lzc_ioctl(ZFS_IOC_DESTROY_BOOKMARKS, pool, bmarks, errlist);
+	error = lzc_ioctl(ioc, pool, bmarks, errlist);
 
 	return (error);
+}
+
+int
+lzc_destroy_bookmarks(nvlist_t *bmarks, nvlist_t **errlist)
+{
+	return (lzc_destroy_bookmarks_impl(ZFS_IOC_DESTROY_BOOKMARKS,
+	    bmarks, errlist));
+}
+
+/*
+ * Destroys bookmarks through an ioctl that guarantees kernel-side alias
+ * canonicalization and overflow-safe sync task accounting.  Callers requiring
+ * these guarantees must not retry through the legacy ioctl.
+ */
+int
+lzc_destroy_bookmarks2(nvlist_t *bmarks, nvlist_t **errlist)
+{
+	return (lzc_destroy_bookmarks_impl(ZFS_IOC_DESTROY_BOOKMARKS2,
+	    bmarks, errlist));
 }
 
 static int

--- a/man/man8/zfs-destroy.8
+++ b/man/man8/zfs-destroy.8
@@ -26,7 +26,7 @@
 .
 .Sh NAME
 .Nm zfs-destroy
-.Nd destroy ZFS dataset, snapshots, or bookmark
+.Nd destroy ZFS datasets, snapshots, or bookmarks
 .Sh SYNOPSIS
 .Nm zfs
 .Cm destroy
@@ -39,7 +39,9 @@
 .Oo % Ns Ar snap Ns Oo , Ns Ar snap Ns Oo % Ns Ar snap Oc Oc Oc Ns …
 .Nm zfs
 .Cm destroy
-.Ar filesystem Ns | Ns Ar volume Ns # Ns Ar bookmark
+.Op Fl r
+.Ar filesystem Ns | Ns Ar volume Ns # Ns Ar bookmark Ns
+.Oo , Ns Ar bookmark Oc Ns …
 .
 .Sh DESCRIPTION
 .Bl -tag -width ""
@@ -167,9 +169,34 @@ behavior for mounted file systems in use.
 .It Xo
 .Nm zfs
 .Cm destroy
-.Ar filesystem Ns | Ns Ar volume Ns # Ns Ar bookmark
+.Op Fl r
+.Ar filesystem Ns | Ns Ar volume Ns # Ns Ar bookmark Ns
+.Oo , Ns Ar bookmark Oc Ns …
 .Xc
-The given bookmark is destroyed.
+Destroys the named bookmarks.
+Multiple bookmarks from one file system or volume can be specified as a
+comma-separated list of short bookmark names.
+Repeated names are destroyed only once.
+Snapshot range syntax using
+.Sy %
+is not supported.
+.Pp
+When a comma-separated list or
+.Fl r
+is specified, bookmarks that do not exist are ignored and the command succeeds
+even if none of the requested bookmarks exist.
+A single bookmark (i.e. no comma-separated list) without
+.Fl r
+retains the legacy behavior: an error is reported and the command fails if
+the bookmark does not exist.
+.Pp
+Regardless of which form is used, any failure to destroy a bookmark other than
+an ignored nonexistent bookmark causes the command to fail.
+.Bl -tag -width "-r"
+.It Fl r
+Also destroy bookmarks with the specified names in descendant file systems
+and volumes.
+.El
 .El
 .
 .Sh EXAMPLES

--- a/module/zfs/dsl_bookmark.c
+++ b/module/zfs/dsl_bookmark.c
@@ -60,10 +60,11 @@ dsl_bookmark_hold_ds(dsl_pool_t *dp, const char *fullname,
  * Returns ESRCH if bookmark is not found.
  * Note, we need to use the ZAP rather than the AVL to look up bookmarks
  * by name, because only the ZAP honors the casesensitivity setting.
+ * On success, realname receives the stored bookmark name when non-NULL.
  */
 int
 dsl_bookmark_lookup_impl(dsl_dataset_t *ds, const char *shortname,
-    zfs_bookmark_phys_t *bmark_phys)
+    zfs_bookmark_phys_t *bmark_phys, char *realname, int realname_len)
 {
 	objset_t *mos = ds->ds_dir->dd_pool->dp_meta_objset;
 	uint64_t bmark_zapobj = ds->ds_bookmarks_obj;
@@ -83,8 +84,8 @@ dsl_bookmark_lookup_impl(dsl_dataset_t *ds, const char *shortname,
 	memset(bmark_phys, 0, sizeof (*bmark_phys));
 
 	err = zap_lookup_norm(mos, bmark_zapobj, shortname, sizeof (uint64_t),
-	    sizeof (*bmark_phys) / sizeof (uint64_t), bmark_phys, mt, NULL, 0,
-	    NULL);
+	    sizeof (*bmark_phys) / sizeof (uint64_t), bmark_phys, mt, realname,
+	    realname_len, NULL);
 
 	return (err == ENOENT ? SET_ERROR(ESRCH) : err);
 }
@@ -109,7 +110,7 @@ dsl_bookmark_lookup(dsl_pool_t *dp, const char *fullname,
 	if (error != 0)
 		return (error);
 
-	error = dsl_bookmark_lookup_impl(ds, shortname, bmp);
+	error = dsl_bookmark_lookup_impl(ds, shortname, bmp, NULL, 0);
 	if (error == 0 && later_ds != NULL) {
 		if (!dsl_dataset_is_before(later_ds, ds, bmp->zbm_creation_txg))
 			error = SET_ERROR(EXDEV);
@@ -223,7 +224,8 @@ dsl_bookmark_create_check_impl(dsl_pool_t *dp,
 		return (error);
 
 	/* Verify that the new bookmark does not already exist */
-	error = dsl_bookmark_lookup_impl(newbm_ds, newbm_short, &bmark_phys);
+	error = dsl_bookmark_lookup_impl(newbm_ds, newbm_short, &bmark_phys,
+	    NULL, 0);
 	switch (error) {
 	case ESRCH:
 		/* happy path: new bmark doesn't exist, proceed after switch */
@@ -559,7 +561,7 @@ dsl_bookmark_create_sync_impl_book(
 	 */
 
 	VERIFY0(dsl_bookmark_lookup_impl(bmark_fs_source, source_shortname,
-	    &source_phys));
+	    &source_phys, NULL, 0));
 	dsl_bookmark_node_t *new_dbn = dsl_bookmark_node_alloc(new_shortname);
 
 	memcpy(&new_dbn->dbn_phys, &source_phys, sizeof (source_phys));
@@ -876,7 +878,7 @@ dsl_bookmark_init_ds(dsl_dataset_t *ds)
 		    dsl_bookmark_node_alloc(attr->za_name);
 
 		err = dsl_bookmark_lookup_impl(ds,
-		    dbn->dbn_name, &dbn->dbn_phys);
+		    dbn->dbn_name, &dbn->dbn_phys, NULL, 0);
 		ASSERT3U(err, !=, ENOENT);
 		if (err != 0) {
 			kmem_free(dbn, sizeof (*dbn));
@@ -958,7 +960,7 @@ dsl_get_bookmark_props(const char *dsname, const char *bmname, nvlist_t *props)
 		return (err);
 	}
 
-	err = dsl_bookmark_lookup_impl(ds, bmname, &bmark_phys);
+	err = dsl_bookmark_lookup_impl(ds, bmname, &bmark_phys, NULL, 0);
 	if (err != 0)
 		goto out;
 
@@ -1087,6 +1089,7 @@ dsl_bookmark_destroy_check(void *arg, dmu_tx_t *tx)
 {
 	dsl_bookmark_destroy_arg_t *dbda = arg;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
+	boolean_t syncing = dmu_tx_is_syncing(tx);
 	int rv = 0;
 
 	ASSERT(nvlist_empty(dbda->dbda_success));
@@ -1100,6 +1103,9 @@ dsl_bookmark_destroy_check(void *arg, dmu_tx_t *tx)
 		const char *fullname = nvpair_name(pair);
 		dsl_dataset_t *ds;
 		zfs_bookmark_phys_t bm;
+		char canonical[ZFS_MAX_DATASET_NAME_LEN];
+		char *realname = NULL;
+		int realname_len = 0;
 		int error;
 		const char *shortname;
 
@@ -1110,7 +1116,22 @@ dsl_bookmark_destroy_check(void *arg, dmu_tx_t *tx)
 			continue;
 		}
 		if (error == 0) {
-			error = dsl_bookmark_lookup_impl(ds, shortname, &bm);
+			/*
+			 * Record each stored bookmark exactly once.
+			 * Resolve its name while the syncing check and sync are
+			 * protected by the configuration lock.  The unique
+			 * success nvlist then collapses case aliases.
+			 */
+			if (syncing && (dsl_dataset_phys(ds)->ds_flags &
+			    DS_FLAG_CI_DATASET) != 0) {
+				size_t prefix_len = shortname - fullname;
+
+				memcpy(canonical, fullname, prefix_len);
+				realname = canonical + prefix_len;
+				realname_len = sizeof (canonical) - prefix_len;
+			}
+			error = dsl_bookmark_lookup_impl(ds, shortname, &bm,
+			    realname, realname_len);
 			dsl_dataset_rele(ds, FTAG);
 			if (error == ESRCH) {
 				/*
@@ -1134,12 +1155,10 @@ dsl_bookmark_destroy_check(void *arg, dmu_tx_t *tx)
 				}
 			}
 		}
-		if (error == 0) {
-			if (dmu_tx_is_syncing(tx)) {
-				fnvlist_add_boolean(dbda->dbda_success,
-				    fullname);
-			}
-		} else {
+		if (error == 0 && syncing)
+			fnvlist_add_boolean(dbda->dbda_success,
+			    realname != NULL ? canonical : fullname);
+		if (error != 0) {
 			fnvlist_add_int32(dbda->dbda_errors, fullname, error);
 			rv = error;
 		}

--- a/module/zfs/dsl_bookmark.c
+++ b/module/zfs/dsl_bookmark.c
@@ -1089,6 +1089,7 @@ dsl_bookmark_destroy_check(void *arg, dmu_tx_t *tx)
 {
 	dsl_bookmark_destroy_arg_t *dbda = arg;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
+	dsl_dataset_t *held_ds = NULL;
 	boolean_t syncing = dmu_tx_is_syncing(tx);
 	int rv = 0;
 
@@ -1132,7 +1133,13 @@ dsl_bookmark_destroy_check(void *arg, dmu_tx_t *tx)
 			}
 			error = dsl_bookmark_lookup_impl(ds, shortname, &bm,
 			    realname, realname_len);
-			dsl_dataset_rele(ds, FTAG);
+			if (held_ds == ds) {
+				dsl_dataset_rele(ds, FTAG);
+			} else {
+				if (held_ds != NULL)
+					dsl_dataset_rele(held_ds, FTAG);
+				held_ds = ds;
+			}
 			if (error == ESRCH) {
 				/*
 				 * ignore it; the bookmark is
@@ -1163,6 +1170,8 @@ dsl_bookmark_destroy_check(void *arg, dmu_tx_t *tx)
 			rv = error;
 		}
 	}
+	if (held_ds != NULL)
+		dsl_dataset_rele(held_ds, FTAG);
 	return (rv);
 }
 
@@ -1172,6 +1181,7 @@ dsl_bookmark_destroy_sync(void *arg, dmu_tx_t *tx)
 	dsl_bookmark_destroy_arg_t *dbda = arg;
 	dsl_pool_t *dp = dmu_tx_pool(tx);
 	objset_t *mos = dp->dp_meta_objset;
+	dsl_dataset_t *held_ds = NULL;
 
 	for (nvpair_t *pair = nvlist_next_nvpair(dbda->dbda_success, NULL);
 	    pair != NULL; pair = nvlist_next_nvpair(dbda->dbda_success, pair)) {
@@ -1200,8 +1210,16 @@ dsl_bookmark_destroy_sync(void *arg, dmu_tx_t *tx)
 		spa_history_log_internal_ds(ds, "remove bookmark", tx,
 		    "name=%s", shortname);
 
-		dsl_dataset_rele(ds, FTAG);
+		if (held_ds == ds) {
+			dsl_dataset_rele(ds, FTAG);
+		} else {
+			if (held_ds != NULL)
+				dsl_dataset_rele(held_ds, FTAG);
+			held_ds = ds;
+		}
 	}
+	if (held_ds != NULL)
+		dsl_dataset_rele(held_ds, FTAG);
 }
 
 /*

--- a/module/zfs/dsl_dataset.c
+++ b/module/zfs/dsl_dataset.c
@@ -3573,7 +3573,7 @@ dsl_dataset_promote_check(void *arg, dmu_tx_t *tx)
 		}
 		zfs_bookmark_phys_t bm;
 		err = dsl_bookmark_lookup_impl(ddpa->ddpa_clone,
-		    dbn->dbn_name, &bm);
+		    dbn->dbn_name, &bm, NULL, 0);
 
 		if (err == 0) {
 			fnvlist_add_boolean(ddpa->err_ds, dbn->dbn_name);

--- a/module/zfs/dsl_synctask.c
+++ b/module/zfs/dsl_synctask.c
@@ -52,7 +52,7 @@ top:
 
 	dst.dst_pool = dp;
 	dst.dst_txg = dmu_tx_get_txg(tx);
-	dst.dst_space = blocks_modified << DST_AVG_BLKSHIFT;
+	dst.dst_space = (uint64_t)blocks_modified << DST_AVG_BLKSHIFT;
 	dst.dst_space_check = space_check;
 	dst.dst_checkfunc = checkfunc != NULL ? checkfunc : dsl_null_checkfunc;
 	dst.dst_syncfunc = syncfunc;

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -8090,6 +8090,12 @@ zfs_ioctl_init(void)
 	    POOL_CHECK_SUSPENDED | POOL_CHECK_READONLY, B_TRUE, B_TRUE,
 	    zfs_keys_destroy_bookmarks,
 	    ARRAY_SIZE(zfs_keys_destroy_bookmarks));
+	zfs_ioctl_register("destroy_bookmarks2", ZFS_IOC_DESTROY_BOOKMARKS2,
+	    zfs_ioc_destroy_bookmarks, zfs_secpolicy_destroy_bookmarks,
+	    POOL_NAME,
+	    POOL_CHECK_SUSPENDED | POOL_CHECK_READONLY, B_TRUE, B_TRUE,
+	    zfs_keys_destroy_bookmarks,
+	    ARRAY_SIZE(zfs_keys_destroy_bookmarks));
 
 	zfs_ioctl_register("receive", ZFS_IOC_RECV_NEW,
 	    zfs_ioc_recv_new, zfs_secpolicy_recv, DATASET_NAME,

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -234,6 +234,7 @@ tests = ['zfs_clone_livelist_condense_and_disable',
     'zfs_destroy_010_pos', 'zfs_destroy_011_pos', 'zfs_destroy_012_pos',
     'zfs_destroy_013_neg', 'zfs_destroy_014_pos', 'zfs_destroy_015_pos',
     'zfs_destroy_016_pos', 'zfs_destroy_clone_livelist',
+    'zfs_destroy_bookmarks',
     'zfs_destroy_dev_removal', 'zfs_destroy_dev_removal_condense']
 tags = ['functional', 'cli_root', 'zfs_destroy']
 

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -187,7 +187,8 @@ tests = ['zfs_001_neg', 'zfs_002_pos']
 tags = ['functional', 'cli_root', 'zfs']
 
 [tests/functional/cli_root/zfs_bookmark]
-tests = ['zfs_bookmark_cliargs', 'zfs_bookmark_recursive']
+tests = ['zfs_bookmark_cliargs', 'zfs_bookmark_destroy_lzc',
+    'zfs_bookmark_recursive']
 tags = ['functional', 'cli_root', 'zfs_bookmark']
 
 [tests/functional/cli_root/zfs_change-key]

--- a/tests/runfiles/sanity.run
+++ b/tests/runfiles/sanity.run
@@ -128,7 +128,7 @@ tests = ['zfs_destroy_002_pos', 'zfs_destroy_003_pos',
     'zfs_destroy_004_pos', 'zfs_destroy_006_neg', 'zfs_destroy_007_neg',
     'zfs_destroy_008_pos', 'zfs_destroy_009_pos', 'zfs_destroy_010_pos',
     'zfs_destroy_011_pos', 'zfs_destroy_012_pos', 'zfs_destroy_013_neg',
-    'zfs_destroy_014_pos', 'zfs_destroy_dev_removal',
+    'zfs_destroy_014_pos', 'zfs_destroy_bookmarks', 'zfs_destroy_dev_removal',
     'zfs_destroy_dev_removal_condense']
 tags = ['functional', 'cli_root', 'zfs_destroy']
 

--- a/tests/zfs-tests/cmd/.gitignore
+++ b/tests/zfs-tests/cmd/.gitignore
@@ -19,6 +19,7 @@
 /largest_file
 /libzfs_input_check
 /libzfs_mnttab_cache_check
+/lzc_destroy_bookmarks
 /manipulate_user_buffer
 /makedir
 /mkbusy

--- a/tests/zfs-tests/cmd/Makefile.am
+++ b/tests/zfs-tests/cmd/Makefile.am
@@ -66,6 +66,11 @@ scripts_zfs_tests_bin_PROGRAMS += %D%/libzfs_input_check
 	libzfs_core.la \
 	libnvpair.la
 
+scripts_zfs_tests_bin_PROGRAMS += %D%/lzc_destroy_bookmarks
+%C%_lzc_destroy_bookmarks_LDADD = \
+	libzfs_core.la \
+	libnvpair.la
+
 scripts_zfs_tests_bin_PROGRAMS += %D%/libzfs_mnttab_cache_check
 %C%_libzfs_mnttab_cache_check_LDADD = \
 	libzfs.la

--- a/tests/zfs-tests/cmd/libzfs_input_check.c
+++ b/tests/zfs-tests/cmd/libzfs_input_check.c
@@ -565,6 +565,8 @@ test_destroy_bookmarks(const char *pool, const char *bookmark)
 	fnvlist_add_boolean(required, bookmark);
 
 	IOC_INPUT_TEST_WILD(ZFS_IOC_DESTROY_BOOKMARKS, pool, required, NULL, 0);
+	IOC_INPUT_TEST_WILD(ZFS_IOC_DESTROY_BOOKMARKS2, pool, required, NULL,
+	    0);
 
 	nvlist_free(required);
 }
@@ -1216,6 +1218,7 @@ validate_ioc_values(void)
 	CHECK(ZFS_IOC_BASE + 83 == ZFS_IOC_WAIT);
 	CHECK(ZFS_IOC_BASE + 84 == ZFS_IOC_WAIT_FS);
 	CHECK(ZFS_IOC_BASE + 87 == ZFS_IOC_POOL_SCRUB);
+	CHECK(ZFS_IOC_BASE + 91 == ZFS_IOC_DESTROY_BOOKMARKS2);
 	CHECK(ZFS_IOC_PLATFORM_BASE + 1 == ZFS_IOC_EVENTS_NEXT);
 	CHECK(ZFS_IOC_PLATFORM_BASE + 2 == ZFS_IOC_EVENTS_CLEAR);
 	CHECK(ZFS_IOC_PLATFORM_BASE + 3 == ZFS_IOC_EVENTS_SEEK);

--- a/tests/zfs-tests/cmd/lzc_destroy_bookmarks.c
+++ b/tests/zfs-tests/cmd/lzc_destroy_bookmarks.c
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: CDDL-1.0
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * https://opensource.org/license/CDDL-1.0.
+ */
+
+#include <err.h>
+#include <libzfs_core.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sysexits.h>
+#include <sys/nvpair.h>
+
+int
+main(int argc, char **argv)
+{
+	int error;
+	nvlist_t *bookmarks;
+
+	if (argc < 2)
+		errx(EX_USAGE, "usage: %s bookmark ...", argv[0]);
+
+	error = libzfs_core_init();
+	if (error != 0)
+		errx(EX_OSERR, "libzfs_core_init: %s", strerror(error));
+
+	bookmarks = fnvlist_alloc();
+	for (int i = 1; i < argc; i++)
+		fnvlist_add_boolean(bookmarks, argv[i]);
+
+	error = lzc_destroy_bookmarks(bookmarks, NULL);
+	fnvlist_free(bookmarks);
+	libzfs_core_fini();
+
+	if (error != 0)
+		errx(EX_OSERR, "lzc_destroy_bookmarks: %s", strerror(error));
+
+	return (EXIT_SUCCESS);
+}

--- a/tests/zfs-tests/cmd/lzc_destroy_bookmarks.c
+++ b/tests/zfs-tests/cmd/lzc_destroy_bookmarks.c
@@ -21,25 +21,33 @@ int
 main(int argc, char **argv)
 {
 	int error;
+	int first_bookmark = 1;
 	nvlist_t *bookmarks;
+	boolean_t use_v2 = B_FALSE;
 
-	if (argc < 2)
-		errx(EX_USAGE, "usage: %s bookmark ...", argv[0]);
+	if (argc > 1 && strcmp(argv[1], "-2") == 0) {
+		use_v2 = B_TRUE;
+		first_bookmark++;
+	}
+	if (argc <= first_bookmark)
+		errx(EX_USAGE, "usage: %s [-2] bookmark ...", argv[0]);
 
 	error = libzfs_core_init();
 	if (error != 0)
 		errx(EX_OSERR, "libzfs_core_init: %s", strerror(error));
 
 	bookmarks = fnvlist_alloc();
-	for (int i = 1; i < argc; i++)
+	for (int i = first_bookmark; i < argc; i++)
 		fnvlist_add_boolean(bookmarks, argv[i]);
 
-	error = lzc_destroy_bookmarks(bookmarks, NULL);
+	error = use_v2 ? lzc_destroy_bookmarks2(bookmarks, NULL) :
+	    lzc_destroy_bookmarks(bookmarks, NULL);
 	fnvlist_free(bookmarks);
 	libzfs_core_fini();
 
 	if (error != 0)
-		errx(EX_OSERR, "lzc_destroy_bookmarks: %s", strerror(error));
+		errx(EX_OSERR, "lzc_destroy_bookmarks%s: %s", use_v2 ? "2" : "",
+		    strerror(error));
 
 	return (EXIT_SUCCESS);
 }

--- a/tests/zfs-tests/include/commands.cfg
+++ b/tests/zfs-tests/include/commands.cfg
@@ -205,6 +205,7 @@ export ZFSTEST_FILES_COMMON='badsend
     largest_file
     libzfs_mnttab_cache_check
     libzfs_input_check
+    lzc_destroy_bookmarks
     makedir
     manipulate_user_buffer
     mkbusy

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -722,6 +722,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zfs_bookmark/cleanup.ksh \
 	functional/cli_root/zfs_bookmark/setup.ksh \
 	functional/cli_root/zfs_bookmark/zfs_bookmark_cliargs.ksh \
+	functional/cli_root/zfs_bookmark/zfs_bookmark_destroy_lzc.ksh \
 	functional/cli_root/zfs_bookmark/zfs_bookmark_recursive.ksh \
 	functional/cli_root/zfs_change-key/cleanup.ksh \
 	functional/cli_root/zfs_change-key/setup.ksh \

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -804,6 +804,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zfs_destroy/zfs_destroy_014_pos.ksh \
 	functional/cli_root/zfs_destroy/zfs_destroy_015_pos.ksh \
 	functional/cli_root/zfs_destroy/zfs_destroy_016_pos.ksh \
+	functional/cli_root/zfs_destroy/zfs_destroy_bookmarks.ksh \
 	functional/cli_root/zfs_destroy/zfs_destroy_clone_livelist.ksh \
 	functional/cli_root/zfs_destroy/zfs_destroy_dev_removal_condense.ksh \
 	functional/cli_root/zfs_destroy/zfs_destroy_dev_removal.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_bookmark/zfs_bookmark_destroy_lzc.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_bookmark/zfs_bookmark_destroy_lzc.ksh
@@ -15,12 +15,13 @@
 
 #
 # DESCRIPTION:
-# lzc_destroy_bookmarks() destroys case-insensitive aliases exactly once.
+# Both destroy-bookmarks ioctls destroy case-insensitive aliases exactly once.
 #
 # STRATEGY:
 # - Create case-sensitive and case-insensitive filesystems.
 # - Destroy two distinct bookmarks from the case-sensitive filesystem.
 # - Pass two aliases of one case-insensitive bookmark in a single request.
+# - Repeat the case-insensitive request through the v2 capability ioctl.
 # - Verify each logical bookmark was destroyed exactly once.
 #
 
@@ -58,6 +59,10 @@ bookmark_must_not_exist "$SENSITIVE#MiXeD"
 
 log_must zfs bookmark "$INSENSITIVE@source" "$INSENSITIVE#MiXeD"
 log_must lzc_destroy_bookmarks "$INSENSITIVE#mixed" "$INSENSITIVE#MIXED"
+bookmark_must_not_exist "$INSENSITIVE#MiXeD"
+
+log_must zfs bookmark "$INSENSITIVE@source" "$INSENSITIVE#MiXeD"
+log_must lzc_destroy_bookmarks -2 "$INSENSITIVE#mixed" "$INSENSITIVE#MIXED"
 bookmark_must_not_exist "$INSENSITIVE#MiXeD"
 
 log_pass "lzc_destroy_bookmarks handles case-insensitive aliases"

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_bookmark/zfs_bookmark_destroy_lzc.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_bookmark/zfs_bookmark_destroy_lzc.ksh
@@ -1,0 +1,63 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# lzc_destroy_bookmarks() destroys case-insensitive aliases exactly once.
+#
+# STRATEGY:
+# - Create case-sensitive and case-insensitive filesystems.
+# - Destroy two distinct bookmarks from the case-sensitive filesystem.
+# - Pass two aliases of one case-insensitive bookmark in a single request.
+# - Verify each logical bookmark was destroyed exactly once.
+#
+
+verify_runnable "both"
+
+typeset ROOT="$TESTPOOL/${TESTFS}_bookmark_destroy_lzc"
+typeset SENSITIVE="$ROOT/sensitive"
+typeset INSENSITIVE="$ROOT/insensitive"
+
+function cleanup
+{
+	datasetexists "$ROOT" && destroy_dataset "$ROOT" "-r"
+}
+
+function bookmark_must_not_exist
+{
+	bkmarkexists "$1" && log_fail "Bookmark $1 exists"
+	return 0
+}
+
+log_assert "lzc_destroy_bookmarks handles case-insensitive aliases"
+log_onexit cleanup
+
+log_must zfs create "$ROOT"
+log_must zfs create "$SENSITIVE"
+log_must zfs create -o casesensitivity=insensitive "$INSENSITIVE"
+log_must zfs snapshot "$SENSITIVE@source"
+log_must zfs snapshot "$INSENSITIVE@source"
+
+log_must zfs bookmark "$SENSITIVE@source" "$SENSITIVE#mixed"
+log_must zfs bookmark "$SENSITIVE@source" "$SENSITIVE#MiXeD"
+log_must lzc_destroy_bookmarks "$SENSITIVE#mixed" "$SENSITIVE#MiXeD"
+bookmark_must_not_exist "$SENSITIVE#mixed"
+bookmark_must_not_exist "$SENSITIVE#MiXeD"
+
+log_must zfs bookmark "$INSENSITIVE@source" "$INSENSITIVE#MiXeD"
+log_must lzc_destroy_bookmarks "$INSENSITIVE#mixed" "$INSENSITIVE#MIXED"
+bookmark_must_not_exist "$INSENSITIVE#MiXeD"
+
+log_pass "lzc_destroy_bookmarks handles case-insensitive aliases"

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_bookmarks.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_bookmarks.ksh
@@ -173,6 +173,33 @@ bookmark_must_not_exist "$VOL#vol2"
 log_must zfs destroy -r "$VOL#vol3"
 bookmark_must_not_exist "$VOL#vol3"
 
+# Debug builds can simulate a newer userland with an older kernel before the
+# ioctl is issued.  Confirm new-style requests fail without falling back to the
+# legacy ioctl.  Production builds ignore ZFS_IOC_TEST and skip this subtest.
+typeset legacy_destroy_ioc=69
+typeset destroy_v2_ioc=91
+if is_linux; then
+	legacy_destroy_ioc=0x5a45
+	destroy_v2_ioc=0x5a5b
+fi
+log_must zfs bookmark "$ROOT@source" "$ROOT#ioc_probe"
+if env ZFS_IOC_TEST="$legacy_destroy_ioc:1029" \
+    lzc_destroy_bookmarks "$ROOT#ioc_probe" >/dev/null 2>&1; then
+	bookmark_must_not_exist "$ROOT#ioc_probe"
+else
+	bookmark_must_exist "$ROOT#ioc_probe"
+	log_must zfs destroy "$ROOT#ioc_probe"
+	log_must zfs bookmark "$ROOT@source" "$ROOT#no_fallback"
+	typeset ioc_error="$TEST_BASE_DIR/zfs_destroy_bookmarks_ioc.$$"
+	log_mustnot eval "env ZFS_IOC_TEST=$destroy_v2_ioc:1029 zfs destroy \
+	    $ROOT#no_fallback,missing >$ioc_error 2>&1"
+	log_must grep -q "loaded zfs module does not support this operation" \
+	    "$ioc_error"
+	log_must rm -f "$ioc_error"
+	bookmark_must_exist "$ROOT#no_fallback"
+	log_must zfs destroy "$ROOT#no_fallback"
+fi
+
 # New-style batch and recursive requests omit each qualified bookmark name that
 # reaches the full-name limit and therefore cannot exist.
 (( ${#ROOT} + 1 + ${#IMPOSSIBLE_NAME} == ZFS_MAX_DATASET_NAME_LEN )) ||

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_bookmarks.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_bookmarks.ksh
@@ -1,0 +1,240 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# Multiple bookmarks from one dataset can be destroyed in one command, and
+# -r applies the same bookmark names to descendant datasets.
+#
+# STRATEGY:
+# - Verify the legacy single-bookmark compatibility boundary.
+# - Verify batching, recursion, deduplication, and missing-name handling.
+# - Verify case-sensitive names stay distinct and aliases are deduplicated.
+# - Verify filesystems and volumes.
+# - Verify impossible overlong targets are omitted from new-style requests.
+# - Verify unsupported options, malformed specifications, and cross-dataset
+#   specifications destroy nothing.
+#
+
+verify_runnable "both"
+
+typeset ROOT="$TESTPOOL/${TESTFS1}_bookmark_destroy"
+typeset CHILD="$ROOT/child"
+typeset GRANDCHILD="$CHILD/grandchild"
+typeset INSENSITIVE="$ROOT/insensitive"
+typeset LATE="$ROOT/late"
+typeset VOL="$ROOT/vol"
+typeset OUTSIDE="${ROOT}_outside"
+typeset REDACT_SOURCE="$ROOT/redact_source"
+typeset REDACT_CLONE="$ROOT/redact_clone"
+typeset REDACT_ERROR="$TEST_BASE_DIR/zfs_destroy_bookmarks_redact_error.$$"
+typeset REDACT_SEND_PID=
+typeset -a DESCENDANTS=("$CHILD" "$GRANDCHILD" "$INSENSITIVE" "$VOL")
+typeset -r ZFS_MAX_DATASET_NAME_LEN=256
+typeset -r BATCH_LENGTH_NAME=length_batch
+typeset -r RECURSIVE_LENGTH_NAME=length_recursive
+typeset -r IMPOSSIBLE_NAME=$(gen_dataset_name \
+	$((ZFS_MAX_DATASET_NAME_LEN - ${#ROOT} - 1)) x)
+typeset -r OVERLONG_CHILD="$ROOT/$(gen_dataset_name \
+	$((ZFS_MAX_DATASET_NAME_LEN - ${#ROOT} - \
+	${#RECURSIVE_LENGTH_NAME} - 2)) x)"
+
+function cleanup
+{
+	if [[ -n "$REDACT_SEND_PID" ]]; then
+		kill "$REDACT_SEND_PID" 2>/dev/null
+		wait "$REDACT_SEND_PID" 2>/dev/null
+		REDACT_SEND_PID=
+	fi
+	datasetexists "$ROOT" && destroy_dataset "$ROOT" "-r"
+	datasetexists "$OUTSIDE" && destroy_dataset "$OUTSIDE" "-r"
+	[[ -e "$REDACT_ERROR" ]] && log_must rm -f "$REDACT_ERROR"
+}
+
+function bookmark_must_exist
+{
+	bkmarkexists "$1" || log_fail "Bookmark $1 does not exist"
+}
+
+function bookmark_must_not_exist
+{
+	bkmarkexists "$1" && log_fail "Bookmark $1 exists"
+	return 0
+}
+
+log_assert "zfs destroy handles multiple and recursive bookmarks"
+log_onexit cleanup
+
+log_must zfs create "$ROOT"
+log_must zfs create "$CHILD"
+log_must zfs create "$GRANDCHILD"
+log_must zfs create -o casesensitivity=insensitive "$INSENSITIVE"
+log_must zfs create -V 16M -o volmode=none "$VOL"
+log_must zfs create "$OUTSIDE"
+log_must zfs snapshot -r "$ROOT@source"
+log_must zfs snapshot "$OUTSIDE@source"
+
+# A non-recursive single bookmark retains the legacy behavior, including an
+# error for a missing bookmark.  A list or -r selects the new behavior, where
+# missing bookmarks are successful no-ops.
+log_must zfs bookmark "$ROOT@source" "$ROOT#legacy"
+log_must zfs destroy "$ROOT#legacy"
+bookmark_must_not_exist "$ROOT#legacy"
+log_mustnot zfs destroy "$ROOT#missing"
+log_must zfs destroy "$ROOT#missing1,missing2"
+log_must zfs destroy -r "$ROOT#missing"
+
+# Case-equivalent names are distinct on a sensitive dataset, but are submitted
+# only once per insensitive dataset.
+for name in mixed MiXeD; do
+	log_must zfs bookmark "$ROOT@source" "$ROOT#$name"
+done
+log_must zfs bookmark "$INSENSITIVE@source" "$INSENSITIVE#MiXeD"
+log_must zfs destroy -r "$ROOT#mixed,MiXeD"
+for name in mixed MiXeD; do
+	bookmark_must_not_exist "$ROOT#$name"
+done
+bookmark_must_not_exist "$INSENSITIVE#MiXeD"
+
+# An alias and an unrelated name remain independent on an insensitive dataset.
+for name in MiXeD FOO; do
+	log_must zfs bookmark "$INSENSITIVE@source" "$INSENSITIVE#$name"
+done
+log_must zfs destroy "$INSENSITIVE#mixed,FOO"
+bookmark_must_not_exist "$INSENSITIVE#MiXeD"
+bookmark_must_not_exist "$INSENSITIVE#FOO"
+
+# A non-recursive batch only affects the named dataset.  Duplicate names are
+# submitted once.  Recursive destroy then removes the remaining descendant
+# bookmarks, skips the late descendant, and leaves a prefix sibling alone.
+for name in one two keep; do
+	log_must zfs bookmark -r "$ROOT@source" "$ROOT#$name"
+	log_must zfs bookmark "$OUTSIDE@source" "$OUTSIDE#$name"
+done
+log_must zfs destroy "$ROOT#one,two,one"
+for name in one two; do
+	bookmark_must_not_exist "$ROOT#$name"
+	for ds in "${DESCENDANTS[@]}"; do
+		bookmark_must_exist "$ds#$name"
+	done
+done
+
+log_must zfs create "$LATE"
+log_must zfs destroy -r "$ROOT#one,two,one,missing"
+for ds in "$ROOT" "${DESCENDANTS[@]}" "$LATE"; do
+	for name in one two; do
+		bookmark_must_not_exist "$ds#$name"
+	done
+	if [[ $ds == "$LATE" ]]; then
+		bookmark_must_not_exist "$ds#keep"
+	else
+		bookmark_must_exist "$ds#keep"
+	fi
+done
+for name in one two keep; do
+	bookmark_must_exist "$OUTSIDE#$name"
+done
+
+# A recursive command with one bookmark also uses the new path.
+log_must zfs bookmark -r "$ROOT@source" "$ROOT#single_recursive"
+log_must zfs destroy -r "$ROOT#single_recursive"
+for ds in "$ROOT" "${DESCENDANTS[@]}" "$LATE"; do
+	bookmark_must_not_exist "$ds#single_recursive"
+done
+
+# Volumes accept both a list and -r; recursion has no additional effect.
+for name in vol1 vol2 vol3; do
+	log_must zfs bookmark "$VOL@source" "$VOL#$name"
+done
+log_must zfs destroy "$VOL#vol1,vol2,vol1,missing"
+bookmark_must_not_exist "$VOL#vol1"
+bookmark_must_not_exist "$VOL#vol2"
+log_must zfs destroy -r "$VOL#vol3"
+bookmark_must_not_exist "$VOL#vol3"
+
+# New-style batch and recursive requests omit each qualified bookmark name that
+# reaches the full-name limit and therefore cannot exist.
+(( ${#ROOT} + 1 + ${#IMPOSSIBLE_NAME} == ZFS_MAX_DATASET_NAME_LEN )) ||
+	log_fail "Unexpected impossible bookmark name length"
+
+log_must zfs bookmark "$ROOT@source" "$ROOT#$BATCH_LENGTH_NAME"
+log_must zfs destroy "$ROOT#$BATCH_LENGTH_NAME,$IMPOSSIBLE_NAME"
+bookmark_must_not_exist "$ROOT#$BATCH_LENGTH_NAME"
+log_must zfs destroy "$ROOT#$IMPOSSIBLE_NAME,$IMPOSSIBLE_NAME"
+
+(( ${#OVERLONG_CHILD} + 1 + ${#RECURSIVE_LENGTH_NAME} == \
+	ZFS_MAX_DATASET_NAME_LEN )) ||
+	log_fail "Unexpected recursive bookmark name length"
+log_must zfs create "$OVERLONG_CHILD"
+log_must zfs bookmark "$ROOT@source" "$ROOT#$RECURSIVE_LENGTH_NAME"
+log_must zfs destroy -r "$ROOT#$RECURSIVE_LENGTH_NAME"
+bookmark_must_not_exist "$ROOT#$RECURSIVE_LENGTH_NAME"
+
+# Unsupported, invalid, and cross-dataset forms fail before destroying any
+# bookmark.
+for name in invalid1 invalid2; do
+	log_must zfs bookmark "$ROOT@source" "$ROOT#$name"
+done
+log_must zfs bookmark "$OUTSIDE@source" "$OUTSIDE#outside"
+for ds in "$ROOT" "$CHILD"; do
+	log_must zfs bookmark "$ds@source" "$ds#reject_R"
+done
+log_mustnot zfs destroy -R "$ROOT#reject_R"
+bookmark_must_exist "$ROOT#reject_R"
+bookmark_must_exist "$CHILD#reject_R"
+log_mustnot zfs destroy "$ROOT#invalid1" "$OUTSIDE#outside"
+log_mustnot zfs destroy "$ROOT#invalid1,$OUTSIDE#outside"
+log_mustnot zfs destroy "$ROOT#invalid1%invalid2"
+log_mustnot zfs destroy "$ROOT#invalid1,,invalid2"
+log_mustnot zfs destroy "$ROOT#invalid1,."
+log_mustnot zfs destroy "$ROOT#invalid2,.."
+for name in invalid1 invalid2; do
+	bookmark_must_exist "$ROOT#$name"
+done
+bookmark_must_exist "$OUTSIDE#outside"
+
+# A busy redaction bookmark identifies the exact failing target, and the
+# otherwise valid bookmark remains because batch destruction is atomic.
+log_must zfs create "$REDACT_SOURCE"
+typeset redact_mount
+redact_mount=$(get_prop mountpoint "$REDACT_SOURCE")
+log_must dd if=/dev/urandom of="$redact_mount/data" bs=1M count=8
+log_must zfs snapshot "$REDACT_SOURCE@source"
+log_must zfs clone "$REDACT_SOURCE@source" "$REDACT_CLONE"
+log_must zfs snapshot "$REDACT_CLONE@source"
+log_must zfs redact "$REDACT_SOURCE@source" busy \
+	"$REDACT_CLONE@source"
+log_must zfs bookmark "$REDACT_SOURCE@source" "$REDACT_SOURCE#free"
+
+zfs send --redact busy "$REDACT_SOURCE@source" |&
+REDACT_SEND_PID=$!
+log_must dd bs=1 count=1 <&p >/dev/null 2>&1
+
+log_mustnot eval "zfs destroy '$REDACT_SOURCE#free,busy' \
+	>'$REDACT_ERROR' 2>&1"
+log_must grep -Fxq \
+	"cannot destroy bookmark $REDACT_SOURCE#busy: dataset is busy" \
+	"$REDACT_ERROR"
+log_must test "$(wc -l < "$REDACT_ERROR")" -eq 1
+bookmark_must_exist "$REDACT_SOURCE#busy"
+bookmark_must_exist "$REDACT_SOURCE#free"
+
+kill "$REDACT_SEND_PID" 2>/dev/null
+wait "$REDACT_SEND_PID" 2>/dev/null
+REDACT_SEND_PID=
+log_must zfs destroy "$REDACT_SOURCE#busy,free"
+log_must rm -f "$REDACT_ERROR"
+
+log_pass "zfs destroy handles multiple and recursive bookmarks"

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_bookmarks.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_bookmarks.ksh
@@ -24,6 +24,7 @@
 # - Verify case-sensitive names stay distinct and aliases are deduplicated.
 # - Verify filesystems and volumes.
 # - Verify impossible overlong targets are omitted from new-style requests.
+# - Verify a large recursive target product is accepted.
 # - Verify unsupported options, malformed specifications, and cross-dataset
 #   specifications destroy nothing.
 #
@@ -39,12 +40,18 @@ typeset VOL="$ROOT/vol"
 typeset OUTSIDE="${ROOT}_outside"
 typeset REDACT_SOURCE="$ROOT/redact_source"
 typeset REDACT_CLONE="$ROOT/redact_clone"
+typeset OVERFLOW_ROOT="$TESTPOOL2/${TESTFS1}_bookmark_destroy_overflow"
+typeset OVERFLOW_VDEV="$TEST_BASE_DIR/zfs_destroy_bookmarks_overflow.$$"
 typeset REDACT_ERROR="$TEST_BASE_DIR/zfs_destroy_bookmarks_redact_error.$$"
 typeset REDACT_SEND_PID=
 typeset -a DESCENDANTS=("$CHILD" "$GRANDCHILD" "$INSENSITIVE" "$VOL")
 typeset -r ZFS_MAX_DATASET_NAME_LEN=256
 typeset -r BATCH_LENGTH_NAME=length_batch
 typeset -r RECURSIVE_LENGTH_NAME=length_recursive
+typeset -r SYNC_TASK_SAFE_TARGETS=43690
+typeset -r OVERFLOW_DATASET_COUNT=4
+typeset -r OVERFLOW_NAME_COUNT=$((SYNC_TASK_SAFE_TARGETS / \
+	OVERFLOW_DATASET_COUNT + 1))
 typeset -r IMPOSSIBLE_NAME=$(gen_dataset_name \
 	$((ZFS_MAX_DATASET_NAME_LEN - ${#ROOT} - 1)) x)
 typeset -r OVERLONG_CHILD="$ROOT/$(gen_dataset_name \
@@ -60,6 +67,8 @@ function cleanup
 	fi
 	datasetexists "$ROOT" && destroy_dataset "$ROOT" "-r"
 	datasetexists "$OUTSIDE" && destroy_dataset "$OUTSIDE" "-r"
+	poolexists "$TESTPOOL2" && destroy_pool "$TESTPOOL2"
+	[[ -e "$OVERFLOW_VDEV" ]] && log_must rm -f "$OVERFLOW_VDEV"
 	[[ -e "$REDACT_ERROR" ]] && log_must rm -f "$REDACT_ERROR"
 }
 
@@ -181,6 +190,27 @@ log_must zfs create "$OVERLONG_CHILD"
 log_must zfs bookmark "$ROOT@source" "$ROOT#$RECURSIVE_LENGTH_NAME"
 log_must zfs destroy -r "$ROOT#$RECURSIVE_LENGTH_NAME"
 bookmark_must_not_exist "$ROOT#$RECURSIVE_LENGTH_NAME"
+
+# Recursive expansion can submit more targets than the sync-task MOS
+# reservation can represent in a signed int.  Missing bookmarks are sufficient
+# because they are submitted to the same kernel path and are successful no-ops.
+log_must truncate -s 4G "$OVERFLOW_VDEV"
+log_must zpool create "$TESTPOOL2" "$OVERFLOW_VDEV"
+log_must zfs create "$OVERFLOW_ROOT"
+for child in one two three; do
+	log_must zfs create "$OVERFLOW_ROOT/$child"
+done
+typeset overflow_names
+overflow_names=$(awk -v count="$OVERFLOW_NAME_COUNT" 'BEGIN {
+	for (i = 0; i < count; i++)
+		printf "%sb%d", (i == 0 ? "" : ","), i
+}')
+(( OVERFLOW_DATASET_COUNT * OVERFLOW_NAME_COUNT > \
+	SYNC_TASK_SAFE_TARGETS )) || log_fail "Target count is below boundary"
+log_must zfs destroy -r "$OVERFLOW_ROOT#$overflow_names"
+log_must zfs destroy -r "$OVERFLOW_ROOT"
+log_must destroy_pool "$TESTPOOL2"
+log_must rm -f "$OVERFLOW_VDEV"
 
 # Unsupported, invalid, and cross-dataset forms fail before destroying any
 # bookmark.


### PR DESCRIPTION


## Motivation and Context

- Deleting bookmarks can be unsafe and cause kernel panics.
- Deleting many bookmarks is cumbersome and slow.

## Overview

There are four parts to this PR.

- Part 1 fixes the potential for userspace to cause kernel panics when deleting bookmarks. This is an existing problem and not caused by anything in this PR.

- Part 2 adds a CLI option to delete multiple bookmarks, also recursively:

    `zfs destroy [-r] filesystem|volume#bookmark[,bookmark]...`

- Part 3 improves bookmark deletion throughput via a little trick in the kernel that reduces quadratic time to linear time for the common case. 
For example, deleting 4096 bookmarks took 42 seconds before the change vs 0.162 seconds after the change (260x speedup).

- Part 4 is to not make the new bookmark deletion CLI option available on old kernels (which don't contain the kernel panic fix from Part 1). 
Part 4 could simply be omitted if it's considered unnecessary.


### Part 1: dsl_bookmark: prevent panic when destroying case-insensitive aliases

On a case-insensitive dataset, bookmark names that differ only by case
refer to the same bookmark. For example, if pool/fs#BBB exists, then
pool/fs#bbb and pool/fs#Bbb are valid names for that bookmark.

A caller with destroy permission can panic the kernel by passing any of
those alternative spellings to lzc_destroy_bookmarks().

Before this fix, bookmark destruction honored case-insensitive name
matching only while validating the request. It then retained the
spelling supplied by the caller in dbda_success and passed that caller
spelling to dsl_bookmark_destroy_sync_impl(), which in turn calls
VERIFY0(zap_length(...)) with that name. It requires the supplied name
to be identical to the stored ZAP entry name. Otherwise zap_length()
returns an error and VERIFY0() panics the kernel.

For example, suppose pool/fs#BBB exists and the caller makes one
lzc_destroy_bookmarks() call whose input nvlist contains this key:

    pool/fs#bbb

The syncing-context call to dsl_bookmark_destroy_check() finds
pool/fs#BBB because the dataset is case-insensitive. The subsequent
VERIFY0(zap_length(...)) in dsl_bookmark_destroy_sync_impl() requires
an entry stored as bbb. Only BBB is stored, so zap_length() returns an
error and VERIFY0() panics the kernel.

Thus, that single-name lzc_destroy_bookmarks() call panics the kernel
instead of destroying the bookmark.

The same API accepts multiple bookmark names in one input nvlist.
Suppose the caller makes one lzc_destroy_bookmarks() call whose nvlist
contains:

    pool/fs#BBB
    pool/fs#bbb

The nvlist treats these as distinct keys, while case-insensitive
bookmark matching treats them as two names for the same bookmark. Both
names pass dsl_bookmark_destroy_check() validation, and the old code
schedules two destruction operations.

If BBB is processed first, it destroys the bookmark. Processing bbb next
makes VERIFY0(zap_length(...)) fail because the bookmark no longer
exists, and the kernel panics.

If bbb is processed first, VERIFY0(zap_length(...)) fails immediately
because bbb is not identical to the stored name BBB, and the kernel
panics.

Therefore, this two-name lzc_destroy_bookmarks() call panics the kernel
regardless of which nvlist entry is processed first.

This fix resolves each requested name to the bookmark’s stored spelling
during the final, syncing-context call to dsl_bookmark_destroy_check(),
then uses that spelling for the destruction worklist. A request for
bbb that resolves to the stored bookmark BBB therefore queues BBB,
allowing VERIFY0(zap_length(...)) to find the stored entry.

The worklist permits only one entry with a given name. Converting all
case variants to BBB therefore turns the two-name request above into
one destruction operation, and the bookmark is destroyed exactly once,
as expected.

The name is resolved while the pool configuration writer lock remains
held through validation and destruction. This prevents the bookmark
from being removed and recreated under a different spelling between
those steps; resolving the name in userland cannot provide that
guarantee.

Case-sensitive datasets remain unchanged: names that differ by case
still identify distinct bookmarks. Errors also remain associated with
the names supplied by the caller.

Add a libzfs_core regression helper which constructs an nvlist
containing multiple bookmark names and passes it to
lzc_destroy_bookmarks(). Test that a bookmark stored as BBB can be
destroyed by submitting bbb and Bbb in one call on a case-insensitive
dataset. Also verify that bookmarks differing only by case remain
distinct on a case-sensitive dataset.


### Part 2: zfs destroy: add option to delete multiple bookmarks, also recursively

Before this change, bookmark destruction accepted exactly one bookmark:

    zfs destroy filesystem|volume#bookmark

There was no way to destroy several bookmark names in one command or
apply the same names recursively to descendant datasets.

After this change, the syntax is:

    zfs destroy [-r] filesystem|volume#bookmark[,bookmark]...

A comma-separated list selects multiple short bookmark names on one file
system or volume. The -r option applies those names to the named
dataset and its descendant file systems and volumes. Repeated names are
destroyed only once. Snapshot range syntax using % remains
unsupported.

When a comma-separated list or -r is specified, bookmarks that do not
exist are ignored and the command succeeds even if none of the
requested bookmarks exist.

A single bookmark (i.e. no comma-separated list) without -r retains the
legacy behavior: an error is reported and the command fails if the
bookmark does not exist.

Regardless of which form is used, any failure to destroy a bookmark
other than an ignored nonexistent bookmark causes the command to fail.

Gather the fully qualified targets from the named dataset and, for -r,
its descendants, then submit them in one lzc_destroy_bookmarks
() request. Qualified names that are too long to exist are ignored.

Update the CLI help and zfs-destroy(8) documentation for the new syntax
and behavior.

Add a ZTS test covering legacy compatibility, batching, recursion,
duplicate and missing names, case sensitivity, file systems, volumes,
overlong targets, invalid specifications, and unsupported -R.


### Part 3: avoid quadratic AVL rebuilds in batch destroy

Deleting N bookmarks from one dataset rebuilds all N entries in its
bookmark AVL tree for every one of the N bookmarks. For each bookmark,
dsl_bookmark_destroy_check() acquires and releases the dataset's last
hold. Releasing that hold evicts the dsl_dataset_t and tears down its
ds_bookmarks AVL tree. Checking the next bookmark reopens the dataset,
scans the unchanged bookmark ZAP, and reconstructs all N AVL nodes.

The check phase does not delete any bookmarks, so it repeats this work N
times with N entries each. That is N * N AVL node reconstructions
before the sync phase starts. The sync callback has the same teardown
and reload problem while it deletes the bookmarks. This quadratic work
drastically slows large batched bookmark destroys.

Instead of releasing the dataset hold after checking or deleting each
bookmark, retain the first hold across consecutive bookmarks from the
same dataset. Continue to call dsl_bookmark_hold_ds() and perform the
existing lookup for every bookmark. When a new hold refers to the
retained dataset, release the duplicate hold while retaining the
original one. After acquiring a hold for another dataset, release the
previous retained hold and retain the new one. Release the final hold
before the callback returns.

This changes only the lifetime of one ordinary dataset reference. Every
bookmark still follows the existing validation and deletion path in the
original order. Each callback retains at most one dataset reference,
and no reference is shared between the check and sync phases.

With 2048 bookmarks in each of a case-sensitive parent and one child
dataset, the batched destroy of 4096 bookmarks took 0.162 seconds.
Destroying the same bookmarks individually through the legacy path took
42.019 seconds, making the batched path 260 times faster. For a batch
of 2048 bookmarks in one case-sensitive dataset, dsl_bookmark_init_ds
() was called 6146 times before this change and 5 times after it.


### How Has This Been Tested?

`zfs-tests.sh -v zfs_destroy,libzfs,zfs_property,zfs_bookmark,zfs_snapshot,snapshot,zfs_get, zfs_list`
passed on AlmaLinux-10/aarch64.

Full OpenZFS Github CI matrix passed on all platforms (except for an unrelated spurious large_dnode_009_pos failure on FreeBSD-16 which appears already fixed by https://github.com/freebsd/freebsd-src/commit/dd532ad13371dcabc07d05052a7a256fc83c6ead)

Added a series of additional functional tests to ZTS test suite,
described in detail in each individual commit msg.


### Stats

Aggregate diff line stats between first and last commit in the entire PR, including the other commits (comment/blank lines excluded):

```
+---------------------+-----------+----------+
| Category            | Additions | Removals |
+---------------------+-----------+----------+
| kernel              |        54 |       19 |
| libzfs              |        16 |        3 |
| zfs CLI             |       107 |       17 |
| headers/boilerplate |        12 |        2 |
| tests               |       304 |        2 |
| docs                |        31 |        4 |
| other               |         0 |        0 |
+---------------------+-----------+----------+
| Total               |       524 |       47 |
+---------------------+-----------+----------+
```


### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)


### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

