### PR TITLE
ZTS: Do not run rm -rf / when $TESTPOOL is empty

### DIFF
--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -262,6 +262,10 @@ function default_setup_noexit
 	typeset no_mountpoint=$4
 	log_note begin default_setup_noexit
 
+	if [[ "/${TESTPOOL}" -ef / ]]; then
+		log_fail "TESTPOOL is not set"
+	fi
+
 	if is_global_zone; then
 		if poolexists $TESTPOOL ; then
 			destroy_pool $TESTPOOL
@@ -464,6 +468,10 @@ function default_mirror_setup_noexit
 	typeset primary=$1
 	typeset secondary=$2
 
+	if [[ "/${TESTPOOL}" -ef / ]]; then
+		log_fail "TESTPOOL is not set"
+	fi
+
 	[[ -z $primary ]] && \
 		log_fail "$func: No parameters passed"
 	[[ -z $secondary ]] && \
@@ -500,6 +508,10 @@ function default_raidz_setup_noexit
 {
 	typeset disklist="$*"
 	disks=(${disklist[*]})
+
+	if [[ "/${TESTPOOL}" -ef / ]]; then
+		log_fail "TESTPOOL is not set"
+	fi
 
 	if [[ ${#disks[*]} -lt 2 ]]; then
 		log_fail "A raid-z requires a minimum of two disks."


### PR DESCRIPTION
### Motivation and Context
Grok accidentally did this to itself in a cloud development environment. Let us learn from its goof.

### Description
We call log_fail if /$TESTPOOL resolves to /, before any statements that would become `rm -rf /`. This covers TESTPOOL being empty and other variations, such as TESTPOOL=/. In these cases, rm implementations that implement --no-preserve-root such as GNU coreutils 9.1 and later, will not save us.

Grok 4.5 Build Beta found this bug.

### How Has This Been Tested?
It has been A/B tested in a cloud environment where the patch prevented the loss of the filesystem and the absence of the patch lead to the loss of the filesystem, when TESTPOOL was empty.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
