### PR TITLE
zgenhostid: seed the generated hostid from the system CSPRNG

### DIFF
--- a/cmd/zgenhostid.c
+++ b/cmd/zgenhostid.c
@@ -24,8 +24,38 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
-#include <time.h>
 #include <unistd.h>
+
+/*
+ * Fill buf with len bytes from the system CSPRNG.  Returns 0 on success
+ * and -1 on failure, with errno set.
+ */
+static int
+get_random_bytes(void *buf, size_t len)
+{
+	int fd = open("/dev/urandom", O_RDONLY | O_CLOEXEC);
+	if (fd < 0)
+		return (-1);
+
+	size_t got = 0;
+	while (got < len) {
+		ssize_t n = read(fd, (char *)buf + got, len - got);
+		if (n <= 0) {
+			if (n < 0 && errno == EINTR)
+				continue;
+			if (n == 0)
+				errno = EIO;
+			int saved = errno;
+			(void) close(fd);
+			errno = saved;
+			return (-1);
+		}
+		got += (size_t)n;
+	}
+
+	(void) close(fd);
+	return (0);
+}
 
 static __attribute__((noreturn)) void
 usage(void)
@@ -49,7 +79,7 @@ main(int argc, char **argv)
 {
 	/* default file path, can be optionally set by user */
 	const char *path = "/etc/hostid";
-	/* holds converted user input or lrand48() generated value */
+	/* holds converted user input or generated value */
 	unsigned long input_i = 0;
 
 	int opt;
@@ -102,12 +132,24 @@ main(int argc, char **argv)
 	}
 
 	/*
-	 * generate if not provided by user
-	 * also handle unlikely zero return from lrand48()
+	 * Generate if not provided by user. The hostid identifies
+	 * this machine to ZFS multihost protection, so it must be
+	 * unique. Obtain a value from the system CSPRNG to ensure
+	 * that even on systems that share a common image and boot
+	 * deterministically different hostids will be generated.
+	 * The loop handles the unlikely zero return case.
 	 */
 	while (input_i == 0) {
-		srand48(getpid() ^ time(NULL));
-		input_i = lrand48();
+		uint32_t rnd;
+
+		if (get_random_bytes(&rnd, sizeof (rnd)) != 0) {
+			(void) fprintf(stderr,
+			    "zgenhostid: failed to read /dev/urandom: %s\n",
+			    strerror(errno));
+			exit(EXIT_FAILURE);
+		}
+
+		input_i = rnd;
 	}
 
 	FILE *fp = fopen(path, "wb");


### PR DESCRIPTION
### Motivation and Context

When no value is given on the command line, `zgenhostid` generates one with:

```c
srand48(getpid() ^ time(NULL));
input_i = lrand48();
```

Neither input is reliably unpredictable at the point this actually runs, which is usually early in an unattended install (`truenas-installer`, for example, calls `zgenhostid` as its first install step when `/etc/hostid` is absent):

* **`time(NULL)` is often a constant.** On a machine with no usable RTC the clock has not yet been set from the network, and systemd has already advanced it to the fixed epoch compiled into the image. Every machine booting that image reaches the installer with the same wall clock.
* **`getpid()` is often the same too.** The PID reached at that point is a function of the boot sequence, which is identical for the same image on comparable hardware.

Two independent installs can therefore derive the same seed and write **byte-identical hostids**, which defeats the multihost protection the hostid exists to provide. This is not theoretical — we hit it in the field, where two unrelated machines installed from the same image ended up sharing a hostid.

The construction is also trivially invertible. `lrand48()` is a 48-bit LCG whose low 16 bits after `srand48()` are fixed, so a hostid can be mapped back to its seed in constant time, and in the situation above the reachable seed space is only a few thousand values rather than 2^32.

### Description

Read four bytes from `/dev/urandom` and use them directly.

On failure the command now exits with an error instead of falling back to the old construction: a silent fallback to a predictable source would reintroduce exactly the problem this is meant to avoid, and `/dev/urandom` being unavailable is worth surfacing when generating a machine identity.

Explicit user-supplied values, `-f`, and `-o` are unaffected. `<time.h>` is no longer needed and is dropped.

One visible behaviour change: generated hostids now cover the full 32-bit range. `lrand48()` returns 31 bits, so previously no generated hostid ever had the high bit set.

### How Has This Been Tested?

Reproduction of the original bug, on Proxmox 9.2 with the RTC forced to a past date (`--startdate 2018-01-01T00:00:00`) to simulate hardware with no working clock:

* Two VMs created with identical virtual hardware, installed unattended from the same image, driven over the serial console with identical timing, both produced **the same `/etc/hostid`**.
* In the live installer both showed `RTC time: 2018-01-01` alongside a system clock advanced to the image's fixed epoch, with `System clock synchronized: no`.
* A third VM given deliberately different hardware (different CPU/RAM/machine type/HBA/NIC/disks) booted a few seconds slower and landed on a different value — a timing shift, not additional entropy.

With this patch applied:

* Repeated runs produce unrelated values.
* An explicit argument is still honoured exactly (`0x5eb04b77` → `77 4b b0 5e`, native byte order preserved).
* Overwrite protection still applies without `-f`.
* Over 200 generated samples, 103 had the high bit set, consistent with a uniform 32-bit draw; the previous code would have produced 0.
* `scripts/cstyle.pl cmd/zgenhostid.c` is clean.

### Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

Notes on the unchecked boxes:

* **Documentation** — no change appeared necessary; `zgenhostid.8` only describes the value as randomly generated, which remains accurate.
* **Tests** — there is currently no `zgenhostid` coverage in the test suite to extend. Happy to add a `cli_root/zgenhostid` case (generation is non-zero and varies across runs, explicit values round-trip, `-f`/`-o` behaviour) if maintainers would like that in this PR.
* **Full test suite** — not run; this change is confined to a standalone userland command with no kernel or library surface. The functional checks above were run against a build of the patched command.
