### PR TITLE
build: only cppcheck module/ when the kernel side is configured

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -31,9 +31,10 @@ if BUILD_LINUX
 include $(srcdir)/%D%/udev/Makefile.am
 endif
 endif
-CPPCHECKDIRS += module
 if CONFIG_KERNEL
 SUBDIRS += module
+
+CPPCHECKDIRS += module
 
 extradir = $(prefix)/src/zfs-$(VERSION)
 extra_HEADERS = zfs.release.in zfs_config.h.in


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
I'm working on a docker based build I can run from OSX and building with `./configure --with-config=user` I'm seeing an error:
```
  nofile:0:0: error: Can not open include file
  '/include/generated/autoconf.h' that is explicitly included.
```
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->
CPPCHECKDIRS picked up module/ unconditionally, but module/Makefile's cppcheck rule resolves the kernel headers through @LINUX_OBJ@, which is only set once ZFS_AC_CONFIG_KERNEL has run.  With --with-config=user it expands empty, so cppcheck is handed an unopenable include path and make lint fails before it checks anything.

Move it inside CONFIG_KERNEL, next to the SUBDIRS entry it belongs with.

### How Has This Been Tested?
cppcheck/lint
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
