### PR TITLE
Linux: tighten secpolicy zone checks

### DIFF
--- a/include/os/freebsd/spl/sys/policy.h
+++ b/include/os/freebsd/spl/sys/policy.h
@@ -37,7 +37,6 @@ struct mount;
 struct vattr;
 struct znode;
 
-int	secpolicy_nfs(cred_t *cr);
 int	secpolicy_zfs(cred_t *crd);
 int	secpolicy_sys_config(cred_t *cr, int checkonly);
 int	secpolicy_zinject(cred_t *cr);

--- a/include/os/linux/zfs/sys/policy.h
+++ b/include/os/linux/zfs/sys/policy.h
@@ -28,7 +28,6 @@
 
 struct znode;
 
-int secpolicy_nfs(const cred_t *);
 int secpolicy_sys_config(const cred_t *, boolean_t);
 int secpolicy_vnode_access2(const cred_t *, struct inode *,
     uid_t, mode_t, mode_t);

--- a/module/os/freebsd/spl/spl_policy.c
+++ b/module/os/freebsd/spl/spl_policy.c
@@ -39,13 +39,6 @@
 
 
 int
-secpolicy_nfs(cred_t *cr)
-{
-
-	return (priv_check_cred(cr, PRIV_NFS_DAEMON));
-}
-
-int
 secpolicy_zfs(cred_t *cr)
 {
 

--- a/module/os/linux/zfs/policy.c
+++ b/module/os/linux/zfs/policy.c
@@ -85,6 +85,9 @@ priv_policy_user(const cred_t *cr, int capability, int err)
 int
 secpolicy_sys_config(const cred_t *cr, boolean_t checkonly)
 {
+	/* pools can only be manipulated from the global zone */
+	if (crgetzoneid(cr) != GLOBAL_ZONEID)
+		return (EACCES);
 	return (priv_policy(cr, CAP_SYS_ADMIN, EPERM));
 }
 

--- a/module/os/linux/zfs/policy.c
+++ b/module/os/linux/zfs/policy.c
@@ -77,16 +77,6 @@ priv_policy_user(const cred_t *cr, int capability, int err)
 }
 
 /*
- * Checks for operations that are either client-only or are used by
- * both clients and servers.
- */
-int
-secpolicy_nfs(const cred_t *cr)
-{
-	return (priv_policy(cr, CAP_SYS_ADMIN, EPERM));
-}
-
-/*
  * Catch all system configuration.
  */
 int

--- a/module/os/linux/zfs/policy.c
+++ b/module/os/linux/zfs/policy.c
@@ -15,7 +15,10 @@
  * Copyright 2013, Joyent, Inc. All rights reserved.
  * Copyright (C) 2016 Lawrence Livermore National Security, LLC.
  * Copyright (c) 2025, Rob Norris <robn@despairlabs.com>
- *
+ * Copyright (c) 2026, TrueNAS.
+ */
+
+/*
  * For Linux the vast majority of this enforcement is already handled via
  * the standard Linux VFS permission checks.  However certain administrative
  * commands which bypass the standard mechanisms may need to make use of
@@ -221,6 +224,9 @@ secpolicy_vnode_setids_setgids(const cred_t *cr, gid_t gid, zidmap_t *idmap,
 int
 secpolicy_zinject(const cred_t *cr)
 {
+	/* zinject is only in the global zone */
+	if (crgetzoneid(cr) != GLOBAL_ZONEID)
+		return (EACCES);
 	return (priv_policy(cr, CAP_SYS_ADMIN, EACCES));
 }
 

--- a/module/os/linux/zfs/policy.c
+++ b/module/os/linux/zfs/policy.c
@@ -240,6 +240,14 @@ secpolicy_zinject(const cred_t *cr)
 int
 secpolicy_zfs(const cred_t *cr)
 {
+	/*
+	 * Note that CAP_SYS_ADMIN is effectively "root"-like privileges in
+	 * the given user namespace. Those happen to include mount control
+	 * (matching PRIV_SYS_MOUNT on illumos). There is not a narrower
+	 * permission available. It's important that callers do narrower
+	 * permission checks (eg zone checks) along with this call.
+	 *   -- robn, 2026-08-14
+	 */
 	return (priv_policy(cr, CAP_SYS_ADMIN, EACCES));
 }
 

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -236,7 +236,7 @@ tags = ['functional', 'upgrade']
 
 [tests/functional/user_namespace:Linux]
 tests = ['user_namespace_001', 'user_namespace_002', 'user_namespace_003',
-    'user_namespace_004']
+    'user_namespace_004', 'user_namespace_secpolicy_sys_config']
 tags = ['functional', 'user_namespace']
 
 [tests/functional/userquota:Linux]

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -236,7 +236,8 @@ tags = ['functional', 'upgrade']
 
 [tests/functional/user_namespace:Linux]
 tests = ['user_namespace_001', 'user_namespace_002', 'user_namespace_003',
-    'user_namespace_004', 'user_namespace_secpolicy_sys_config']
+    'user_namespace_004', 'user_namespace_secpolicy_sys_config',
+    'user_namespace_secpolicy_zinject']
 tags = ['functional', 'user_namespace']
 
 [tests/functional/userquota:Linux]

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -2331,6 +2331,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/user_namespace/user_namespace_002.ksh \
 	functional/user_namespace/user_namespace_003.ksh \
 	functional/user_namespace/user_namespace_004.ksh \
+	functional/user_namespace/user_namespace_secpolicy_sys_config.ksh \
 	functional/userquota/cleanup.ksh \
 	functional/userquota/groupspace_001_pos.ksh \
 	functional/userquota/groupspace_002_pos.ksh \

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -2332,6 +2332,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/user_namespace/user_namespace_003.ksh \
 	functional/user_namespace/user_namespace_004.ksh \
 	functional/user_namespace/user_namespace_secpolicy_sys_config.ksh \
+	functional/user_namespace/user_namespace_secpolicy_zinject.ksh \
 	functional/userquota/cleanup.ksh \
 	functional/userquota/groupspace_001_pos.ksh \
 	functional/userquota/groupspace_002_pos.ksh \

--- a/tests/zfs-tests/tests/functional/user_namespace/user_namespace_secpolicy_sys_config.ksh
+++ b/tests/zfs-tests/tests/functional/user_namespace/user_namespace_secpolicy_sys_config.ksh
@@ -1,0 +1,46 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
+#
+
+#
+# Copyright (c) 2026, TrueNAS.
+#
+
+. $STF_SUITE/tests/functional/user_namespace/user_namespace_common.kshlib
+
+#
+# Verify that secpolicy_sys_config() only allows the superuser in the root/init
+# namespace.
+#
+# Currently, zpool/zfs start by getting a list of pools, which has separate
+# zone visibility checks, and then don't proceed if no pools are found. So,
+# we use `zpool events` for the test, which uses secpolicy_sys_config() but
+# doesn't need a name to work, and so zpool doesn't bother with the lookup.
+#
+
+verify_runnable "both"
+
+log_assert "secpolicy_sys_config correctly limits access."
+
+# default superuser can access pool events
+log_must eval 'zpool events >/dev/null'
+
+# regular user cannot access pool events
+log_mustnot eval 'sudo -u nobody zpool events >/dev/null'
+
+# superuser in a new user namespace cannot access pool events
+log_mustnot eval 'unshare -Ur zpool events >/dev/null'
+
+# regular user in a new user namespace cannot access pool events
+log_mustnot eval 'unshare -U zpool events >/dev/null'
+
+log_pass "secpolicy_sys_config correctly limits access."

--- a/tests/zfs-tests/tests/functional/user_namespace/user_namespace_secpolicy_zinject.ksh
+++ b/tests/zfs-tests/tests/functional/user_namespace/user_namespace_secpolicy_zinject.ksh
@@ -1,0 +1,46 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
+#
+
+#
+# Copyright (c) 2026, TrueNAS.
+#
+
+. $STF_SUITE/tests/functional/user_namespace/user_namespace_common.kshlib
+
+#
+# Verify that secpolicy_zinject() only allows the superuser in the root/init
+# namespace.
+#
+# Because we don't actually want to inject anything, we just try to run
+# `zinject -c all`, which with no injections is just a permission check and
+# then an (effective) no-op.
+#
+
+verify_runnable "both"
+
+log_assert "secpolicy_zinject correctly limits access."
+
+# default superuser can access pool events
+log_must zinject -c all
+
+# regular user cannot access pool events
+log_mustnot sudo -u nobody zinject -c all
+
+# superuser in a new user namespace cannot access pool events
+log_mustnot unshare -Ur zinject -c all
+
+# regular user in a new user namespace cannot access pool events
+log_mustnot unshare -U zinject -c all
+
+log_pass "secpolicy_zinject correctly limits access."
+


### PR DESCRIPTION
_[Sponsors: TrueNAS]_

### Motivation and Context

A couple of the secpolicy checks on Linux were not quite as tight as their FreeBSD (and illumos!) equivalents. This brings them into line.

### Description

See commits. Extends `secpolicy_sys_config()` and `secpolicy_zinject()` to be scoped to the global zone, matching FreeBSD behaviour.

### How Has This Been Tested?

ZTS run against 7.2.0 passed. Compile checked on 5.4, 6.1, 6.8 and 7.0.

Two new tests included to exercise these checks in/out of global zone.

### Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).