### PR TITLE
vdev: expose dtl_sm_blksz and standard_sm_blksz on Linux

### DIFF
--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -532,6 +532,16 @@ and are recovering a damaged label.
 .It Sy zfs_vdev_ms_count_limit Ns = Ns Sy 131072 Po 128k Pc Pq uint
 Practical upper limit of total metaslabs per top-level vdev.
 .
+.It Sy zfs_vdev_dtl_sm_blksz Ns = Ns Sy 4096 Ns B Po 4 KiB Pc Pq int
+Since the DTL space map of a vdev is not expected to have a lot of
+entries, we default its block size to 4K.
+.
+.It Sy zfs_vdev_standard_sm_blksz Ns = Ns Sy 131072 Ns B Po 128 KiB Pc Pq int
+vdev-wide space maps that have lots of entries written to them at
+the end of each transaction can benefit from a higher I/O bandwidth
+.Pq e.g. Sy vdev_obsolete_sm ,
+thus we default their block size to 128K.
+.
 .It Sy metaslab_preload_enabled Ns = Ns Sy 1 Ns | Ns 0 Pq int
 Enable metaslab group preloading.
 .

--- a/module/os/freebsd/zfs/sysctl_os.c
+++ b/module/os/freebsd/zfs/sysctl_os.c
@@ -483,27 +483,6 @@ param_set_max_auto_ashift(SYSCTL_HANDLER_ARGS)
 	return (0);
 }
 
-/*
- * Since the DTL space map of a vdev is not expected to have a lot of
- * entries, we default its block size to 4K.
- */
-extern int zfs_vdev_dtl_sm_blksz;
-
-SYSCTL_INT(_vfs_zfs, OID_AUTO, dtl_sm_blksz,
-	CTLFLAG_RDTUN, &zfs_vdev_dtl_sm_blksz, 0,
-	"Block size for DTL space map.  Power of 2 greater than 4096.");
-
-/*
- * vdev-wide space maps that have lots of entries written to them at
- * the end of each transaction can benefit from a higher I/O bandwidth
- * (e.g. vdev_obsolete_sm), thus we default their block size to 128K.
- */
-extern int zfs_vdev_standard_sm_blksz;
-
-SYSCTL_INT(_vfs_zfs, OID_AUTO, standard_sm_blksz,
-	CTLFLAG_RDTUN, &zfs_vdev_standard_sm_blksz, 0,
-	"Block size for standard space map.  Power of 2 greater than 4096.");
-
 /* zio.c */
 
 SYSCTL_INT(_vfs_zfs_zio, OID_AUTO, exclude_metadata,

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -7072,6 +7072,12 @@ ZFS_MODULE_PARAM(zfs_vdev, zfs_vdev_, min_ms_count, UINT, ZMOD_RW,
 ZFS_MODULE_PARAM(zfs_vdev, zfs_vdev_, ms_count_limit, UINT, ZMOD_RW,
 	"Practical upper limit of total metaslabs per top-level vdev");
 
+ZFS_MODULE_PARAM(zfs, zfs_vdev_, dtl_sm_blksz, INT, ZMOD_RD,
+	"Block size for DTL space map.  Power of 2 greater than 4096.");
+
+ZFS_MODULE_PARAM(zfs, zfs_vdev_, standard_sm_blksz, INT, ZMOD_RD,
+	"Block size for standard space map.  Power of 2 greater than 4096.");
+
 ZFS_MODULE_PARAM(zfs, zfs_, slow_io_events_per_second, UINT, ZMOD_RW,
 	"Rate limit slow IO (delay) events to this many per second");
 

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -7072,10 +7072,10 @@ ZFS_MODULE_PARAM(zfs_vdev, zfs_vdev_, min_ms_count, UINT, ZMOD_RW,
 ZFS_MODULE_PARAM(zfs_vdev, zfs_vdev_, ms_count_limit, UINT, ZMOD_RW,
 	"Practical upper limit of total metaslabs per top-level vdev");
 
-ZFS_MODULE_PARAM(zfs, zfs_vdev_, dtl_sm_blksz, INT, ZMOD_RD,
+ZFS_MODULE_PARAM(zfs, zfs_vdev_, dtl_sm_blksz, INT, ZMOD_RW,
 	"Block size for DTL space map.  Power of 2 greater than 4096.");
 
-ZFS_MODULE_PARAM(zfs, zfs_vdev_, standard_sm_blksz, INT, ZMOD_RD,
+ZFS_MODULE_PARAM(zfs, zfs_vdev_, standard_sm_blksz, INT, ZMOD_RW,
 	"Block size for standard space map.  Power of 2 greater than 4096.");
 
 ZFS_MODULE_PARAM(zfs, zfs_, slow_io_events_per_second, UINT, ZMOD_RW,


### PR DESCRIPTION
### Motivation and Context

`zfs_vdev_dtl_sm_blksz` and `zfs_vdev_standard_sm_blksz` are only tunable on FreeBSD

### Description

Add `ZFS_MODULE_PARAM` declarations in `module/zfs/vdev.c`, and update `zfs.4`.

### How Has This Been Tested?

Built on Linux (Arch, kernel 7.1.8-arch1-3). Both parameters appear in `modinfo zfs`

### Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
