### PR TITLE
zstream: remove the enqueue mutex

### DIFF
--- a/cmd/zstream/zstream.h
+++ b/cmd/zstream/zstream.h
@@ -24,8 +24,8 @@ extern "C" {
 #endif
 
 /*
- * Signals used by the watchdog timer and zstream_queue. The signal mask
- * must be set properly before any threads are spawned.
+ * Signals used by the watchdog timer. The signal mask must be set properly
+ * before any threads are spawned.
  */
 #define	WATCHDOG_SIGNAL		SIGALRM
 #define	THREAD_BACKTRACE_SIGNAL	SIGRTMIN

--- a/cmd/zstream/zstream_queue.c
+++ b/cmd/zstream/zstream_queue.c
@@ -17,8 +17,10 @@
 #include <assert.h>
 #include <atomic.h>
 #include <err.h>
+#include <errno.h>
 #include <pthread.h>
 #include <sched.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -27,16 +29,18 @@
 #include <sys/random.h>
 #include <sys/stdtypes.h>
 #include <sys/sysmacros.h>
+#include <sys/time.h>
+#include <time.h>
 #include <unistd.h>
 
 #include "zstream_queue.h"
 #include "zstream_util.h"
 
-#define	MIN_THREADS 	6
-#define	MAX_QUEUES 	16	/* Largest # of queues simultaneously active */
+#define	ENQUEUE_DELAY_NSEC	(100 * 1000)		/* 100us */
+#define	DISPATCH_BACKUP_NSEC	(1000 * 1000)		/* 1ms */
 
 #define	PLENTY_OF_WORK		6	/* "Many" items to claim */
-#define	NO_WORK			0.0001	/* No-work score threshold */
+#define	NO_WORK			1.0E-6	/* No-work score threshold */
 #define	DEQUEUE_SCORE_WEIGHT	0.3	/* Dequeue score relative weight */
 
 #define	Q_MOD(queue, index)	((index) % (queue)->zq_params.qp_queue_length)
@@ -46,16 +50,16 @@
 	    (queue)->zq_params.qp_queue_length)
 
 /*
- * A zstream_queue is a ring buffer with four indices: enqueue, claim,
+ * A zstream_queue is a ring buffer with four indexes: enqueue, claim,
  * complete, and dequeue, in that order. No index can move beyond its
- * preceding index. Every interval between indices contains work items in a
+ * preceding index. Every interval between indexes contains work items in a
  * particular state: enqueued, claimed for work, or completed. Items never
  * leave the ring buffer, so FIFO order is guaranteed on dequeueing.
  *
  * In concept, every index has a corresponding condition that threads can
  * wait on if they are interested in knowing when that index moves:
- * enqueued, claimed, completed, dequeued. However, the exact reality
- * deviates from this model in two ways:
+ * enqueued, claimed, completed, dequeued. However, the reality deviates
+ * from this model in two ways:
  *
  * - There is no "claimed" condition, because no thread would wait on it.
  * Claiming and processing are one unified operation. Dequeuers await the
@@ -63,33 +67,51 @@
  *
  * - All queues share one thread pool, so idle threads are not bound to any
  * particular queue. Instead of having queue-specific "enqueued" conditions,
- * one condition is shared by all queues. On awakening, each worker thread
- * is dynamically assigned to a queue using a scoring mechanism described
- * in the comments at score_queue().
+ * queues share a centralized dispatch system. On being awakened, worker
+ * threads assign themselves to a queue through a scoring mechanism
+ * described in the comments at score_queue().
  *
- * THREAD SAFETY STRATEGY
+ * LOCKING
  *
  * There are three types of lock:
  *
- * - One global lock that gates changes to the thread pool and queue cohort
- * - A second global lock associated with the shared "enqueued" condition
+ * - One global lock that gates changes to the thread pool and queue cohort.
+ * This lock also acts as the mutex for the tp_wake_worker condition.
+ *
+ * - A second, low-contention global lock that protects the dispatch system
+ *
  * - One lock for each queue
  *
- * Although the "enqueued" condition and its associated lock are stored as
- * part of the global thread pool, they are logically separate from the pool
- * itself.
- *
- * For the most part, locking is straightforward. Any operation that adds or
- * removes queues or threads should hold the pool lock. Any operation that
- * moves a queue's indices should hold the queue lock. Any thread waiting
- * for work should wait on the "enqueued" condition.
+ * Any operation that adds or removes queues or threads should hold the pool
+ * lock. Any operation that moves a queue's indexes should hold the queue
+ * lock. Any thread waiting for work waits on tp_wake_worker.
  *
  * Worker threads hold no locks while they are actually processing items.
  *
- * Several operations require multiple locks. In these cases, a standardized
- * locking order is used to avoid deadlocks:
+ * The global locking order is dispatch -> pool -> queue.
  *
- *   enqueue -> pool -> queue
+ * DISPATCH
+ *
+ * Four events trigger dispatch loops:
+ *
+ * 1) A worker thread completing its batch. Threads always check to see if
+ * there's more claimable work before going to sleep.
+ *
+ * 2) A worker thread discovering more work than it can handle on its own.
+ * Before starting work on its own batch, the worker attempts to signal
+ * another thread to wake up and assess the current state.
+ *
+ * 3) Enqueues. These go through the dispatch system and are batched.
+ * Roughly ENQUEUE_DELAY_NSEC after an enqueue (on any queue), the dispatch
+ * thread attempts to awaken a worker.
+ *
+ * 4) The expiration of a backup timer. The atomic value tp_unclaimed tracks
+ * the total number of enqueued-but-unclaimed items across all queues. When
+ * zero, it indicates that no worker dispatch is currently necessary. This
+ * value is rigorously maintained and the increments and decrements are
+ * sequentially consistent. However, the reads are relaxed, so a reader may
+ * see a stale value. In the event that a critical worker wakeup is dropped,
+ * the backup timer intervenes to keep dispatches running.
  */
 
 typedef struct {
@@ -104,7 +126,7 @@ typedef struct {
 	uint64_t	claim;
 	uint64_t	complete;
 	uint64_t	dequeue;
-} zq_indices_t;
+} zq_indexes_t;
 
 typedef struct {
 	pthread_cond_t	completed;
@@ -117,49 +139,81 @@ typedef struct {
 } zq_stats_t;
 
 struct zstream_queue {
+	int		zq_id;
 	queue_slot_t	*zq_slots;
 	pthread_mutex_t	zq_mutex;
-	zq_indices_t	zq_ix;
+	zq_indexes_t	zq_ix;
 	zq_conditions_t	zq_cond;
 	zq_params_t	zq_params;
-	zq_stats_t	zq_stats;
 	boolean_t	zq_disallow_enqueue;
+#ifdef MONITOR_QUEUES
+	zq_stats_t	zq_stats;
+	uint64_t	zq_histogram[ZQ_MAX_BATCH+1];	/* Batch sizes */
+#endif
 };
 
 typedef struct {
 	pthread_mutex_t	tp_pool_mutex;
-	pthread_mutex_t tp_enqueue_mutex;
-	pthread_cond_t	tp_enqueued;
-	zstream_queue_t	*tp_queues[MAX_QUEUES];
+	pthread_cond_t	tp_wake_worker;		/* Awaited by workers */
+
+	pthread_mutex_t	tp_dispatch_mutex;
+	pthread_cond_t	tp_request_dispatch;	/* By dispatch thread */
+	boolean_t	tp_dispatch_requested;
+
+	zstream_queue_t	*tp_queues[ZQ_MAX_QUEUES];
 	int		tp_num_queues;
+
 	boolean_t	tp_threads_created;
 	int		tp_num_threads;
+
+	uint64_t	tp_unclaimed;		/* Atomic, all queues */
 } thread_pool_t;
 
 typedef union {
-	long		long ll;
-	long		double ld;
+	long long	ll;
+	long double	ld;
 	void		*p;
 	void		(*fp)(void);
 } worst_case_alignment_t;
 
-static void *
-queue_worker(void *);
+static void *queue_worker(void *);
+static void *dispatch_worker(void *);
 
 #ifdef MONITOR_QUEUES
-static void *
-cpu_and_queue_monitor(void *);
+static void *cpu_and_queue_monitor(void *);
+static void print_batch_size_histogram(zstream_queue_t *);
 #endif
 
 static thread_pool_t	pool = {0};
 static pthread_once_t	once_control = PTHREAD_ONCE_INIT;
 
+/*
+ * The dispatch timer needs sub-millisecond accuracy. POSIX timers on
+ * FreeBSD don't implement that, but nanosleep() works fine.
+ */
+static void
+sleep_nsec(uint64_t nsec)
+{
+	struct timespec ts = {
+		.tv_sec = nsec / NANOSEC,
+		.tv_nsec = nsec % NANOSEC
+	};
+	while (nanosleep(&ts, &ts) != 0) {
+		if (errno != EINTR)
+			err(1, "nanosleep failed");
+	}
+}
+
 static void
 thread_pool_init(void)
 {
 	pthread_mutex_init(&pool.tp_pool_mutex, NULL);
-	pthread_mutex_init(&pool.tp_enqueue_mutex, NULL);
-	pthread_cond_init(&pool.tp_enqueued, NULL);
+	pthread_cond_init(&pool.tp_wake_worker, NULL);
+
+	pthread_mutex_init(&pool.tp_dispatch_mutex, NULL);
+	pthread_cond_init(&pool.tp_request_dispatch, NULL);
+
+	safe_create_thread(dispatch_worker, NULL, "dispatch", B_TRUE);
 }
 
 /*
@@ -167,19 +221,19 @@ thread_pool_init(void)
  * queues have been created.
  */
 void
-zstream_queue_set_num_threads(uint_t n)
+zstream_queue_set_num_threads(int n)
 {
 	pthread_once(&once_control, thread_pool_init);
 	pthread_mutex_lock(&pool.tp_pool_mutex);
 	if (pool.tp_threads_created) {
 		errx(1, "thread pool size must be set before creating queues");
-	} else if (n == 0) {
+	} else if (n < 1) {
 		errx(1, "number of threads must be at least 1");
-	} else if (n < MIN_THREADS) {
-		warnx("using only %u threads may limit performance, setting "
+	} else if (n < ZQ_MIN_THREADS) {
+		warnx("using only %d threads may limit performance, setting "
 		    "anyway...", n);
 	} else if (n > 256) {
-		warnx("num_threads = %u seems suspiciously high, setting "
+		warnx("num_threads = %d seems suspiciously high, setting "
 		    "anyway...", n);
 	}
 	pool.tp_num_threads = n;
@@ -190,11 +244,11 @@ zstream_queue_set_num_threads(uint_t n)
  * Locking: the caller must hold the pool mutex.
  *
  * If tp_num_threads is nonzero, it sets the number of threads to spawn.
- * Otherwise, one thread is spawned per core.
+ * Otherwise, one thread is spawned per core, with a minimum of 6 threads.
  *
- * sched_affinity() is a better estimate of available threads than sysconf
- * because sysconf doesn't account for limits that might be set on, e.g., a
- * container.
+ * sched_getaffinity() is a better estimate of available threads than
+ * sysconf because sysconf doesn't account for limits that might be set on,
+ * e.g., a container.
  */
 static void
 thread_pool_spinup(void)
@@ -202,12 +256,16 @@ thread_pool_spinup(void)
 	if (pool.tp_num_threads == 0) {
 #ifdef	CPU_COUNT
 		cpu_set_t cpu_set;
-		sched_getaffinity(0, sizeof (cpu_set_t), &cpu_set);
-		pool.tp_num_threads = CPU_COUNT(&cpu_set);
+		if (sched_getaffinity(0, sizeof (cpu_set_t), &cpu_set) != 0) {
+			warn("sched_getaffinity failed, using sysconf");
+			pool.tp_num_threads = sysconf(_SC_NPROCESSORS_ONLN);
+		} else {
+			pool.tp_num_threads = CPU_COUNT(&cpu_set);
+		}
 #else
 		pool.tp_num_threads = sysconf(_SC_NPROCESSORS_ONLN);
 #endif
-		pool.tp_num_threads = MAX(pool.tp_num_threads, MIN_THREADS);
+		pool.tp_num_threads = MAX(pool.tp_num_threads, ZQ_MIN_THREADS);
 	}
 	for (int i = 0; i < pool.tp_num_threads; i++) {
 		char name[32];
@@ -222,32 +280,39 @@ thread_pool_spinup(void)
 zstream_queue_t *
 zstream_queue_create(zq_params_t *params)
 {
+	static int next_queue_id = 0;
+
 	VERIFY3P(params->qp_process, !=, NULL);
 	VERIFY3P(params->qp_cost, !=, NULL);
 	VERIFY3U(params->qp_item_size, >, 0);
 	VERIFY3U(params->qp_queue_length, >, 0);
+	VERIFY3U(params->qp_queue_length, <, 1 << 18);
 
 	pthread_once(&once_control, thread_pool_init);
 	pthread_mutex_lock(&pool.tp_pool_mutex);
-	VERIFY3S(pool.tp_num_queues, <, MAX_QUEUES);
+	VERIFY3S(pool.tp_num_queues, <, ZQ_MAX_QUEUES);
 
 	if (!pool.tp_threads_created) {
 		thread_pool_spinup();
 		pool.tp_threads_created = B_TRUE;
 	}
-	zstream_queue_t *queue = safe_malloc(sizeof (zstream_queue_t));
-	pool.tp_queues[pool.tp_num_queues] = queue;
 
+	zstream_queue_t *queue = safe_malloc(sizeof (zstream_queue_t));
 	*queue = (zstream_queue_t) {
+		.zq_id = next_queue_id++,
 		.zq_params = *params,
 		.zq_slots = safe_malloc(params->qp_queue_length *
-		    (sizeof (queue_slot_t)))
+		    (sizeof (queue_slot_t))),
+#ifdef MONITOR_QUEUES
+		.zq_stats.min_depth = INT_MAX
+#endif
 	};
+	pool.tp_queues[pool.tp_num_queues] = queue;
 
 	size_t qpis_rounded = P2ROUNDUP(params->qp_item_size,
 	    _Alignof(worst_case_alignment_t));
 	uint8_t *items = safe_malloc(params->qp_queue_length * qpis_rounded);
-	for (int i = 0; i < params->qp_queue_length; i++) {
+	for (size_t i = 0; i < params->qp_queue_length; i++) {
 		queue->zq_slots[i].qs_item =
 		    (queue_item_t *)(items + i * qpis_rounded);
 	}
@@ -283,11 +348,11 @@ zstream_queue_create(zq_params_t *params)
  * - Whenever an item of cost 0 is enqueued
  *
  * Strictly speaking, advancing on claiming a batch is not logically
- * necessary. However, the claimer already holds the queue mutex, and
- * it's in our interest to make completed items available for dequeueing
- * as expeditiously as possible.
+ * necessary. However, the claimer already holds the queue mutex, and it's
+ * in our interest to make completed items available for dequeueing as
+ * expeditiously as possible.
  *
- * It's also expedient to sweep the "claim" index if we can. This is not
+ * Sweeping of the "claim" index is also an optimization. It is not
  * necessary for correctness. However, if we don't do it here, it can only
  * be done by threads as they claim jobs to work on. In some cases, not
  * advancing the "claim" index here can result in an empty batch and a
@@ -299,9 +364,20 @@ static inline void
 advance_indexes(zstream_queue_t *queue)
 {
 	boolean_t any_completed = B_FALSE;
+	uint64_t claimed = 0;
+
 	while (queue->zq_ix.claim < queue->zq_ix.enqueue &&
 	    Q_SLOT(queue, queue->zq_ix.claim).qs_completed) {
 		queue->zq_ix.claim++;
+		claimed++;
+	}
+	if (claimed > 0) {
+		/*
+		 * tp_unclaimed is decremented both here and in
+		 * claim_batch(). The conditions are mutually exclusive, so
+		 * double counting will not occur.
+		 */
+		atomic_sub_64(&pool.tp_unclaimed, claimed);
 	}
 	while (queue->zq_ix.complete < queue->zq_ix.claim &&
 	    Q_SLOT(queue, queue->zq_ix.complete).qs_completed) {
@@ -314,11 +390,10 @@ advance_indexes(zstream_queue_t *queue)
 }
 
 /*
- * This function scores a queue according to its need for workers. Higher is
- * better. The scoring tries to assign threads to queues that are running
- * out of space for new enqueuements or that have little completed work
- * available to dequeue. The broader goal is to try to avoid pipeline
- * stalls.
+ * Score a queue according to its need for workers. Higher is better. The
+ * scoring tries to assign threads to queues that are running out of space
+ * for new enqueuements or that have little completed work available to
+ * dequeue. The broader goal is to try to avoid pipeline stalls.
  *
  * Two measures are used for scoring. The "open score" is 1/M where M is the
  * number of slots available to receive new items. The "dequeue score" is
@@ -330,26 +405,7 @@ advance_indexes(zstream_queue_t *queue)
  * actually available to be claimed on the queue; there's no point assigning
  * threads to queues that have no work.
  *
- * Locking: the caller must hold the enqueue mutex, the thread pool mutex,
- * and the queue mutex. Several corollaries:
- *
- * 1) Only one thread may score queues at a time.
- *
- * 2) Worker threads can still complete work during the process of scoring
- * all queues, so there will likely be time skew among scores.
- *
- * 3) If a queue score is stale, it will always err on the side of
- * overstating the amount of work that a queue has available. This is fine
- * because at worst, a thread is assigned to a no-work queue and loops
- * immediately.
- *
- * 4) Understatement is not possible because the enqueue mutex is locked
- * during scoring. We don't want a queue to be scored and then receive new
- * work while the scorer is looking at other queues. That would create a
- * potential race condition in which a scorer concludes that there is no
- * work available on any queue and goes back to sleep. If no further items
- * are submitted to any queue, no worker thread will ever be awakened to
- * process the newly-enqueued item.
+ * Locking: the caller must hold the thread pool mutex and the queue mutex.
  */
 static inline double
 score_queue(zstream_queue_t *queue)
@@ -361,7 +417,7 @@ score_queue(zstream_queue_t *queue)
 
 	double open_score = (open_slots > 0) ? (1.0 / open_slots) : 2.0;
 	double dq_score = (dequeueable > 0) ? (1.0 / dequeueable) : 2.0;
-	double claim_factor = MIN(claimable, PLENTY_OF_WORK) /
+	double claim_factor = MIN(claimable, (uint64_t)PLENTY_OF_WORK) /
 	    (double)PLENTY_OF_WORK;
 	double need = open_score + dq_score * DEQUEUE_SCORE_WEIGHT;
 	return (need * claim_factor);
@@ -369,37 +425,43 @@ score_queue(zstream_queue_t *queue)
 
 /*
  * Return a random index from an array of doubles, with the likelihood of
- * index i being selected equal to weights[i] / sum(weights).
+ * index i being selected equal to weights[i] / sum(weights). Returns index
+ * 0 if no weight is greater than 0.
  */
 static inline int
 select_stochastic(double weights[], int num_values)
 {
-	uint32_t numerator;
-	uint32_t denominator = UINT32_MAX;
+	const double denominator = (double)UINT64_MAX;
+	uint64_t numerator;
 	double total = 0.0;
 
 	for (int i = 0; i < num_values; i++) {
 		total += weights[i];
 	}
-	random_get_pseudo_bytes((uint8_t *)&numerator, sizeof (uint32_t));
+	random_get_pseudo_bytes((uint8_t *)&numerator, sizeof (numerator));
 	double select_val = total * numerator / denominator;
 	for (int i = 0; i < num_values; i++) {
-		if (select_val <= weights[i])
+		if (select_val < weights[i])
 			return (i);
 		select_val -= weights[i];
 	}
-	return (num_values - 1);
+	/* Fallback in case of FP rounding not producing a winner */
+	for (int i = num_values - 1; i >= 0; i--) {
+		if (weights[i] != 0.0)
+			return (i);
+	}
+	return (0);
 }
 
 /*
- * Claim up to MAX_BATCH work items from the given queue, trying to
- * accumulate at least queue->qp_batch_budget worth of work data (==
- * "cost"). All items in a batch will be drawn from the same queue.
+ * Claim up to ZQ_MAX_BATCH work items from the given queue, trying to
+ * accumulate at least qp_batch_budget worth of work data (== "cost"). All
+ * items in a batch will be drawn from the same queue.
  *
  * Does not block waiting to fill the budget; returns whatever is available.
  *
- * Locking: this function must be called with both the queue mutex and
- * the thread pool mutex held. zstream_queue_destroy() can't hold a queue's
+ * Locking: this function must be called with both the queue mutex and the
+ * thread pool mutex held. zstream_queue_destroy() can't hold a queue's
  * mutex while destroying it (because destruction entails destroying the
  * queue mutex, which must be unlocked), so holding the queue mutex while
  * attempting to claim work is not a sufficient guarantee of correctness.
@@ -417,12 +479,13 @@ claim_batch(zstream_queue_t *queue, queue_slot_t **batch)
 {
 	size_t cost_claimed = 0;
 	int count = 0;
+	uint64_t passed = 0;
 	boolean_t more_to_claim, more_slots, more_budget;
 	boolean_t first_and_only, ok_to_claim;
 
 	while (B_TRUE) {
 		more_to_claim = queue->zq_ix.claim < queue->zq_ix.enqueue;
-		more_slots = count < MAX_BATCH;
+		more_slots = count < ZQ_MAX_BATCH;
 		more_budget = cost_claimed < queue->zq_params.qp_batch_budget;
 		first_and_only = queue->zq_params.qp_batch_budget == 0 &&
 		    count == 0;
@@ -437,45 +500,41 @@ claim_batch(zstream_queue_t *queue, queue_slot_t **batch)
 			batch[count++] = slot;
 		}
 		queue->zq_ix.claim++;
+		passed++;
 	}
 
+	/*
+	 * Every slot the claim index moved over leaves the unclaimed pool,
+	 * whether we took it for the batch or skipped it as already complete.
+	 */
+	if (passed > 0) {
+		atomic_sub_64(&pool.tp_unclaimed, passed);
+	}
 	advance_indexes(queue);
+#ifdef MONITOR_QUEUES
+	queue->zq_histogram[count]++;
+#endif
 	return (count);
 }
 
 /*
  * Threads are assigned to a queue on each loop so they can be shifted
  * dynamically to follow available work. Idle threads will typically be
- * awaiting the "enqueued" condition within this function.
+ * waiting on the tp_wake_worker condition within this function.
  *
- * Locking: this function has complex locking behavior. At first we must
- * hold both the enqueue mutex (to be sure new work doesn't get sneaked in
- * after a queue is scored, which might cause it to be overlooked entirely)
- * and the thread pool mutex (to guarantee that no queue can be destroyed
- * out from under us). We also lock individual queues while scoring them.
- *
- * After queue selection, we retain the enqueue mutex while claiming a batch
- * so that we can safely signal the "enqueued" condition if there appears to
- * be enough work for more than one thread dispatch. We need to obtain the
- * mutex of the selected queue without releasing the pool mutex because
- * there is still the potential for a claim-vs-destroy race.
- *
- * This sequence dictates the lock acquisition ordering for all of
- * zstream_queue:
- *
- *     enqueue -> pool -> queue
- *
- * If everyone follows that order, deadlocks should not occur.
+ * Locking: we hold the pool mutex throughout, both to keep a queue from
+ * being destroyed out from under us while we score it or claim from it, and
+ * because it is the mutex for tp_wake_worker. Individual queues are locked
+ * for only as long as it takes to score or claim from them.
  */
 static int
 assign_queue_and_get_work(zstream_queue_t **queue, queue_slot_t **batch)
 {
-	pthread_mutex_lock(&pool.tp_enqueue_mutex);
 	pthread_mutex_lock(&pool.tp_pool_mutex);
 
 	while (B_TRUE) {
 		int num_queues = pool.tp_num_queues;
-		double weights[MAX_QUEUES];
+		double weights[ZQ_MAX_QUEUES];
 		int queues_with_work = 0;
 
 		for (int i = 0; i < num_queues; i++) {
@@ -487,40 +546,42 @@ assign_queue_and_get_work(zstream_queue_t **queue, queue_slot_t **batch)
 				queues_with_work++;
 		}
 		if (!queues_with_work) {
-			pthread_mutex_unlock(&pool.tp_pool_mutex);
-			pthread_cond_wait(&pool.tp_enqueued,
-			    &pool.tp_enqueue_mutex);
-			pthread_mutex_lock(&pool.tp_pool_mutex);
+			pthread_cond_wait(&pool.tp_wake_worker,
+			    &pool.tp_pool_mutex);
 		} else {
 			int q = select_stochastic(weights, num_queues);
 			*queue = pool.tp_queues[q];
 			pthread_mutex_lock(&(*queue)->zq_mutex);
 			int count = claim_batch(*queue, batch);
-			/*
-			 * If we didn't claim all available work, wake up
-			 * another worker thread.
-			 */
-			boolean_t more_here = (*queue)->zq_ix.claim <
-			    (*queue)->zq_ix.enqueue;
 			pthread_mutex_unlock(&(*queue)->zq_mutex);
-			if (more_here || queues_with_work > 1) {
-				pthread_cond_signal(&pool.tp_enqueued);
+			/*
+			 * Try to wake up another worker thread if there
+			 * still seems to be work available (on any queue).
+			 */
+			if (atomic_load_64(&pool.tp_unclaimed) > 0) {
+				pthread_cond_signal(&pool.tp_wake_worker);
 			}
 			pthread_mutex_unlock(&pool.tp_pool_mutex);
-			pthread_mutex_unlock(&pool.tp_enqueue_mutex);
 			return (count);
 		}
 	}
 }
 
-static uint64_t items_in_claimed_state = 0;  /* Used for tuning/debugging */
-
+/*
+ * Batches are processed without holding any locks. The existence of the
+ * items we're working on guarantees that the queue can't be destroyed out
+ * from under us.
+ *
+ * However, we can't mark items completed without holding the queue lock
+ * because that creates a potential race condition with advance_indexes()
+ * being called on another thread.
+ */
 static void *
 queue_worker(void *dummy)
 {
 	(void) dummy;
 	zstream_queue_t *queue;
-	queue_slot_t *batch[MAX_BATCH];
+	queue_slot_t *batch[ZQ_MAX_BATCH];
 	int count;
 
 	while (B_TRUE) {
@@ -529,14 +590,6 @@ queue_worker(void *dummy)
 			zq_process_item_f *process =
 			    queue->zq_params.qp_process;
 			void *context = queue->zq_params.qp_context;
-			atomic_add_64(&items_in_claimed_state, count);
-			/*
-			 * Locking note: we complete the whole batch without
-			 * holding any locks. However, we can't mark items
-			 * as completed without holding the queue lock
-			 * because that creates a race condition with
-			 * advance_indexes().
-			 */
 			for (int i = 0; i < count; i++) {
 				process(batch[i]->qs_item, context);
 			}
@@ -545,9 +598,76 @@ queue_worker(void *dummy)
 				batch[i]->qs_completed = B_TRUE;
 			}
 			advance_indexes(queue);
-			atomic_sub_64(&items_in_claimed_state, count);
 			pthread_mutex_unlock(&queue->zq_mutex);
 		}
+	}
+	return (NULL);
+}
+
+/*
+ * Locking: must be called with the dispatch mutex held
+ *
+ * Skips the wakeup if tp_unclaimed == 0.
+ */
+static inline void
+maybe_wake_worker(void)
+{
+	pool.tp_dispatch_requested = B_FALSE;
+	if (atomic_load_64(&pool.tp_unclaimed) > 0) {
+		pthread_mutex_lock(&pool.tp_pool_mutex);
+		pthread_cond_signal(&pool.tp_wake_worker);
+		pthread_mutex_unlock(&pool.tp_pool_mutex);
+	}
+}
+
+static inline struct timespec
+timeout_timespec(void)
+{
+	struct timespec expire;
+	struct timeval tv;
+
+	if (gettimeofday(&tv, NULL) != 0)
+		err(1, "couldn't gettimeofday()");
+	uint64_t nsec = tv.tv_usec * 1000 + DISPATCH_BACKUP_NSEC;
+	expire.tv_sec = tv.tv_sec + nsec / NANOSEC;
+	expire.tv_nsec = nsec % NANOSEC;
+	return (expire);
+}
+
+/*
+ * The enqueue notification pacing thread, which converts a notification
+ * from an enqueuer into a possible worker wakeup roughly ENQUEUE_DELAY_NSEC
+ * later. The delay facilitates larger batch sizes and keeps enqueuers on a
+ * less-contested mutex.
+ *
+ * The condwait timeout is necessary because the tp_unclaimed count is not
+ * the final word on whether there is actually any work to claim. It is
+ * calculated rigorously. However, it's a bare atomic and therefore
+ * potentially out of date at any given moment. A backup strategy is
+ * necessary to restart processing in the event of a race.
+ */
+static void *
+dispatch_worker(void *nope)
+{
+	(void) nope;
+	pthread_mutex_lock(&pool.tp_dispatch_mutex);
+	while (B_TRUE) {
+		while (!pool.tp_dispatch_requested) {
+			int rc;
+			struct timespec expire = timeout_timespec();
+			rc = pthread_cond_timedwait(&pool.tp_request_dispatch,
+			    &pool.tp_dispatch_mutex, &expire);
+			if (rc == ETIMEDOUT) {
+				maybe_wake_worker();
+			} else if (rc != 0) {
+				errx(1, "pthread_cond_timedwait() failed: %s",
+				    strerror(rc));
+			}
+		}
+		pthread_mutex_unlock(&pool.tp_dispatch_mutex);
+		sleep_nsec(ENQUEUE_DELAY_NSEC);
+		pthread_mutex_lock(&pool.tp_dispatch_mutex);
+		maybe_wake_worker();
 	}
 	return (NULL);
 }
@@ -558,14 +678,14 @@ queue_worker(void *dummy)
 void
 zstream_enqueue(zstream_queue_t *queue, queue_item_t *item)
 {
-	VERIFY(queue != NULL);
+	VERIFY3P(queue, !=, NULL);
 	pthread_mutex_lock(&queue->zq_mutex);
-	VERIFY3B(queue->zq_disallow_enqueue, ==, B_FALSE);
 
+	VERIFY3B(queue->zq_disallow_enqueue, ==, B_FALSE);
 	while (Q_FULL(queue)) {
 		pthread_cond_wait(&queue->zq_cond.dequeued, &queue->zq_mutex);
 	}
-
+	VERIFY3B(queue->zq_disallow_enqueue, ==, B_FALSE);
 	queue_slot_t *slot = &Q_SLOT(queue, queue->zq_ix.enqueue);
 	if (item) {
 		slot->qs_cost =
@@ -580,74 +700,85 @@ zstream_enqueue(zstream_queue_t *queue, queue_item_t *item)
 		queue->zq_disallow_enqueue = B_TRUE;
 	}
 	queue->zq_ix.enqueue++;
-	if (slot->qs_completed) {
+	atomic_inc_64(&pool.tp_unclaimed);
+	if (slot->qs_cost == 0)
 		advance_indexes(queue);
-	}
 
 #ifdef MONITOR_QUEUES
 	/* Maintain queue usage data per monitor interval */
-	int depth = queue->zq_ix.enqueue - queue->zq_ix.dequeue;
+	uint64_t depth = queue->zq_ix.enqueue - queue->zq_ix.dequeue;
 	queue->zq_stats.max_depth = MAX(queue->zq_stats.max_depth, depth);
 	queue->zq_stats.min_depth = MIN(queue->zq_stats.min_depth, depth);
 #endif
 
 	pthread_mutex_unlock(&queue->zq_mutex);
-	pthread_mutex_lock(&pool.tp_enqueue_mutex);
-	pthread_cond_signal(&pool.tp_enqueued);
-	pthread_mutex_unlock(&pool.tp_enqueue_mutex);
+
+	pthread_mutex_lock(&pool.tp_dispatch_mutex);
+	pool.tp_dispatch_requested = B_TRUE;
+	pthread_cond_signal(&pool.tp_request_dispatch);
+	pthread_mutex_unlock(&pool.tp_dispatch_mutex);
 }
 
 void
-zstream_queue_fini(zstream_queue_t *queue) {
+zstream_queue_fini(zstream_queue_t *queue)
+{
 	zstream_enqueue(queue, NULL);
 }
 
 /*
  * This function is not public. The only way to destroy a queue through the
  * public API is to call zstream_queue_fini(), wait for all items to be
- * processed, and then dequeue all items.
+ * processed, and then dequeue all items. As a consequence, threads are
+ * entitled to assume that any queue with unprocessed work will not be
+ * removed without locking the pool mutex.
  *
- * Locking: the caller must NOT hold the queue lock. The pool mutex is
- * held while destroying the queue.
+ * Locking: the caller must NOT hold the queue lock. The pool mutex is held
+ * while destroying the queue.
  */
 static void
 zstream_queue_destroy(zstream_queue_t *queue)
 {
 	pthread_mutex_lock(&pool.tp_pool_mutex);
 
-	pthread_mutex_destroy(&queue->zq_mutex);
-	pthread_cond_destroy(&queue->zq_cond.dequeued);
+#ifdef MONITOR_QUEUES
+	print_batch_size_histogram(queue);
+#endif
 
+	VERIFY0(pthread_mutex_destroy(&queue->zq_mutex));
+	VERIFY0(pthread_cond_destroy(&queue->zq_cond.dequeued));
 	if (pthread_cond_destroy(&queue->zq_cond.completed) != 0) {
 		errx(1, "cannot destroy zstream_queue completed condition - "
 		    "are you attempting to dequeue from multiple threads "
 		    "simultaneously?");
 	}
-
-	free(queue->zq_slots[0].qs_item);
-	free(queue->zq_slots);
-	queue->zq_slots = NULL;
-	free(queue);
 	pool.tp_num_queues--;
-
 	if (pool.tp_num_queues > 0) {
 		/* Gaps are not allowed in the tp_queues array */
 		zstream_queue_t **qscan = &pool.tp_queues[0];
 		int i = pool.tp_num_queues;
 		while (*qscan != queue) { qscan++; i--; }
-		memmove(qscan, qscan + 1, i * sizeof (*qscan));
+		if (i > 0)
+			memmove(qscan, qscan + 1, i * sizeof (*qscan));
 	}
+	/*
+	 * Items are allocated as a single block. The address of the first
+	 * item field is in fact the start of the block.
+	 */
+	free(queue->zq_slots[0].qs_item);
+	free(queue->zq_slots);
+	queue->zq_slots = NULL;
+	free(queue);
+
 	pthread_mutex_unlock(&pool.tp_pool_mutex);
 }
 
 /*
  * Locking: if more than one thread attempts to dequeue items
  * simultaneously, disaster is likely. It will work fine until the end of
- * the stream, at which point it's a tossup between a race condition with
- * multiple attempts to destroy the whole queue vs. an attempt to delete a
- * condition that another thread is waiting on. The latter will be trapped
- * in zstream_queue_destroy(), but the former will likely just crash. Hence
- * the warning not to do multithreaded dequeues in zstream_queue.h.
+ * the stream, at which point it becomes a tossup between a race condition
+ * with multiple attempts to destroy the whole queue vs. an attempt to
+ * delete a condition that another thread is waiting on. Hence the warning
+ * not to do multithreaded dequeues in zstream_queue.h.
  *
  * Returns B_TRUE if real data is returned, B_FALSE if the end of the queue
  * has been reached.
@@ -676,33 +807,65 @@ zstream_dequeue(zstream_queue_t *queue, queue_item_t *item)
 
 #ifdef	MONITOR_QUEUES
 
-#define	JIFFIES_PER_SEC 100
-#define	SAMPLE_DURATION_US 1000000
+#define	USEC_PER_JIFFY		10000
+#define	SAMPLE_DURATION_USEC	1000000
+#define	CPU_FIELD_WIDTH		14
+
+/*
+ * Called only during zstream_queue_destroy(), under the pool mutex
+ */
+static void
+print_batch_size_histogram(zstream_queue_t *queue)
+{
+	int last_nonzero = 0;
+	static int lines_printed = 0;
+
+	if (lines_printed++ == 0)
+		fprintf(stderr, "\nBatch size histograms:\n");
+	for (last_nonzero = ZQ_MAX_BATCH; last_nonzero >= 0; last_nonzero--) {
+		if (queue->zq_histogram[last_nonzero] > 0)
+			break;
+	}
+	fprintf(stderr, "Queue %d: ", queue->zq_id);
+	const char *sep = "";
+	for (int i = 0; i <= last_nonzero; i++) {
+		fprintf(stderr, "%s%llu", sep,
+		    (u_longlong_t)queue->zq_histogram[i]);
+		sep = ", ";
+	}
+	fprintf(stderr, "\n");
+	fflush(stderr);
+}
 
 /*
  * Monitor queue and CPU usage from a separate thread. This is all
- * Linux-specific, but it's needed only while tuning queue lengths and batch
- * sizes.
+ * Linux-specific, but it's needed only while tuning queue lengths and
+ * batch sizes. Prints the minimum and maximum queue depth observed
+ * during each period.
+ *
+ * Example output:
+ *
+ *     CPU: 99.85%   Queue 0:  745-1024   Queue 1:  183-256
  */
 static void *
 cpu_and_queue_monitor(void *dummy)
 {
 	(void) dummy;
-	uint64_t period = SAMPLE_DURATION_US;
-	struct timespec clock = {};
-	uint64_t start_us, end_us, delta_jif;
+	uint64_t period = SAMPLE_DURATION_USEC;
+	struct timespec clock = {0};
+	uint64_t start_us, end_us;
 	uint64_t cpu_jif_prior = 0;
-	uint64_t delta_cpu_jif;
+	uint64_t delta_jif, delta_cpu_jif;
 	long unsigned int utime, stime;
 	char buff[1024];
-	boolean_t interrupt = B_FALSE;
 	FILE *fp;
 
-	/* Wait a few seconds for things to settle into steady state */
-	usleep(3 * 1000 * 1000);
+	fprintf(stderr, "Queue depths:\n");
 
 	while (B_TRUE) {
+
 		usleep(period);
+
 		fp = fopen("/proc/self/stat", "r");
 		VERIFY3P(fp, !=, NULL);
 		VERIFY3P(fgets(buff, sizeof (buff), fp), !=, NULL);
@@ -716,33 +879,43 @@ cpu_and_queue_monitor(void *dummy)
 			p++;
 		}
 		VERIFY3U(sscanf(p, "%lu %lu", &utime, &stime), ==, 2);
+
 		pthread_mutex_lock(&pool.tp_pool_mutex);
+
 		clock_gettime(CLOCK_MONOTONIC, &clock);
 		end_us = clock.tv_sec * 1000000 + clock.tv_nsec / 1000;
-		if (cpu_jif_prior) {
+
+		if (cpu_jif_prior > 0) {
 			delta_cpu_jif = utime + stime - cpu_jif_prior;
-			delta_jif = (end_us - start_us) /
-			    (JIFFIES_PER_SEC * 100);
+			delta_jif = (end_us - start_us) / USEC_PER_JIFFY;
 			double cpu_pct = (double)delta_cpu_jif /
 			    (pool.tp_num_threads * delta_jif);
-			fprintf(stderr, "CPU: %.2f%%  ", 100 * cpu_pct);
-			/* Stop to investigate low CPU usage */
-			if (interrupt && cpu_pct < 0.85 && cpu_pct > 0.1) {
-				kill(getpid(), SIGSTOP);
-			}
+			cpu_pct = MIN(cpu_pct, 0.9999); /* Don't print 100% */
+			fprintf(stderr, "CPU: %5.2f%%   ", 100 * cpu_pct);
+		} else {
+			/* No CPU data available for the first interval */
+			fprintf(stderr, "%*s", CPU_FIELD_WIDTH, "");
 		}
 
-		/* Report queue depths */
 		for (int i = 0; i < pool.tp_num_queues; i++) {
 			zstream_queue_t *q = pool.tp_queues[i];
-			fprintf(stderr, "Queue %d: %d-%d  ", i,
-			    q->zq_stats.min_depth, q->zq_stats.max_depth);
-			q->zq_stats.min_depth = 999999999;
+			pthread_mutex_lock(&q->zq_mutex);
+			int min = q->zq_stats.min_depth;
+			int max = q->zq_stats.max_depth;
+			if (min > max)
+				min = max = 0;
+			fprintf(stderr, "Queue %d: %4d-%-4d   ",
+			    q->zq_id, min, max);
+			q->zq_stats.min_depth = INT_MAX;
 			q->zq_stats.max_depth = 0;
+			pthread_mutex_unlock(&q->zq_mutex);
 		}
 
 		pthread_mutex_unlock(&pool.tp_pool_mutex);
+
 		fprintf(stderr, "\n");
+		fflush(stderr);
+
 		cpu_jif_prior = utime + stime;
 		start_us = end_us;
 	}

--- a/cmd/zstream/zstream_queue.h
+++ b/cmd/zstream/zstream_queue.h
@@ -41,29 +41,30 @@ extern "C" {
  * If an item's cost is 0, it is fast-tracked and never presented to the
  * processing function.
  *
- * The cost function is run as items enter the queue, so it's
- * single-threaded and should return a value promptly. If cost estimation is
+ * The cost function is run as items enter the queue, with the queue mutex
+ * held, so it should return a value promptly. If cost estimation is
  * expensive and important, use a separate queue to implement it.
  *
  * Dispatch granularity is specified as a per-batch budget that is set for
  * each queue in the same (arbitrary) units used for item costs. Threads
  * claim items until the budget is met, there are no more items available,
- * or MAX_BATCH items have been claimed. When claiming items to work on,
+ * or ZQ_MAX_BATCH items have been claimed. When claiming items to work on,
  * threads never block waiting for additional work to arrive. They start
  * work as quickly as possible even if the budget has not been reached.
  *
  * A batch budget of 0 means that all batches will have a size of 1.
  *
  * All queues share a single thread pool that is managed to avoid
- * contention. Threads are assigned to queues dynamically according to
- * where work is available. When multiple queues have work, threads are
- * allocated among them stochastically with an eye toward preventing
- * pipeline stalls.
+ * contention. Threads are assigned to queues dynamically according to where
+ * work is available. When multiple queues have work, threads are allocated
+ * among them stochastically with an eye toward preventing pipeline stalls.
  *
  * The shared thread pool persists until the process exits.
  */
 
-#define	MAX_BATCH 32	/* The most items that can be claimed at once */
+#define	ZQ_MAX_BATCH	32	/* The most items that can be claimed at once */
+#define	ZQ_MAX_QUEUES	16	/* The maximum number of simultaneous queues */
+#define	ZQ_MIN_THREADS	6
 
 typedef void queue_item_t;
 
@@ -82,10 +83,10 @@ zq_process_item_f(queue_item_t *item, void *context);
  * Set the number of threads to be spawned for queue work. Since all queues
  * share a thread pool, this value affects all queues. The value must be set
  * before any queues are created. By default, one thread is spawned for
- * every CPU core.
+ * every CPU core, but always at least ZQ_MIN_THREADS threads.
  */
 void
-zstream_queue_set_num_threads(uint_t num_threads);
+zstream_queue_set_num_threads(int num_threads);
 
 /*
  * Create a queue. The qp_context field is passed to the cost and processing

--- a/cmd/zstream/zstream_recompress.c
+++ b/cmd/zstream/zstream_recompress.c
@@ -354,7 +354,7 @@ zstream_do_recompress(int argc, char *argv[])
 {
 	int c;
 	int level = ZIO_COMPLEVEL_DEFAULT;
-	uint_t num_threads = 0;
+	int num_threads = 0;
 
 	chain_attrs_t attrs = { .ca_command_opts = CA_FORBID_DEDUP };
 
@@ -367,7 +367,7 @@ zstream_do_recompress(int argc, char *argv[])
 			}
 			break;
 		case 't':
-			if (sscanf(optarg, "%u", &num_threads) != 1) {
+			if (sscanf(optarg, "%d", &num_threads) != 1) {
 				warnx("failed to parse num_threads '%s'",
 				    optarg);
 				zstream_usage();

--- a/cmd/zstream/zstream_selftest.c
+++ b/cmd/zstream/zstream_selftest.c
@@ -132,7 +132,7 @@ zstream_do_selftest(int argc, char *argv[])
 {
 	boolean_t list_only = B_FALSE;
 	boolean_t have_seed = B_FALSE;
-	uint_t nthreads = 0;
+	int nthreads = 0;
 	char *end;
 	int c;
 
@@ -150,12 +150,12 @@ zstream_do_selftest(int argc, char *argv[])
 			have_seed = B_TRUE;
 			break;
 		case 't':
-			if (sscanf(optarg, "%u", &nthreads) != 1 ||
-			    nthreads == 0) {
+			if (sscanf(optarg, "%d", &nthreads) != 1) {
 				warnx("failed to parse num_threads '%s'",
 				    optarg);
 				selftest_usage();
 			}
+			zstream_queue_set_num_threads(nthreads);
 			break;
 		case '?':
 			warnx("invalid option '%c'", optopt);
@@ -184,10 +184,6 @@ zstream_do_selftest(int argc, char *argv[])
 		    sizeof (selftest_seed));
 	(void) printf("Using seed 0x%016jx (replay with -s 0x%jx)\n",
 	    (uintmax_t)selftest_seed, (uintmax_t)selftest_seed);
-
-	if (nthreads > 0)
-		zstream_queue_set_num_threads(nthreads);
-
 
 	int count = 0;
 	if (argc == 1) {

--- a/cmd/zstream/zstream_selftest_queue.c
+++ b/cmd/zstream/zstream_selftest_queue.c
@@ -399,7 +399,7 @@ static void
 queue_edge_cases(void)
 {
 	static const size_t lengths[] =
-	    { 1, 2, MAX_BATCH - 1, MAX_BATCH, MAX_BATCH + 1, 64 };
+	    { 1, 2, ZQ_MAX_BATCH - 1, ZQ_MAX_BATCH, ZQ_MAX_BATCH + 1, 64 };
 	static const size_t budgets[] = { 0, 1, 16, SIZE_MAX / 2 };
 	uint64_t stream = 200;
 


### PR DESCRIPTION
The current zstream code uses an enqueue mutex to avoid the possibility of enqueue notifications being dropped.

Unfortunately, the enqueue mutex is highly contested. Workers must hold it while searching queues for work, while enqueuers must acquire it to complete their enqueues. This contention results in a nontrivial performance cost.

This PR removes the enqueue mutex and replaces it with a separate dispatch thread. It also adds a lazy 100 microseconds between an enqueue and the signal that wakes up a thread to service it. This coalescing of notifications encourages larger batch sizes and reduces the number of worker loops.

Other changes:

- There's now a pool-level count of unclaimed items that's maintained with atomic operations. This value is used to short-circuit worker loops that would likely be fruitless. Because reads on this value are relaxed, it's possible to see a stale value. A backup timer restarts dispatching in the (unlikely) event of a stall.

- When compiled with the `MONITOR_QUEUES` #define, `zstream` now shows a batch-size histogram for each queue once the queue is complete. The layout of per-queue information printed during operation has also been tuned.

- There are a few additional hygiene and robustness changes that probably aren't worth describing in detail.

### Doesn't the 100us delay limit on the batch-claiming rate?

No. Batch-claiming threads (already) wake up another thread on their way out if more work is available. There's no limit on how long those chains can be.

### Why 100us?

It doesn't really matter. 100us is empirically the smallest delay that seems to put every test load within striking distance of its best possible performance. But anything an order of magnitude to either side is roughly equivalent. The delay is helpful, but it's not the load-bearing element.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
