### PR TITLE
scan: count skipped blocks as examined

### DIFF
--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -674,10 +674,12 @@ dsl_scan_init(dsl_pool_t *dp, uint64_t txg)
 		/*
 		 * We might be restarting after a reboot, so jump the issued
 		 * counter to how far we've scanned. We know we're consistent
-		 * up to here.
+		 * up to here. scn_phys is on disk, so an older version may
+		 * have left scn_skipped above scn_examined.
 		 */
-		scn->scn_issued_before_pass = scn->scn_phys.scn_examined -
-		    scn->scn_phys.scn_skipped;
+		scn->scn_issued_before_pass =
+		    scn->scn_phys.scn_examined > scn->scn_phys.scn_skipped ?
+		    scn->scn_phys.scn_examined - scn->scn_phys.scn_skipped : 0;
 
 		if (dsl_scan_is_running(scn) &&
 		    spa_prev_software_version(dp->dp_spa) < SPA_VERSION_SCAN) {
@@ -4510,8 +4512,10 @@ dsl_scan_sync(dsl_pool_t *dp, dmu_tx_t *tx)
 		 * See print_scan_scrub_resilver_status() issued/total_i
 		 * @ cmd/zpool/zpool_main.c
 		 */
-		to_issue =
-		    scn->scn_phys.scn_to_examine - scn->scn_phys.scn_skipped;
+		/* scn_to_examine is sampled once; scn_skipped keeps growing. */
+		to_issue = scn->scn_phys.scn_to_examine >
+		    scn->scn_phys.scn_skipped ? scn->scn_phys.scn_to_examine -
+		    scn->scn_phys.scn_skipped : 0;
 		issued =
 		    scn->scn_issued_before_pass + spa->spa_scan_pass_issued;
 		restart_early =
@@ -4989,6 +4993,10 @@ dsl_scan_scrub_cb(dsl_pool_t *dp,
 	count_block(dp->dp_blkstats, bp);
 	if (phys_birth <= scn->scn_phys.scn_min_txg ||
 	    phys_birth >= scn->scn_phys.scn_max_txg) {
+		/* Traversed but not scrubbed; both counters must see it. */
+		uint64_t asize = BP_GET_ASIZE(bp);
+		scn->scn_phys.scn_examined += asize;
+		spa->spa_scan_pass_exam += asize;
 		count_block_skipped(scn, bp, B_TRUE);
 		return (0);
 	}


### PR DESCRIPTION
### Motivation and Context

Fixes #17990: after an interrupted scrub is resumed, `zpool status` reports
16.0E issued and a percentage in the hundreds of millions.

It is not only cosmetic. `scn_issued_before_pass` also feeds the deferred
resilver decision in `dsl_scan_sync()`, where a wrapped `issued` never falls
below `zfs_resilver_defer_percent`, so a resilver that should restart early
stays deferred instead.

### Description

`dsl_scan_scrub_cb()` hands a block outside the scan's txg range to
`count_block_skipped()` and returns before `scn_examined` is touched. The skip
is correct: for a scrub `scn_max_txg` is the txg the scrub started in, so those
blocks were written afterwards and are not part of the scan. But they land in
`scn_skipped` and nowhere else, so when `dsl_scan_init()` resumes with
`scn_examined - scn_skipped` the two `uint64_t`s no longer cover the same
blocks and the subtraction wraps.

Count those blocks as examined as well as skipped, restoring the invariant.
The other skip sites already satisfy it.

Two clamps remain for what the invariant cannot reach. `scn_phys` is on disk,
so a pool last written by an older version can arrive already skewed and an
assertion would panic on import. `scn_to_examine - scn_skipped` wraps the same
way, since `scn_to_examine` is sampled once at scan start.

This makes `scanned` include blocks that were traversed but not scrubbed, which
seems more accurate and matches the no-io path, but it is user visible, so say
the word and I will clamp only.

### How Has This Been Tested?

A/B on FreeBSD 16.0-CURRENT with two GENERIC kernels differing only by this
commit. Reproducer: scrub a 512 MiB file-backed pool while writing to it, held
open with `zfs_scan_suspend_progress` and amplified with `zfs_no_scrub_io`,
then export and import.

| build | examined | skipped | issued |
|---|---|---|---|
| without this commit | 537341952 | 537403392 | 18446744073709490176 |
| with this commit | 537395200 | 537395200 | 0 |

Without the fix `examined` falls 61440 bytes short of `skipped`, and the
reported `issued` is exactly 2^64 - 61440.

### Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).