### PR TITLE
zpool: pass compatibility directory paths as format arguments

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -11001,8 +11001,8 @@ print_status_reason(zpool_handle_t *zhp, status_cbdata_t *cbp,
 		(void) snprintf(action, AC_SIZE,
 		    gettext("Check the value of the "
 		    "'compatibility' property against the\n\t"
-		    "appropriate file in " ZPOOL_SYSCONF_COMPAT_D " or "
-		    ZPOOL_DATA_COMPAT_D ".\n"));
+		    "appropriate file in %s or %s.\n"),
+		    ZPOOL_SYSCONF_COMPAT_D, ZPOOL_DATA_COMPAT_D);
 		break;
 
 	case ZPOOL_STATUS_INCOMPATIBLE_FEAT:
@@ -11012,7 +11012,8 @@ print_status_reason(zpool_handle_t *zhp, status_cbdata_t *cbp,
 		(void) snprintf(action, AC_SIZE, gettext("Consider setting "
 		    "'compatibility' to an appropriate value, or\n\t"
 		    "adding needed features to the relevant file in\n\t"
-		    ZPOOL_SYSCONF_COMPAT_D " or " ZPOOL_DATA_COMPAT_D ".\n"));
+		    "%s or %s.\n"),
+		    ZPOOL_SYSCONF_COMPAT_D, ZPOOL_DATA_COMPAT_D);
 		break;
 
 	case ZPOOL_STATUS_UNSUP_FEAT_READ:


### PR DESCRIPTION
### Motivation and Context
Using newer cppcheck (2.13.0 vs 2.7-1 in CI) I'm seeing some issues raised:
```
  zpool_main.c:11004:30: error: There is an unknown macro here
  somewhere. Configuration is required. [unknownMacro]
```
Two status messages concatenate ZPOOL_SYSCONF_COMPAT_D and ZPOOL_DATA_COMPAT_D directly into gettext() string literals.

### Description
Both expand from SYSCONFDIR, a build-time -D, so the msgid xgettext sees contains an unexpanded macro and cannot be translated so cppcheck cannot parse the result.

Pass them as %s arguments.  The rendered output is unchanged.
<!--- Describe your changes in detail -->

### How Has This Been Tested?
checkstyle/lint/module build runs
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
