### PR TITLE
Inherit the project ID for every object type, and allow same-directory renames

### DIFF
--- a/module/os/freebsd/zfs/zfs_vnops_os.c
+++ b/module/os/freebsd/zfs/zfs_vnops_os.c
@@ -1107,8 +1107,7 @@ zfs_create(znode_t *dzp, const char *name, vattr_t *vap, int excl, int mode,
 	    cr, vsecp, &acl_ids)) != 0)
 		goto out;
 
-	if (S_ISREG(vap->va_mode) || S_ISDIR(vap->va_mode))
-		projid = zfs_inherit_projid(dzp);
+	projid = zfs_inherit_projid(dzp);
 	if (zfs_acl_ids_overquota(zfsvfs, &acl_ids, projid)) {
 		zfs_acl_ids_free(&acl_ids);
 		error = SET_ERROR(EDQUOT);
@@ -3651,7 +3650,7 @@ zfs_symlink(znode_t *dzp, const char *name, vattr_t *vap,
 		return (error);
 	}
 
-	if (zfs_acl_ids_overquota(zfsvfs, &acl_ids, ZFS_DEFAULT_PROJID)) {
+	if (zfs_acl_ids_overquota(zfsvfs, &acl_ids, zfs_inherit_projid(dzp))) {
 		zfs_acl_ids_free(&acl_ids);
 		zfs_exit(zfsvfs, FTAG);
 		return (SET_ERROR(EDQUOT));

--- a/module/os/freebsd/zfs/zfs_vnops_os.c
+++ b/module/os/freebsd/zfs/zfs_vnops_os.c
@@ -3377,8 +3377,16 @@ zfs_do_rename_impl(vnode_t *sdvp, vnode_t **svpp, struct componentname *scnp,
 	 * not only the project ID, but also the ZFS_PROJINHERIT flag. Under
 	 * such case, we only allow renames into our tree when the project
 	 * IDs are the same.
+	 *
+	 * A rename within a single directory leaves the object exactly where
+	 * it already is, so it cannot move it between projects and is always
+	 * allowed.  Objects created before symlinks and other non-regular
+	 * files began inheriting a project ID carry none of their own, and
+	 * would otherwise not be renameable within the very directory that
+	 * holds them -- which breaks "ln -sfn", implemented as
+	 * create-under-a-temporary-name-then-rename.
 	 */
-	if (tdzp->z_pflags & ZFS_PROJINHERIT &&
+	if (sdzp != tdzp && tdzp->z_pflags & ZFS_PROJINHERIT &&
 	    tdzp->z_projid != szp->z_projid) {
 		error = SET_ERROR(EXDEV);
 		goto out;

--- a/module/os/freebsd/zfs/zfs_znode_os.c
+++ b/module/os/freebsd/zfs/zfs_znode_os.c
@@ -672,22 +672,28 @@ zfs_mknode(znode_t *dzp, vattr_t *vap, dmu_tx_t *tx, cred_t *cr,
 	if (flag & IS_XATTR)
 		pflags |= ZFS_XATTR;
 
-	if (vap->va_type == VREG || vap->va_type == VDIR) {
-		/*
-		 * With ZFS_PROJID flag, we can easily know whether there is
-		 * project ID stored on disk or not. See zpl_get_file_info().
-		 */
-		if (obj_type != DMU_OT_ZNODE &&
-		    dmu_objset_projectquota_enabled(zfsvfs->z_os))
-			pflags |= ZFS_PROJID;
+	/*
+	 * With ZFS_PROJID flag, we can easily know whether there is
+	 * project ID stored on disk or not. See zpl_get_file_info().
+	 */
+	if (obj_type != DMU_OT_ZNODE &&
+	    dmu_objset_projectquota_enabled(zfsvfs->z_os))
+		pflags |= ZFS_PROJID;
 
-		/*
-		 * Inherit project ID from parent if required.
-		 */
-		projid = zfs_inherit_projid(dzp);
-		if (dzp_pflags & ZFS_PROJINHERIT)
-			pflags |= ZFS_PROJINHERIT;
-	}
+	/*
+	 * Inherit project ID from parent if required.  Every object type
+	 * takes part, as ext4 and XFS do: an object that carried no project
+	 * ID of its own would be treated as belonging to a different project
+	 * than the directory holding it, so zfs_rename() and zfs_link()
+	 * would refuse it with EXDEV even within its own project.
+	 *
+	 * The ZFS_PROJINHERIT flag itself keeps passing to regular files and
+	 * directories only, as before, so that lsattr(1) output is unchanged.
+	 */
+	projid = zfs_inherit_projid(dzp);
+	if ((vap->va_type == VREG || vap->va_type == VDIR) &&
+	    (dzp_pflags & ZFS_PROJINHERIT))
+		pflags |= ZFS_PROJINHERIT;
 
 	/*
 	 * No execs denied will be determined when zfs_mode_compute() is called.

--- a/module/os/linux/zfs/zfs_vnops_os.c
+++ b/module/os/linux/zfs/zfs_vnops_os.c
@@ -725,8 +725,7 @@ top:
 			goto out;
 		have_acl = B_TRUE;
 
-		if (S_ISREG(vap->va_mode) || S_ISDIR(vap->va_mode))
-			projid = zfs_inherit_projid(dzp);
+		projid = zfs_inherit_projid(dzp);
 		if (zfs_acl_ids_overquota(zfsvfs, &acl_ids, projid)) {
 			zfs_acl_ids_free(&acl_ids);
 			error = SET_ERROR(EDQUOT);
@@ -925,8 +924,7 @@ top:
 		goto out;
 	have_acl = B_TRUE;
 
-	if (S_ISREG(vap->va_mode) || S_ISDIR(vap->va_mode))
-		projid = zfs_inherit_projid(dzp);
+	projid = zfs_inherit_projid(dzp);
 	if (zfs_acl_ids_overquota(zfsvfs, &acl_ids, projid)) {
 		zfs_acl_ids_free(&acl_ids);
 		error = SET_ERROR(EDQUOT);
@@ -3068,11 +3066,8 @@ top:
 
 	/* Set up inode creation for RENAME_WHITEOUT. */
 	if (rflags & RENAME_WHITEOUT) {
-		/*
-		 * Whiteout files are not regular files or directories, so to
-		 * match zfs_create() we do not inherit the project id.
-		 */
-		uint64_t wo_projid = ZFS_DEFAULT_PROJID;
+		/* Match zfs_create(): the whiteout joins its directory. */
+		uint64_t wo_projid = zfs_inherit_projid(sdzp);
 
 		error = zfs_zaccess_idmap(sdzp, ACE_ADD_FILE, 0, B_FALSE,
 		    cr, idmap);
@@ -3409,7 +3404,7 @@ top:
 		return (error);
 	}
 
-	if (zfs_acl_ids_overquota(zfsvfs, &acl_ids, ZFS_DEFAULT_PROJID)) {
+	if (zfs_acl_ids_overquota(zfsvfs, &acl_ids, zfs_inherit_projid(dzp))) {
 		zfs_acl_ids_free(&acl_ids);
 		zfs_dirent_unlock(dl);
 		zfs_exit(zfsvfs, FTAG);

--- a/module/os/linux/zfs/zfs_vnops_os.c
+++ b/module/os/linux/zfs/zfs_vnops_os.c
@@ -3004,8 +3004,16 @@ top:
 	 * not only the project ID, but also the ZFS_PROJINHERIT flag. Under
 	 * such case, we only allow renames into our tree when the project
 	 * IDs are the same.
+	 *
+	 * A rename within a single directory leaves the object exactly where
+	 * it already is, so it cannot move it between projects and is always
+	 * allowed.  Objects created before symlinks and other non-regular
+	 * files began inheriting a project ID carry none of their own, and
+	 * would otherwise not be renameable within the very directory that
+	 * holds them -- which breaks "ln -sfn", implemented as
+	 * create-under-a-temporary-name-then-rename.
 	 */
-	if (tdzp->z_pflags & ZFS_PROJINHERIT &&
+	if (sdzp != tdzp && tdzp->z_pflags & ZFS_PROJINHERIT &&
 	    tdzp->z_projid != szp->z_projid) {
 		error = SET_ERROR(EXDEV);
 		goto out;

--- a/module/os/linux/zfs/zfs_znode_os.c
+++ b/module/os/linux/zfs/zfs_znode_os.c
@@ -782,22 +782,28 @@ zfs_mknode(znode_t *dzp, vattr_t *vap, dmu_tx_t *tx, cred_t *cr,
 	if (flag & IS_XATTR)
 		pflags |= ZFS_XATTR;
 
-	if (S_ISREG(vap->va_mode) || S_ISDIR(vap->va_mode)) {
-		/*
-		 * With ZFS_PROJID flag, we can easily know whether there is
-		 * project ID stored on disk or not. See zpl_get_file_info().
-		 */
-		if (obj_type != DMU_OT_ZNODE &&
-		    dmu_objset_projectquota_enabled(zfsvfs->z_os))
-			pflags |= ZFS_PROJID;
+	/*
+	 * With ZFS_PROJID flag, we can easily know whether there is
+	 * project ID stored on disk or not. See zpl_get_file_info().
+	 */
+	if (obj_type != DMU_OT_ZNODE &&
+	    dmu_objset_projectquota_enabled(zfsvfs->z_os))
+		pflags |= ZFS_PROJID;
 
-		/*
-		 * Inherit project ID from parent if required.
-		 */
-		projid = zfs_inherit_projid(dzp);
-		if (dzp->z_pflags & ZFS_PROJINHERIT)
-			pflags |= ZFS_PROJINHERIT;
-	}
+	/*
+	 * Inherit project ID from parent if required.  Every object type
+	 * takes part, as ext4 and XFS do: an object that carried no project
+	 * ID of its own would be treated as belonging to a different project
+	 * than the directory holding it, so zfs_rename() and zfs_link()
+	 * would refuse it with EXDEV even within its own project.
+	 *
+	 * The ZFS_PROJINHERIT flag itself keeps passing to regular files and
+	 * directories only, as before, so that lsattr(1) output is unchanged.
+	 */
+	projid = zfs_inherit_projid(dzp);
+	if ((S_ISREG(vap->va_mode) || S_ISDIR(vap->va_mode)) &&
+	    (dzp->z_pflags & ZFS_PROJINHERIT))
+		pflags |= ZFS_PROJINHERIT;
 
 	/*
 	 * No execs denied will be determined when zfs_mode_compute() is called.

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -186,6 +186,7 @@ tags = ['functional', 'procfs']
 [tests/functional/projectquota:Linux]
 tests = ['defaultprojectquota_001_pos', 'defaultprojectquota_005_pos',
     'projectid_001_pos', 'projectid_002_pos', 'projectid_003_pos',
+    'projectid_004_pos',
     'projectquota_001_pos', 'projectquota_003_pos', 'projectquota_006_pos',
     'projectspace_001_pos', 'projectspace_002_pos', 'projectspace_003_pos',
     'projectspace_004_pos', 'projectspace_005_pos', 'projecttree_001_pos']

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1920,6 +1920,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/projectquota/projectid_001_pos.ksh \
 	functional/projectquota/projectid_002_pos.ksh \
 	functional/projectquota/projectid_003_pos.ksh \
+	functional/projectquota/projectid_004_pos.ksh \
 	functional/projectquota/projectquota_001_pos.ksh \
 	functional/projectquota/projectquota_002_pos.ksh \
 	functional/projectquota/projectquota_003_pos.ksh \

--- a/tests/zfs-tests/tests/functional/projectquota/projectid_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/projectquota/projectid_004_pos.ksh
@@ -1,0 +1,139 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
+#
+
+#
+# Copyright (c) 2026 by Matt Turner. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/projectquota/projectquota_common.kshlib
+
+#
+# DESCRIPTION:
+#	Every object type inherits the project ID, and renaming within a
+#	project directory is always allowed
+#
+#
+# STRATEGY:
+#	1. Create a regular file and a symlink in a directory, then set the
+#	   directory's project ID with the inherit flag, leaving the two
+#	   objects carrying no project ID of their own
+#	2. Rename each of them within that directory, which has to be allowed
+#	   whatever project ID they carry
+#	3. Rename a regular file and a symlink created after the directory was
+#	   tagged, and replace a symlink with "ln -sfn", which creates the new
+#	   symlink under a temporary name and renames it into place
+#	4. Check that a new symlink and a new FIFO are accounted to the
+#	   directory's project, which they only are if they inherited its
+#	   project ID
+#	5. Rename a symlink into a different directory carrying the same
+#	   project ID, which rename(2) only permits if the symlink carries
+#	   that project ID too
+#	6. Check that a rename into a different project is still refused,
+#	   and that a symlink carrying no project ID cannot be renamed into
+#	   one, which shows the check in step 5 is reached and enforced
+#
+
+function cleanup
+{
+	log_must rm -rf $PRJDIR1 $PRJDIR2 $PRJDIR3 $TESTDIR/tlink6
+}
+
+if ! lsattr -pd > /dev/null 2>&1; then
+	log_unsupported "Current e2fsprogs does not support set/show project ID"
+fi
+
+# renameat2(1) is used throughout rather than mv(1), which falls back to
+# copying on EXDEV and would report success either way.
+if ! renameat2 -C; then
+	log_unsupported "renameat2 not supported on this (pre-3.15) linux kernel"
+fi
+
+log_onexit cleanup
+
+log_assert "Every object type inherits the project ID, and renaming within" \
+    "a project directory is always allowed"
+
+log_must mkdir $PRJDIR1
+
+#
+# Objects created before the directory was tagged carry no project ID of
+# their own, as every symlink on an existing pool does. This is the case
+# the same-directory exemption exists for: renaming within one directory
+# cannot move an object between projects, so it has to be allowed whatever
+# project ID the object carries -- including none at all.
+#
+log_must touch $PRJDIR1/tofile1
+log_must ln -s target $PRJDIR1/tolink1
+
+log_must chattr +P -p $PRJID1 $PRJDIR1
+
+log_must renameat2 $PRJDIR1/tofile1 $PRJDIR1/tofile2
+log_must renameat2 $PRJDIR1/tolink1 $PRJDIR1/tolink2
+
+# Objects created after the directory was tagged inherit its project ID, and
+# renaming those within it has to keep working too.
+log_must touch $PRJDIR1/tfile1
+log_must renameat2 $PRJDIR1/tfile1 $PRJDIR1/tfile2
+
+log_must ln -s target $PRJDIR1/tlink1
+log_must renameat2 $PRJDIR1/tlink1 $PRJDIR1/tlink2
+
+log_must ln -sfn other $PRJDIR1/tlink2
+log_must eval '[[ $(readlink $PRJDIR1/tlink2) == other ]]'
+
+# A subdirectory inherits both the project ID and the inherit flag, so it
+# has to behave the same way.
+log_must mkdir $PRJDIR1/subdir
+log_must ln -s target $PRJDIR1/subdir/tlink3
+log_must renameat2 $PRJDIR1/subdir/tlink3 $PRJDIR1/subdir/tlink4
+
+#
+# A symlink and a FIFO are not regular files or directories, and used to be
+# left at the default project ID. Creating one now adds an object to the
+# directory's project.
+#
+sync_pool
+typeset prj_bef=$(project_obj_count $QFS $PRJID1)
+
+log_must ln -s target $PRJDIR1/tlink5
+log_must mkfifo $PRJDIR1/tfifo1
+
+sync_pool
+typeset prj_aft=$(project_obj_count $QFS $PRJID1)
+
+[[ $prj_aft -eq $((prj_bef + 2)) ]] ||
+	log_fail "new value ($prj_aft) is NOT 2 larger than old one ($prj_bef)"
+
+#
+# rename(2) into a different directory is allowed only when the project IDs
+# match, so this passes only if the symlink really did inherit one.
+#
+log_must mkdir $PRJDIR2
+log_must chattr +P -p $PRJID1 $PRJDIR2
+log_must renameat2 $PRJDIR1/tlink5 $PRJDIR2/tlink5
+
+# Crossing into a different project is still refused.
+log_must mkdir $PRJDIR3
+log_must chattr +P -p $PRJID2 $PRJDIR3
+log_mustnot renameat2 $PRJDIR2/tlink5 $PRJDIR3/tlink5
+
+# And a symlink created outside any project carries no project ID, so it
+# cannot be renamed into one. This is what makes the check above meaningful:
+# it shows the cross-project test is reached and enforced, so the rename that
+# succeeded did so because the symlink had inherited a project ID.
+log_must ln -s target $TESTDIR/tlink6
+log_mustnot renameat2 $TESTDIR/tlink6 $PRJDIR1/tlink6
+log_must rm -f $TESTDIR/tlink6
+
+log_pass "Every object type inherits the project ID, and renaming within" \
+    "a project directory is always allowed"


### PR DESCRIPTION
### Motivation and Context

`ln -sfn` fails with `EXDEV` inside a directory that carries a project ID with
`ZFS_PROJINHERIT` set, and so does any program that renames a symlink into
place. On Gentoo this breaks `dosym` over an existing path, which is enough to
stop `sys-apps/portage` from installing `/usr/bin/ebuild` when the build
directory is tagged for project-quota accounting.

There are two causes.

`zfs_mknode()` only assigned a project ID to regular files and directories, so
a symlink, device node, FIFO or socket created inside such a directory was left
at `ZFS_DEFAULT_PROJID`. The cross-project checks in `zfs_rename()` and
`zfs_link()` compare the object's project ID against the directory's, so the
object reads as foreign to the very directory holding it. ext4 and XFS store a
project ID on every inode type and do not have this problem.

Separately, `zfs_rename()` applied that check even when the source and target
directories are the same. A rename within one directory cannot move an object
between projects, so refusing it is never right. This is what makes the bug
reachable on existing pools, where symlinks already on disk carry no project ID
of their own.

<!-- Link an issue here if one exists. -->

### Description

1. **Inherit the project ID for every object type.** `zfs_mknode()` now calls
   `zfs_inherit_projid()` for all object types, and new symlinks and rename
   whiteouts are quota-checked against the inherited ID rather than the default
   one, so their space is accounted to the project that owns them. The
   `ZFS_PROJINHERIT` flag itself still propagates to regular files and
   directories only, so `lsattr(1)` output is unchanged. Linux and FreeBSD both.

2. **Allow renames within a single directory.** `zfs_rename()` skips the
   cross-project check when `sdzp == tdzp`. Linux and FreeBSD both.

3. **ZTS coverage** in `projectid_004_pos`.

Two things worth reviewers' attention:

- **This changes accounting for newly created objects.** Symlinks, device nodes
  and FIFOs now consume the project's quota where they previously consumed
  none, so on a dataset already at its project quota, creating one begins to
  fail with `EDQUOT` where it used to succeed. The space involved is small, but
  the change in behavior is visible.

- **`zfs_link()` keeps its unconditional check.** It has no source directory to
  compare against, so there is no equivalent "the object is already here" case
  to exempt. Linking a pre-existing symlink, device node or FIFO into the
  project directory that already holds it therefore still fails with `EXDEV`,
  until the object is given a project ID of its own. Happy to revisit if
  reviewers would rather see that addressed here.

Only newly created objects are covered; objects already on disk keep the
default project ID.

### How Has This Been Tested?

ZTS `projectquota` group on Linux (x86_64, 6.18 kernel, file vdevs): **32
passed, 0 failed**, including the new `projectid_004_pos`.

The new test is written so that it fails without change 1 rather than passing
on change 2 alone. It asserts that a new symlink and a new FIFO each add an
object to the containing directory's project, and that a symlink can then be
renamed into a *different* directory carrying the same project ID, which
`rename(2)` permits only when the two project IDs match. It uses `renameat2(1)`
rather than `mv(1)`, which falls back to copying on `EXDEV` and would report
success either way. A negative control — a symlink created outside any project
cannot be renamed into one — shows the cross-project check is reached and
enforced, so the rename that succeeds does so because inheritance happened.

Also verified end to end on the original reproducer: with the change applied,
`FEATURES=diskquota` merges of `sys-apps/portage` complete, including the
`dosym` over `/usr/bin/ebuild` that previously failed.

Caveats on my testing:

- The kernel changes were exercised on a Linux module built from these changes
  backported onto the 2.4.3 release tag; the Linux sources are identical to
  this branch, but I have not booted a master-based module.
- The FreeBSD changes are by inspection only — I have no FreeBSD build here and
  am relying on CI for them.

### Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by)
