### PR TITLE
FreeBSD: Do not leak TSD zfs_geom_probe_vdev_key on errors

### DIFF
--- a/module/os/freebsd/zfs/vdev_geom.c
+++ b/module/os/freebsd/zfs/vdev_geom.c
@@ -801,12 +801,6 @@ vdev_geom_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
 	uint16_t rate;
 
 	/*
-	 * Set the TLS to indicate downstack that we
-	 * should not access zvols
-	 */
-	VERIFY0(tsd_set(zfs_geom_probe_vdev_key, vd));
-
-	/*
 	 * We must have a pathname, and it must be absolute.
 	 */
 	if (vd->vdev_path == NULL || strncmp(vd->vdev_path, "/dev/", 5) != 0) {
@@ -822,6 +816,13 @@ vdev_geom_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
 		ASSERT(vd->vdev_reopening);
 		goto skip_open;
 	}
+
+	/*
+	 * Set the TLS to indicate downstack that we
+	 * should not access zvols
+	 */
+	VERIFY0(tsd_set(zfs_geom_probe_vdev_key, vd));
+
 
 	DROP_GIANT();
 	g_topology_lock();


### PR DESCRIPTION
### Motivation and Context
If there is an error early in `vdev_geom_open()`, the thread will leak `zfs_geom_probe_vdev_key`, causing every `zvol_geom_open()` in the thread to return `EOPNOTSUPP`. The purpose of `zfs_geom_probe_vdev_key` is to prevent recursion into `vdev_geom_open()`, not inhibit it permanently.

### Description
We modify `vdev_geom_open()` to set it after the error checks.

Grok 4.5 Build Beta found this bug.

### How Has This Been Tested?
It is trivial. The buildbot can test it.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
