### PR TITLE
build: Fix rpm/deb link failure with older system libzfs_core.so

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -22,7 +22,8 @@ zfs_ids_to_path_SOURCES = \
 	%D%/zfs_ids_to_path.c
 
 zfs_ids_to_path_LDADD = \
-	libzfs.la
+	libzfs.la \
+	libzfs_core.la
 
 
 zhack_CPPFLAGS = $(AM_CPPFLAGS) $(LIBZPOOL_CPPFLAGS)

--- a/cmd/zpool_influxdb/Makefile.am
+++ b/cmd/zpool_influxdb/Makefile.am
@@ -8,4 +8,5 @@ zpool_influxdb_SOURCES = \
 zpool_influxdb_LDADD = \
 	libspl.la \
 	libnvpair.la \
-	libzfs.la
+	libzfs.la \
+	libzfs_core.la

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -80,7 +80,8 @@ systemdgenerator_PROGRAMS = \
 	%D%/systemd/system-generators/zfs-mount-generator.c
 
 %C%_systemd_system_generators_zfs_mount_generator_LDADD = \
-	libzfs.la
+	libzfs.la \
+	libzfs_core.la
 
 CPPCHECKTARGETS += $(systemdgenerator_PROGRAMS)
 endif

--- a/tests/zfs-tests/Makefile.am
+++ b/tests/zfs-tests/Makefile.am
@@ -7,7 +7,8 @@ include $(srcdir)/%D%/cmd/Makefile.am
 scripts_zfs_tests_functional_libzfsdir = $(datadir)/$(PACKAGE)/zfs-tests/tests/functional/libzfs
 scripts_zfs_tests_functional_libzfs_PROGRAMS = %D%/tests/functional/libzfs/many_fds
 %C%_tests_functional_libzfs_many_fds_LDADD = \
-	libzfs.la
+	libzfs.la \
+	libzfs_core.la
 
 scripts_zfs_tests_functional_hkdfdir = $(datadir)/$(PACKAGE)/zfs-tests/tests/functional/hkdf
 scripts_zfs_tests_functional_hkdf_PROGRAMS = %D%/tests/functional/hkdf/hkdf_test

--- a/tests/zfs-tests/cmd/Makefile.am
+++ b/tests/zfs-tests/cmd/Makefile.am
@@ -68,7 +68,8 @@ scripts_zfs_tests_bin_PROGRAMS += %D%/libzfs_input_check
 
 scripts_zfs_tests_bin_PROGRAMS += %D%/libzfs_mnttab_cache_check
 %C%_libzfs_mnttab_cache_check_LDADD = \
-	libzfs.la
+	libzfs.la \
+	libzfs_core.la
 
 scripts_zfs_tests_bin_PROGRAMS += %D%/manipulate_user_buffer
 
@@ -90,6 +91,7 @@ endif
 scripts_zfs_tests_bin_PROGRAMS += %D%/zcp_support
 %C%_zcp_support_LDADD = \
 	libzfs.la \
+	libzfs_core.la \
 	libnvpair.la
 
 %C%_zcp_support_SOURCES = %D%/zcp_support.c
@@ -119,7 +121,8 @@ scripts_zfs_tests_bin_PROGRAMS += %D%/threadsappend
 scripts_zfs_tests_bin_PROGRAMS += %D%/ereports
 %C%_ereports_LDADD = \
 	libnvpair.la \
-	libzfs.la
+	libzfs.la \
+	libzfs_core.la
 
 
 scripts_zfs_tests_bin_PROGRAMS += %D%/edonr_test %D%/skein_test \


### PR DESCRIPTION
### Motivation and Context

On an Ubuntu 26.04 system with ZFS 2.4.3 installed, running `make rpm` / `make deb` gives a linker error:

```
  CCLD     zpool_influxdb
/usr/bin/x86_64-linux-gnu-ld.bfd: ./.libs/libzfs.so: undefined reference to `lzc_send_progress'
/usr/bin/x86_64-linux-gnu-ld.bfd: ./.libs/libzfs.so: undefined reference to `lzc_condense'
collect2: error: ld returned 1 exit status
```

This is because it is trying to link against the system `libzfs_core` instead of using the one produced by the current build, and my system library is an older version.

closes #18944

### Description

Seven executables link `libzfs.la` but not `libzfs_core.la`, so `libzfs_core.so` is not on the link line and `ld` must find it via search path. The RPM spec installs to `/lib/x86_64-linux-gnu`, which `libtool` does not recognize as a system dir
(`sys_lib_dlsearch_path_spec` only has `/usr/lib/x86_64-linux-gnu`), so it emits `-Wl,-rpath -Wl,/lib/x86_64-linux-gnu`. That `rpath` makes `ld` resolve `libzfs.so`'s NEEDED `libzfs_core.so.3` to the old system lib before consulting `libzfs.so`'s own `RUNPATH=.libs`, causing undefined references to the two newest `lzc_*` symbols. In-tree builds use `/usr/lib/x86_64-linux-gnu` so no rpath is emitted and the fresh `.libs` copy is found.

Add `libzfs_core.la` to the `LDADD` of the affected targets:

* `zpool_influxdb`
* `zfs_ids_to_path`
* `zfs-mount-generator`
* `many_fds`
* `libzfs_mnttab_cache_check`
* `zcp_support`
* `ereports`

### How Has This Been Tested?

* `make`
* `make rpm`
* `make deb`

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
