### PR TITLE
L2ARC: validate individual log entries during rebuild

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -11230,6 +11230,27 @@ cleanup:
 	return (err);
 }
 
+/* A log block whose payload wraps l2ad_end carries entries on both sides. */
+static boolean_t
+l2arc_log_ent_valid(l2arc_dev_t *dev, const l2arc_log_ent_phys_t *le)
+{
+	uint64_t asize = vdev_psize_to_asize(dev->l2ad_vdev,
+	    L2BLK_GET_PSIZE((le)->le_prop));
+	uint64_t start = le->le_daddr;
+	uint64_t end = start + asize - 1;
+
+	if (asize == 0 || start < dev->l2ad_start || end > dev->l2ad_end)
+		return (B_FALSE);
+
+	/* On a first sweep only the region below the write hand was written. */
+	if (dev->l2ad_first)
+		return (end < dev->l2ad_hand);
+
+	return (!l2arc_range_check_overlap(dev->l2ad_hand, dev->l2ad_evict,
+	    start) &&
+	    !l2arc_range_check_overlap(dev->l2ad_hand, dev->l2ad_evict, end));
+}
+
 /*
  * Restores the payload of a log block to ARC. This creates empty ARC hdr
  * entries which only contain an l2arc hdr, essentially restoring the
@@ -11240,7 +11261,7 @@ static void
 l2arc_log_blk_restore(l2arc_dev_t *dev, const l2arc_log_blk_phys_t *lb,
     uint64_t lb_asize)
 {
-	uint64_t	size = 0, asize = 0;
+	uint64_t	size = 0, asize = 0, bufs = 0;
 	uint64_t	log_entries = dev->l2ad_log_entries;
 
 	/*
@@ -11251,6 +11272,9 @@ l2arc_log_blk_restore(l2arc_dev_t *dev, const l2arc_log_blk_phys_t *lb,
 	arc_adapt(log_entries * HDR_L2ONLY_SIZE);
 
 	for (int i = log_entries - 1; i >= 0; i--) {
+		if (!l2arc_log_ent_valid(dev, &lb->lb_entries[i]))
+			continue;
+
 		/*
 		 * Restore goes in the reverse temporal direction to preserve
 		 * correct temporal ordering of buffers in the l2ad_buflist.
@@ -11274,6 +11298,7 @@ l2arc_log_blk_restore(l2arc_dev_t *dev, const l2arc_log_blk_phys_t *lb,
 		size += L2BLK_GET_LSIZE((&lb->lb_entries[i])->le_prop);
 		asize += vdev_psize_to_asize(dev->l2ad_vdev,
 		    L2BLK_GET_PSIZE((&lb->lb_entries[i])->le_prop));
+		bufs++;
 		l2arc_hdr_restore(&lb->lb_entries[i], dev);
 	}
 
@@ -11284,7 +11309,7 @@ l2arc_log_blk_restore(l2arc_dev_t *dev, const l2arc_log_blk_phys_t *lb,
 	 */
 	ARCSTAT_INCR(arcstat_l2_rebuild_size, size);
 	ARCSTAT_INCR(arcstat_l2_rebuild_asize, asize);
-	ARCSTAT_INCR(arcstat_l2_rebuild_bufs, log_entries);
+	ARCSTAT_INCR(arcstat_l2_rebuild_bufs, bufs);
 	ARCSTAT_F_AVG(arcstat_l2_log_blk_avg_asize, lb_asize);
 	ARCSTAT_F_AVG(arcstat_l2_data_to_meta_ratio, asize / lb_asize);
 	ARCSTAT_BUMP(arcstat_l2_rebuild_log_blks);


### PR DESCRIPTION
### Motivation and Context

A cache vdev reports 16.0E free once `vs_alloc` passes `vs_space`. #18827 fixed
half of it: it bounds a whole log block by the write hand, but a block whose
payload wraps `l2ad_end` still passes that test while carrying entries on both
sides of the wrap, and `l2arc_log_blk_restore()` restores all of them.

### Description

Restored headers go in with `list_insert_tail()`, so a straddling block's high
offsets land at the tail of `l2ad_buflist`, older in list order than the lower
offsets restored after them. `l2arc_evict()` walks from the tail and `break`s at
the first header outside the window it is clearing, which assumes the list is
ordered by device offset in the frame of the write hand. One out-of-frame header
at the tail therefore ends every eviction pass before it does any work: nothing
is decremented, `vs_alloc` climbs past `vs_space`, and the unclamped
`vs_space - vs_alloc` in `zpool_main.c` wraps.

Bound each entry by the same geometry as it is restored, and count
`l2_rebuild_bufs` from the entries actually restored.

### How Has This Been Tested?

A/B kernels differeing only with this commit.

Reproducer: 256 MiB file-backed cache vdev, wrap the write hand twice, then
`zpool remove` and `zpool add` the cache vdev — plain export/import will not set
this up, because `l2arc_add_vdev()` resetting the hand is what disables the
rebuild's loop protection. Advance the hand partway, export, import, keep
writing.

* without this commit: 306 MiB and 313 MiB allocated on a 256 MiB device on the
  first post-import write cycle (two runs), FREE wrapped to a 20-digit `uint64`
* with this commit: held at 250 MiB / 256 MiB across 30 cycles (two runs)

### Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

