### PR TITLE
ztest: remove ztest_mmp_enable_disable()

### DIFF
--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -419,7 +419,6 @@ ztest_func_t ztest_spa_prop_get_set;
 ztest_func_t ztest_spa_create_destroy;
 ztest_func_t ztest_fault_inject;
 ztest_func_t ztest_dmu_snapshot_hold;
-ztest_func_t ztest_mmp_enable_disable;
 ztest_func_t ztest_scrub;
 ztest_func_t ztest_dsl_dataset_promote_busy;
 ztest_func_t ztest_vdev_attach_detach;
@@ -479,7 +478,6 @@ static ztest_info_t ztest_info[] = {
 	ZTI_INIT(ztest_spa_create_destroy, 1, &zopt_sometimes),
 	ZTI_INIT(ztest_fault_inject, 1, &zopt_sometimes),
 	ZTI_INIT(ztest_dmu_snapshot_hold, 1, &zopt_sometimes),
-	ZTI_INIT(ztest_mmp_enable_disable, 1, &zopt_sometimes),
 	ZTI_INIT(ztest_reguid, 1, &zopt_rarely),
 	ZTI_INIT(ztest_scrub, 1, &zopt_rarely),
 	ZTI_INIT(ztest_spa_upgrade, 1, &zopt_rarely),
@@ -3074,56 +3072,6 @@ ztest_spa_create_destroy(ztest_ds_t *zd, uint64_t id)
 	spa_close(spa, FTAG);
 
 	(void) pthread_rwlock_unlock(&ztest_name_lock);
-}
-
-/*
- * Start and then stop the MMP threads to ensure the startup and shutdown code
- * works properly.  Actual protection and property-related code tested via ZTS.
- */
-void
-ztest_mmp_enable_disable(ztest_ds_t *zd, uint64_t id)
-{
-	(void) zd, (void) id;
-	ztest_shared_opts_t *zo = &ztest_opts;
-	spa_t *spa = ztest_spa;
-
-	if (zo->zo_mmp_test)
-		return;
-
-	/*
-	 * Since enabling MMP involves setting a property, it could not be done
-	 * while the pool is suspended.
-	 */
-	if (spa_suspended(spa))
-		return;
-
-	spa_config_enter(spa, SCL_CONFIG, FTAG, RW_READER);
-	mutex_enter(&spa->spa_props_lock);
-
-	zfs_multihost_fail_intervals = 0;
-
-	if (!spa_multihost(spa)) {
-		spa->spa_multihost = B_TRUE;
-		mmp_thread_start(spa);
-	}
-
-	mutex_exit(&spa->spa_props_lock);
-	spa_config_exit(spa, SCL_CONFIG, FTAG);
-
-	txg_wait_synced(spa_get_dsl(spa), 0);
-	mmp_signal_all_threads();
-	txg_wait_synced(spa_get_dsl(spa), 0);
-
-	spa_config_enter(spa, SCL_CONFIG, FTAG, RW_READER);
-	mutex_enter(&spa->spa_props_lock);
-
-	if (spa_multihost(spa)) {
-		mmp_thread_stop(spa);
-		spa->spa_multihost = B_FALSE;
-	}
-
-	mutex_exit(&spa->spa_props_lock);
-	spa_config_exit(spa, SCL_CONFIG, FTAG);
 }
 
 static int


### PR DESCRIPTION
### Motivation and Context

`ztest_mmp_enable_disable()` turns multihost on, signals the MMP threads, and
turns it off again. If the ztest child is killed while it is enabled, the
last-synced uberblock is left with a nonzero `ub_mmp_delay`. Reopening the pool
on the next pass then triggers the MMP activity check, and on a system with no
hostid set `spa_open()` returns `EREMOTEIO` instead of the expected `ENOENT`,
tripping the `VERIFY3S()` in `ztest_run()`.

The result is a random `zloop.sh` abort on any machine without `/etc/hostid`,
which looks like a bug in whatever change is being tested. Creating the file
avoids it but silently disables the ZTS `mmp` group, which skips itself when
`/etc/hostid` is present.

Issue #18918. Removing this function was suggested by @behlendorf in that issue
as the first of five items; the remaining four are still open there.

### Description

Removes the function, its `ztest_func_t` prototype, and its `ZTI_INIT` entry.

The function has no `VERIFY` or `ASSERT` of any kind, so its only failure modes
are a crash or a hang. What it exercises is already covered: `mmp_thread_start()` and
`mmp_thread_stop()` run on every pool import and export, and multihost
protection and property handling are covered by the ZTS `mmp` group. It also
reached the transition by assigning `spa->spa_multihost` directly rather than
through the property, which is what made the stranded state reachable at all,
since `spa_prop_validate()` refuses `multihost=on` when the hostid is zero.

After the removal nothing in ztest enables multihost at all, so an uberblock with
a nonzero `ub_mmp_delay` cannot be produced and the reported abort is unreachable
rather than merely less likely.

Two corner cases are worth naming, both outside normal `zloop.sh` operation:
`-E` against a pool a pre-fix ztest already left MMP-active still aborts, and
`-B` with a pre-fix alternate binary can still enable multihost mid-run.

### How Has This Been Tested?

Built userspace with `--with-config=user --enable-debug` in a clean container
from this branch. Verified against the linked binary with `nm` that
`ztest_mmp_enable_disable` is absent while a control symbol from the same table
(`ztest_fault_inject`) is still present.

Ran `ztest -T 60 -P 10` with no `/etc/hostid` on the host, which exits 0. That
exercises the kill-and-reopen path, since ztest kills its own child at the
default 70% rate per pass and each restarted pass reopens the pool through the
assertion in question.

`scripts/commitcheck.sh` and `make checkstyle` both pass on this branch.

Not run: a full ZTS pass, and a long `zloop.sh` soak. The original failure is
probabilistic, so a clean short run is a no-regression result rather than a
demonstration that the abort is gone; the argument for that is the mechanical
one above.

### Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
