### PR TITLE
zed: suppress cppcheck memleak false positive in zed_strings

### DIFF
--- a/cmd/zed/zed_strings.c
+++ b/cmd/zed/zed_strings.c
@@ -118,6 +118,7 @@ _zed_strings_node_create(const char *key, const char *val)
 	} else {
 		np->key = np->val;
 	}
+	/* cppcheck-suppress memleak */
 	return (np);
 
 nomem:


### PR DESCRIPTION
### Motivation and Context
Using newer cppcheck (2.13.0 vs 2.7-1 in CI) I'm seeing some issues raised:
```
  zed_strings.c:121:2: error: Memory leak: np.key [memleak]
```

### Description
`_zed_strings_node_create()` returns a node that owns its two strdup()ed strings; `zed_strings_add()` puts it in an AVL tree and `_zed_strings_node_destroy()` frees it later.  cppcheck does not model ownership passing to the caller through a returned struct, and reports both allocations as leaked at the return.
Removing the np->key = np->val aliasing does not change the verdict, so suppress it inline as other sites in the tree already do.
### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
