### PR TITLE
`vdev_open`: use calling credential to check for device access

### DIFF
--- a/include/sys/vdev.h
+++ b/include/sys/vdev.h
@@ -15,6 +15,7 @@
  * Copyright (c) 2011, 2020 by Delphix. All rights reserved.
  * Copyright (c) 2017, Intel Corporation.
  * Copyright (c) 2019, Datto Inc. All rights reserved.
+ * Copyright (c) 2026, TrueNAS.
  */
 
 #ifndef _SYS_VDEV_H
@@ -46,9 +47,10 @@ typedef boolean_t vdev_open_children_func_t(vdev_t *vd);
 extern void vdev_dbgmsg(vdev_t *vd, const char *fmt, ...)
     __attribute__((format(__printf__, 2, 3)));
 extern void vdev_dbgmsg_print_tree(vdev_t *, int);
-extern int vdev_open(vdev_t *);
-extern void vdev_open_children(vdev_t *);
-extern void vdev_open_children_subset(vdev_t *, vdev_open_children_func_t *);
+extern int vdev_open(vdev_t *, cred_t *);
+extern void vdev_open_children(vdev_t *, cred_t *);
+extern void vdev_open_children_subset(vdev_t *, cred_t *,
+    vdev_open_children_func_t *);
 extern int vdev_validate(vdev_t *);
 extern int vdev_copy_path_strict(vdev_t *, vdev_t *);
 extern void vdev_copy_path_relaxed(vdev_t *, vdev_t *);

--- a/include/sys/vdev_impl.h
+++ b/include/sys/vdev_impl.h
@@ -57,7 +57,7 @@ typedef int	vdev_init_func_t(spa_t *spa, nvlist_t *nv, void **tsd);
 typedef void	vdev_kobj_post_evt_func_t(vdev_t *vd);
 typedef void	vdev_fini_func_t(vdev_t *vd);
 typedef int	vdev_open_func_t(vdev_t *vd, uint64_t *size, uint64_t *max_size,
-    uint64_t *ashift, uint64_t *pshift);
+    uint64_t *ashift, uint64_t *pshift, cred_t *cr);
 typedef void	vdev_close_func_t(vdev_t *vd);
 typedef uint64_t vdev_asize_func_t(vdev_t *vd, uint64_t psize, uint64_t txg);
 typedef uint64_t vdev_min_asize_func_t(vdev_t *vd);

--- a/include/sys/zfs_file.h
+++ b/include/sys/zfs_file.h
@@ -42,7 +42,8 @@ typedef struct zfs_file_attr {
 	mode_t		zfa_mode;	/* file type */
 } zfs_file_attr_t;
 
-int zfs_file_open(const char *path, int flags, int mode, zfs_file_t **fp);
+int zfs_file_open(const char *path, int flags, int mode, cred_t *cr,
+    zfs_file_t **fp);
 void zfs_file_close(zfs_file_t *fp);
 
 int zfs_file_write(zfs_file_t *fp, const void *buf, size_t len, ssize_t *resid);

--- a/lib/libzpool/kernel.c
+++ b/lib/libzpool/kernel.c
@@ -346,9 +346,9 @@ spa_config_load(void)
 
 	(void) snprintf(pathname, MAXPATHLEN, "%s", spa_config_path);
 
-	err = zfs_file_open(pathname, O_RDONLY, 0, &fp);
+	err = zfs_file_open(pathname, O_RDONLY, 0, kcred, &fp);
 	if (err)
-		err = zfs_file_open(ZPOOL_CACHE_BOOT, O_RDONLY, 0, &fp);
+		err = zfs_file_open(ZPOOL_CACHE_BOOT, O_RDONLY, 0, kcred, &fp);
 
 	kmem_free(pathname, MAXPATHLEN);
 

--- a/lib/libzpool/zfs_file_os.c
+++ b/lib/libzpool/zfs_file_os.c
@@ -34,8 +34,10 @@ char *vn_dumpdir = NULL;
  * Returns 0 on success underlying error on failure.
  */
 int
-zfs_file_open(const char *path, int flags, int mode, zfs_file_t **fpp)
+zfs_file_open(const char *path, int flags, int mode, cred_t *cr,
+    zfs_file_t **fpp)
 {
+	(void) cr;
 	int fd;
 	int dump_fd;
 	int err;

--- a/module/os/freebsd/zfs/vdev_geom.c
+++ b/module/os/freebsd/zfs/vdev_geom.c
@@ -14,6 +14,7 @@
  * All rights reserved.
  *
  * Portions Copyright (c) 2012 Martin Matuska <mm@FreeBSD.org>
+ * Copyright (c) 2026, TrueNAS.
  */
 
 #include <sys/zfs_context.h>
@@ -198,8 +199,45 @@ vdev_geom_orphan(struct g_consumer *cp)
 	}
 }
 
+/*
+ * Ensure the supplied credential has access to the /dev node for this
+ * provider. geom itself has no access control capability, so this is all
+ * we can do. This of course won't work if there is an attempt to use a
+ * geom provider that genuinely has no node, or its tested before /dev
+ * is available. That seems better than allowing access to things they
+ * shouldn't have, We shall see.
+ */
+static bool
+vdev_geom_can_access(struct g_provider *pp, cred_t *cr)
+{
+	struct nameidata nd;
+	struct vnode *vp;
+
+	ASSERT3P(cr, !=, NULL);
+	g_topology_assert_not();
+
+	NDINIT(&nd, LOOKUP, FOLLOW, UIO_SYSSPACE, "/dev");
+	if (namei(&nd) != 0)
+		return (false);
+	NDFREE_PNBUF(&nd);
+
+	vp = nd.ni_vp;
+	NDINIT_ATVP(&nd, LOOKUP, FOLLOW, UIO_SYSSPACE, pp->name, vp);
+	if (namei(&nd) != 0)
+		return (false);
+	NDFREE_PNBUF(&nd);
+	vrele(vp);
+
+	vp = nd.ni_vp;
+	bool can_access = (VOP_ACCESS(vp, VREAD|VWRITE, cr, curthread) == 0);
+	vrele(vp);
+
+	return (can_access);
+}
+
 static struct g_consumer *
-vdev_geom_attach(struct g_provider *pp, vdev_t *vd, boolean_t sanity)
+vdev_geom_attach(struct g_provider *pp, vdev_t *vd, boolean_t sanity,
+    cred_t *cr)
 {
 	struct g_geom *gp;
 	struct g_consumer *cp;
@@ -208,6 +246,19 @@ vdev_geom_attach(struct g_provider *pp, vdev_t *vd, boolean_t sanity)
 	g_topology_assert();
 
 	ZFS_LOG(1, "Attaching to %s.", pp->name);
+
+	if (cr != NULL && cr != kcred) {
+		/* If no cred or non-kernel cred supplied, check access. */
+		g_topology_unlock();
+		bool can_access = vdev_geom_can_access(pp, cr);
+		g_topology_lock();
+		if (!can_access) {
+			ZFS_LOG(1, "Failing attach of %s. "
+			    "No access to dev node.\n",
+			    pp->name);
+			return (NULL);
+		}
+	}
 
 	if (sanity) {
 		if (pp->sectorsize > VDEV_PAD_SIZE || !ISP2(pp->sectorsize)) {
@@ -600,7 +651,11 @@ vdev_geom_read_pool_label(const char *name,
 			LIST_FOREACH(pp, &gp->provider, provider) {
 				if (pp->flags & G_PF_WITHER)
 					continue;
-				zcp = vdev_geom_attach(pp, NULL, B_TRUE);
+				/*
+				 * no cred, because this is during early boot
+				 * and there's no /dev nodes to check yet.
+				 */
+				zcp = vdev_geom_attach(pp, NULL, B_TRUE, NULL);
 				if (zcp == NULL)
 					continue;
 				g_topology_unlock();
@@ -633,14 +688,14 @@ enum match {
 };
 
 static enum match
-vdev_attach_ok(vdev_t *vd, struct g_provider *pp)
+vdev_attach_ok(vdev_t *vd, struct g_provider *pp, cred_t *cr)
 {
 	nvlist_t *config;
 	uint64_t pool_guid, top_guid, vdev_guid;
 	struct g_consumer *cp;
 	int nlabels;
 
-	cp = vdev_geom_attach(pp, NULL, B_TRUE);
+	cp = vdev_geom_attach(pp, NULL, B_TRUE, cr);
 	if (cp == NULL) {
 		ZFS_LOG(1, "Unable to attach tasting instance to %s.",
 		    pp->name);
@@ -692,7 +747,7 @@ vdev_attach_ok(vdev_t *vd, struct g_provider *pp)
 }
 
 static struct g_consumer *
-vdev_geom_attach_by_guids(vdev_t *vd)
+vdev_geom_attach_by_guids(vdev_t *vd, cred_t *cr)
 {
 	struct g_class *mp;
 	struct g_geom *gp;
@@ -714,7 +769,7 @@ vdev_geom_attach_by_guids(vdev_t *vd)
 			if (gp->flags & G_GEOM_WITHER)
 				continue;
 			LIST_FOREACH(pp, &gp->provider, provider) {
-				match = vdev_attach_ok(vd, pp);
+				match = vdev_attach_ok(vd, pp, cr);
 				if (match > best_match) {
 					best_match = match;
 					best_pp = pp;
@@ -731,7 +786,7 @@ vdev_geom_attach_by_guids(vdev_t *vd)
 
 out:
 	if (best_pp) {
-		cp = vdev_geom_attach(best_pp, vd, B_TRUE);
+		cp = vdev_geom_attach(best_pp, vd, B_TRUE, cr);
 		if (cp == NULL) {
 			printf("ZFS WARNING: Unable to attach to %s.\n",
 			    best_pp->name);
@@ -741,7 +796,7 @@ out:
 }
 
 static struct g_consumer *
-vdev_geom_open_by_guids(vdev_t *vd)
+vdev_geom_open_by_guids(vdev_t *vd, cred_t *cr)
 {
 	struct g_consumer *cp;
 	char *buf;
@@ -751,7 +806,7 @@ vdev_geom_open_by_guids(vdev_t *vd)
 
 	ZFS_LOG(1, "Searching by guids [%ju:%ju].",
 	    (uintmax_t)spa_guid(vd->vdev_spa), (uintmax_t)vd->vdev_guid);
-	cp = vdev_geom_attach_by_guids(vd);
+	cp = vdev_geom_attach_by_guids(vd, cr);
 	if (cp != NULL) {
 		len = strlen(cp->provider->name) + strlen("/dev/") + 1;
 		buf = kmem_alloc(len, KM_SLEEP);
@@ -773,7 +828,7 @@ vdev_geom_open_by_guids(vdev_t *vd)
 }
 
 static struct g_consumer *
-vdev_geom_open_by_path(vdev_t *vd, int check_guid)
+vdev_geom_open_by_path(vdev_t *vd, int check_guid, cred_t *cr)
 {
 	struct g_provider *pp;
 	struct g_consumer *cp;
@@ -784,8 +839,8 @@ vdev_geom_open_by_path(vdev_t *vd, int check_guid)
 	pp = g_provider_by_name(vd->vdev_path + sizeof ("/dev/") - 1);
 	if (pp != NULL) {
 		ZFS_LOG(1, "Found provider by name %s.", vd->vdev_path);
-		if (!check_guid || vdev_attach_ok(vd, pp) == FULL_MATCH)
-			cp = vdev_geom_attach(pp, vd, B_FALSE);
+		if (!check_guid || vdev_attach_ok(vd, pp, cr) == FULL_MATCH)
+			cp = vdev_geom_attach(pp, vd, B_FALSE, cr);
 	}
 
 	return (cp);
@@ -795,7 +850,6 @@ static int
 vdev_geom_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
     uint64_t *logical_ashift, uint64_t *physical_ashift, cred_t *cr)
 {
-	(void) cr;
 	struct g_provider *pp;
 	struct g_consumer *cp;
 	int error, has_trim;
@@ -847,13 +901,13 @@ vdev_geom_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
 		 *           unless we are doing a split, in which case we
 		 *           should allow any guid.
 		 */
-		cp = vdev_geom_open_by_path(vd, 0);
+		cp = vdev_geom_open_by_path(vd, 0, cr);
 	} else {
 		/*
 		 * Try using the recorded path for this device, but only
 		 * accept it if its label data contains the expected GUIDs.
 		 */
-		cp = vdev_geom_open_by_path(vd, 1);
+		cp = vdev_geom_open_by_path(vd, 1, cr);
 		if (cp == NULL) {
 			/*
 			 * The device at vd->vdev_path doesn't have the
@@ -861,7 +915,7 @@ vdev_geom_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
 			 * moved around so try all other GEOM providers
 			 * to find one with the right GUIDs.
 			 */
-			cp = vdev_geom_open_by_guids(vd);
+			cp = vdev_geom_open_by_guids(vd, cr);
 		}
 	}
 

--- a/module/os/freebsd/zfs/vdev_geom.c
+++ b/module/os/freebsd/zfs/vdev_geom.c
@@ -793,8 +793,9 @@ vdev_geom_open_by_path(vdev_t *vd, int check_guid)
 
 static int
 vdev_geom_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
-    uint64_t *logical_ashift, uint64_t *physical_ashift)
+    uint64_t *logical_ashift, uint64_t *physical_ashift, cred_t *cr)
 {
+	(void) cr;
 	struct g_provider *pp;
 	struct g_consumer *cp;
 	int error, has_trim;

--- a/module/os/freebsd/zfs/zfs_file_os.c
+++ b/module/os/freebsd/zfs/zfs_file_os.c
@@ -48,7 +48,8 @@
 #include <sys/stat.h>
 
 int
-zfs_file_open(const char *path, int flags, int mode, zfs_file_t **fpp)
+zfs_file_open(const char *path, int flags, int mode, cred_t *cr,
+    zfs_file_t **fpp)
 {
 	struct thread *td;
 	struct vnode *vp;
@@ -76,7 +77,7 @@ zfs_file_open(const char *path, int flags, int mode, zfs_file_t **fpp)
 #else
 	NDINIT(&nd, LOOKUP, FOLLOW, UIO_SYSSPACE, path, td);
 #endif
-	error = vn_open(&nd, &flags, mode, fp);
+	error = vn_open_cred(&nd, &flags, mode, 0, cr, fp);
 	if (error != 0) {
 		falloc_abort(td, fp);
 		return (SET_ERROR(error));
@@ -94,7 +95,7 @@ zfs_file_open(const char *path, int flags, int mode, zfs_file_t **fpp)
 	}
 
 	if (flags & O_TRUNC) {
-		error = fo_truncate(fp, 0, td->td_ucred, td);
+		error = fo_truncate(fp, 0, cr, td);
 		if (error != 0) {
 			zfs_file_close(fp);
 			return (SET_ERROR(error));

--- a/module/os/linux/zfs/vdev_disk.c
+++ b/module/os/linux/zfs/vdev_disk.c
@@ -16,6 +16,7 @@
  * LLNL-CODE-403049.
  * Copyright (c) 2012, 2019 by Delphix. All rights reserved.
  * Copyright (c) 2023, 2024, 2025, Klara, Inc.
+ * Copyright (c) 2026, TrueNAS.
  */
 
 #include <sys/zfs_context.h>
@@ -280,14 +281,28 @@ vdev_blkdev_put(zfs_bdev_handle_t *bdh, spa_mode_t smode, void *holder)
 }
 
 static int
+vdev_path_backing_permission(struct path *path, int mask)
+{
+#if defined(HAVE_IDMAP_MNTIDMAP)
+	return (inode_permission(mnt_idmap(path->mnt),
+	    d_backing_inode(path->dentry), mask));
+#elif defined(HAVE_IDMAP_USERNS)
+	return (inode_permission(mnt_user_ns(path->mnt),
+	    d_backing_inode(path->dentry), mask));
+#else
+	return (inode_permission(d_backing_inode(path->dentry), mask));
+#endif
+}
+
+static int
 vdev_disk_open(vdev_t *v, uint64_t *psize, uint64_t *max_psize,
     uint64_t *logical_ashift, uint64_t *physical_ashift, cred_t *cr)
 {
-	(void) cr;
 	zfs_bdev_handle_t *bdh;
 	spa_mode_t smode = spa_mode(v->vdev_spa);
 	hrtime_t timeout = MSEC2NSEC(zfs_vdev_open_timeout_ms);
 	vdev_disk_t *vd;
+	const cred_t *oldcr = NULL;
 
 	/* Must have a pathname and it must be absolute. */
 	if (v->vdev_path == NULL || v->vdev_path[0] != '/') {
@@ -308,6 +323,13 @@ vdev_disk_open(vdev_t *v, uint64_t *psize, uint64_t *max_psize,
 	if (vd) {
 		char disk_name[BDEVNAME_SIZE + 6] = "/dev/";
 		boolean_t reread_part = B_FALSE;
+
+		/*
+		 * Reopening an already-open device, so the caller credential
+		 * is irrelevant - we had access to it before, we can assume
+		 * we still do.
+		 */
+		oldcr = override_creds(kcred);
 
 		rw_enter(&vd->vd_lock, RW_WRITER);
 		bdh = vd->vd_bdh;
@@ -357,6 +379,9 @@ vdev_disk_open(vdev_t *v, uint64_t *psize, uint64_t *max_psize,
 
 		rw_init(&vd->vd_lock, NULL, RW_DEFAULT, NULL);
 		rw_enter(&vd->vd_lock, RW_WRITER);
+
+		/* Restrict device access below to caller's permissions. */
+		oldcr = override_creds(cr);
 	}
 
 	/*
@@ -387,12 +412,37 @@ vdev_disk_open(vdev_t *v, uint64_t *psize, uint64_t *max_psize,
 	 * logic in zvol_open().  Extend the timeout and retry the open
 	 * subsequent attempts are expected to eventually succeed.
 	 */
+
 	hrtime_t start = gethrtime();
-	bdh = BDH_ERR_PTR(-ENXIO);
-	while (BDH_IS_ERR(bdh) && ((gethrtime() - start) < timeout)) {
-		bdh = vdev_blkdev_get_by_path(v->vdev_path, smode,
-		    zfs_vdev_holder);
-		if (unlikely(BDH_PTR_ERR(bdh) == -ENOENT)) {
+	int err = ENXIO;
+	while (err != 0 && ((gethrtime() - start) < timeout)) {
+
+		/*
+		 * Ensure the caller credential (made live by override_creds()
+		 * above) has access to the device node. This will include
+		 * checking file permissions and considering the
+		 * CAP_DAC_OVERRIDE capability.
+		 */
+		struct path devpath;
+		err = kern_path(v->vdev_path, LOOKUP_FOLLOW, &devpath);
+		if (err == 0) {
+			int mask =
+			    (smode & SPA_MODE_READ ? MAY_READ : 0) |
+			    (smode & SPA_MODE_WRITE ? MAY_WRITE : 0);
+			err = vdev_path_backing_permission(&devpath, mask);
+			path_put(&devpath);
+		}
+
+		if (err == 0) {
+			bdh = vdev_blkdev_get_by_path(v->vdev_path, smode,
+			    zfs_vdev_holder);
+			err = BDH_IS_ERR(bdh) ? BDH_PTR_ERR(bdh) : 0;
+		}
+
+		if (err == 0)
+			break;
+
+		if (unlikely(err == -ENOENT)) {
 			/*
 			 * There is no point of waiting since device is removed
 			 * explicitly
@@ -401,28 +451,29 @@ vdev_disk_open(vdev_t *v, uint64_t *psize, uint64_t *max_psize,
 				break;
 
 			schedule_timeout_interruptible(MSEC_TO_TICK(10));
-		} else if (unlikely(BDH_PTR_ERR(bdh) == -ERESTARTSYS)) {
+		} else if (unlikely(err == -ERESTARTSYS)) {
 			timeout = MSEC2NSEC(zfs_vdev_open_timeout_ms * 10);
 			continue;
-		} else if (BDH_IS_ERR(bdh)) {
-			break;
 		}
+
+		break;
 	}
 
-	if (BDH_IS_ERR(bdh)) {
-		int error = -BDH_PTR_ERR(bdh);
-		vdev_dbgmsg(v, "open error=%d timeout=%llu/%llu", error,
+	revert_creds(oldcr);
+
+	if (err != 0) {
+		vdev_dbgmsg(v, "open error=%d timeout=%llu/%llu", -err,
 		    (u_longlong_t)(gethrtime() - start),
 		    (u_longlong_t)timeout);
 		vd->vd_bdh = NULL;
 		v->vdev_tsd = vd;
 		rw_exit(&vd->vd_lock);
-		return (SET_ERROR(error));
-	} else {
-		vd->vd_bdh = bdh;
-		v->vdev_tsd = vd;
-		rw_exit(&vd->vd_lock);
+		return (SET_ERROR(-err));
 	}
+
+	vd->vd_bdh = bdh;
+	v->vdev_tsd = vd;
+	rw_exit(&vd->vd_lock);
 
 	struct block_device *bdev = BDH_BDEV(vd->vd_bdh);
 

--- a/module/os/linux/zfs/vdev_disk.c
+++ b/module/os/linux/zfs/vdev_disk.c
@@ -281,8 +281,9 @@ vdev_blkdev_put(zfs_bdev_handle_t *bdh, spa_mode_t smode, void *holder)
 
 static int
 vdev_disk_open(vdev_t *v, uint64_t *psize, uint64_t *max_psize,
-    uint64_t *logical_ashift, uint64_t *physical_ashift)
+    uint64_t *logical_ashift, uint64_t *physical_ashift, cred_t *cr)
 {
+	(void) cr;
 	zfs_bdev_handle_t *bdh;
 	spa_mode_t smode = spa_mode(v->vdev_spa);
 	hrtime_t timeout = MSEC2NSEC(zfs_vdev_open_timeout_ms);

--- a/module/os/linux/zfs/zfs_file_os.c
+++ b/module/os/linux/zfs/zfs_file_os.c
@@ -31,7 +31,8 @@
  * Returns 0 on success underlying error on failure.
  */
 int
-zfs_file_open(const char *path, int flags, int mode, zfs_file_t **fpp)
+zfs_file_open(const char *path, int flags, int mode, cred_t *cr,
+    zfs_file_t **fpp)
 {
 	struct file *filp;
 	int saved_umask;
@@ -42,7 +43,9 @@ zfs_file_open(const char *path, int flags, int mode, zfs_file_t **fpp)
 	if (flags & O_CREAT)
 		saved_umask = xchg(&current->fs->umask, 0);
 
+	const cred_t *oldcr = override_creds(cr);
 	filp = filp_open(path, flags, mode);
+	revert_creds(oldcr);
 
 	if (flags & O_CREAT)
 		(void) xchg(&current->fs->umask, saved_umask);

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -2572,7 +2572,7 @@ spa_load_spares(spa_t *spa)
 		vd->vdev_top = vd;
 		vd->vdev_aux = &spa->spa_spares;
 
-		if (vdev_open(vd) != 0)
+		if (vdev_open(vd, CRED()) != 0)
 			continue;
 
 		if (vdev_validate_aux(vd) == 0)
@@ -2685,7 +2685,7 @@ spa_load_l2cache(spa_t *spa)
 
 			spa_l2cache_activate(vd);
 
-			if (vdev_open(vd) != 0)
+			if (vdev_open(vd, CRED()) != 0)
 				continue;
 
 			(void) vdev_validate_aux(vd);
@@ -4721,7 +4721,7 @@ spa_ld_open_vdevs(spa_t *spa)
 	    MAX(zfs_max_missing_tvds, spa->spa_missing_tvds_allowed);
 
 	spa_config_enter(spa, SCL_ALL, FTAG, RW_WRITER);
-	error = vdev_open(spa->spa_root_vdev);
+	error = vdev_open(spa->spa_root_vdev, CRED());
 	spa_config_exit(spa, SCL_ALL, FTAG);
 
 	if (spa->spa_missing_tvds != 0) {
@@ -6993,7 +6993,7 @@ spa_validate_aux_devs(spa_t *spa, nvlist_t *nvroot, uint64_t crtxg, int mode,
 
 		vd->vdev_top = vd;
 
-		if ((error = vdev_open(vd)) == 0 &&
+		if ((error = vdev_open(vd, CRED())) == 0 &&
 		    (error = vdev_label_init(vd, crtxg, label)) == 0) {
 			fnvlist_add_uint64(dev[i], ZPOOL_CONFIG_GUID,
 			    vd->vdev_guid);

--- a/module/zfs/spa_config.c
+++ b/module/zfs/spa_config.c
@@ -74,7 +74,7 @@ spa_config_remove(spa_config_dirent_t *dp)
 		int flags = O_RDWR | O_TRUNC;
 		zfs_file_t *fp;
 
-		error = zfs_file_open(dp->scd_path, flags, 0644, &fp);
+		error = zfs_file_open(dp->scd_path, flags, 0644, kcred, &fp);
 		if (error == 0) {
 			(void) zfs_file_fsync(fp, O_SYNC);
 			(void) zfs_file_close(fp);
@@ -117,7 +117,7 @@ spa_config_write(spa_config_dirent_t *dp, nvlist_t *nvl)
 	 * is instead truncated and overwritten in place.  This way we always
 	 * have a consistent view of the data or a zero length file.
 	 */
-	err = zfs_file_open(dp->scd_path, oflags, 0644, &fp);
+	err = zfs_file_open(dp->scd_path, oflags, 0644, kcred, &fp);
 	if (err == 0) {
 		err = zfs_file_write(fp, buf, buflen, NULL);
 		if (err == 0)

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -22,6 +22,7 @@
  * Copyright (c) 2021, 2025, Klara, Inc.
  * Copyright (c) 2021, 2023 Hewlett Packard Enterprise Development LP.
  * Copyright (c) 2026, Seagate Technology, LLC.
+ * Copyright (c) 2026, TrueNAS.
  */
 
 #include <sys/zfs_context.h>
@@ -1987,14 +1988,23 @@ vdev_load_child(void *arg)
 	vd->vdev_load_error = vdev_load(vd);
 }
 
+typedef struct {
+	vdev_t	*voc_vdev;
+	cred_t	*voc_cred;
+} vdev_open_child_t;
+
 static void
 vdev_open_child(void *arg)
 {
-	vdev_t *vd = arg;
+	vdev_open_child_t *voc = arg;
+	vdev_t *vd = voc->voc_vdev;
 
 	vd->vdev_open_thread = curthread;
-	vd->vdev_open_error = vdev_open(vd);
+	vd->vdev_open_error = vdev_open(vd, voc->voc_cred);
 	vd->vdev_open_thread = NULL;
+
+	crfree(voc->voc_cred);
+	kmem_free(voc, sizeof (vdev_open_child_t));
 }
 
 static boolean_t
@@ -2028,7 +2038,8 @@ vdev_default_open_children_func(vdev_t *vd)
  * deadlock when the current thread is holding the spa_namespace_lock.
  */
 static void
-vdev_open_children_impl(vdev_t *vd, vdev_open_children_func_t *open_func)
+vdev_open_children_impl(vdev_t *vd, cred_t *cred,
+    vdev_open_children_func_t *open_func)
 {
 	int children = vd->vdev_children;
 
@@ -2043,10 +2054,15 @@ vdev_open_children_impl(vdev_t *vd, vdev_open_children_func_t *open_func)
 			continue;
 
 		if (tq == NULL || vdev_uses_zvols(vd)) {
-			cvd->vdev_open_error = vdev_open(cvd);
+			cvd->vdev_open_error = vdev_open(cvd, cred);
 		} else {
+			vdev_open_child_t *voc =
+			    kmem_alloc(sizeof (vdev_open_child_t), KM_SLEEP);
+			voc->voc_vdev = cvd;
+			voc->voc_cred = cred;
+			crhold(cred);
 			VERIFY(taskq_dispatch(tq, vdev_open_child,
-			    cvd, TQ_SLEEP) != TASKQID_INVALID);
+			    voc, TQ_SLEEP) != TASKQID_INVALID);
 		}
 	}
 
@@ -2069,18 +2085,19 @@ vdev_open_children_impl(vdev_t *vd, vdev_open_children_func_t *open_func)
  * Open all child vdevs.
  */
 void
-vdev_open_children(vdev_t *vd)
+vdev_open_children(vdev_t *vd, cred_t *cred)
 {
-	vdev_open_children_impl(vd, vdev_default_open_children_func);
+	vdev_open_children_impl(vd, cred, vdev_default_open_children_func);
 }
 
 /*
  * Conditionally open a subset of child vdevs.
  */
 void
-vdev_open_children_subset(vdev_t *vd, vdev_open_children_func_t *open_func)
+vdev_open_children_subset(vdev_t *vd, cred_t *cred,
+    vdev_open_children_func_t *open_func)
 {
-	vdev_open_children_impl(vd, open_func);
+	vdev_open_children_impl(vd, cred, open_func);
 }
 
 /*
@@ -2156,7 +2173,7 @@ vdev_ashift_optimize(vdev_t *vd)
  * Prepare a virtual device for access.
  */
 int
-vdev_open(vdev_t *vd)
+vdev_open(vdev_t *vd, cred_t *cred)
 {
 	spa_t *spa = vd->vdev_spa;
 	int error;
@@ -2197,7 +2214,7 @@ vdev_open(vdev_t *vd)
 	}
 
 	error = vd->vdev_ops->vdev_op_open(vd, &osize, &max_osize,
-	    &logical_ashift, &physical_ashift);
+	    &logical_ashift, &physical_ashift, cred);
 
 	/* Keep the device in removed state if unplugged */
 	if (error == ENOENT && vd->vdev_removed) {
@@ -2889,7 +2906,7 @@ vdev_reopen(vdev_t *vd)
 	/* set the reopening flag unless we're taking the vdev offline */
 	vd->vdev_reopening = !vd->vdev_offline;
 	vdev_close(vd);
-	(void) vdev_open(vd);
+	(void) vdev_open(vd, CRED());
 
 	/*
 	 * Call vdev_validate() here to make sure we have the same device.
@@ -2944,7 +2961,7 @@ vdev_create(vdev_t *vd, uint64_t txg, boolean_t isreplacing)
 	 * For a create, however, we want to fail the request if
 	 * there are any components we can't open.
 	 */
-	error = vdev_open(vd);
+	error = vdev_open(vd, CRED());
 
 	if (error || vd->vdev_state != VDEV_STATE_HEALTHY) {
 		vdev_close(vd);

--- a/module/zfs/vdev_draid.c
+++ b/module/zfs/vdev_draid.c
@@ -1684,7 +1684,7 @@ vdev_draid_open_children(vdev_t *vd)
  */
 static int
 vdev_draid_open(vdev_t *vd, uint64_t *asize, uint64_t *max_asize,
-    uint64_t *logical_ashift, uint64_t *physical_ashift)
+    uint64_t *logical_ashift, uint64_t *physical_ashift, cred_t *cr)
 {
 	vdev_draid_config_t *vdc =  vd->vdev_tsd;
 	uint64_t nparity = vdc->vdc_nparity;
@@ -1701,8 +1701,8 @@ vdev_draid_open(vdev_t *vd, uint64_t *asize, uint64_t *max_asize,
 	 * ordering is important to ensure the distributed spares calculate
 	 * the correct psize in the event that the dRAID vdevs were expanded.
 	 */
-	vdev_open_children_subset(vd, vdev_draid_open_children);
-	vdev_open_children_subset(vd, vdev_draid_open_spares);
+	vdev_open_children_subset(vd, cr, vdev_draid_open_children);
+	vdev_open_children_subset(vd, cr, vdev_draid_open_spares);
 
 	/*
 	 * Verify enough of the children are available to continue.
@@ -2720,8 +2720,9 @@ vdev_draid_spare_close(vdev_t *vd)
  */
 static int
 vdev_draid_spare_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
-    uint64_t *logical_ashift, uint64_t *physical_ashift)
+    uint64_t *logical_ashift, uint64_t *physical_ashift, cred_t *cr)
 {
+	(void) cr;
 	vdev_draid_spare_t *vds = vd->vdev_tsd;
 	vdev_t *rvd = vd->vdev_spa->spa_root_vdev;
 	uint64_t asize, max_asize;

--- a/module/zfs/vdev_file.c
+++ b/module/zfs/vdev_file.c
@@ -146,7 +146,8 @@ vdev_file_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
 	ASSERT3S(vd->vdev_path[0], ==, '/');
 
 	error = zfs_file_open(vd->vdev_path,
-	    vdev_file_open_mode(spa_mode(vd->vdev_spa)), 0, &fp);
+	    vdev_file_open_mode(spa_mode(vd->vdev_spa)), 0, kcred, &fp);
+
 	if (error) {
 		vd->vdev_stat.vs_aux = VDEV_AUX_OPEN_FAILED;
 		return (error);

--- a/module/zfs/vdev_file.c
+++ b/module/zfs/vdev_file.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011, 2020 by Delphix. All rights reserved.
  * Copyright (c) 2025, Klara, Inc.
+ * Copyright (c) 2026, TrueNAS.
  */
 
 #include <sys/zfs_context.h>
@@ -89,7 +90,6 @@ static int
 vdev_file_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
     uint64_t *logical_ashift, uint64_t *physical_ashift, cred_t *cr)
 {
-	(void) cr;
 	vdev_file_t *vf;
 	zfs_file_t *fp;
 	zfs_file_attr_t zfa;
@@ -146,7 +146,7 @@ vdev_file_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
 	ASSERT3S(vd->vdev_path[0], ==, '/');
 
 	error = zfs_file_open(vd->vdev_path,
-	    vdev_file_open_mode(spa_mode(vd->vdev_spa)), 0, kcred, &fp);
+	    vdev_file_open_mode(spa_mode(vd->vdev_spa)), 0, cr, &fp);
 
 	if (error) {
 		vd->vdev_stat.vs_aux = VDEV_AUX_OPEN_FAILED;

--- a/module/zfs/vdev_file.c
+++ b/module/zfs/vdev_file.c
@@ -87,8 +87,9 @@ vdev_file_open_mode(spa_mode_t spa_mode)
 
 static int
 vdev_file_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
-    uint64_t *logical_ashift, uint64_t *physical_ashift)
+    uint64_t *logical_ashift, uint64_t *physical_ashift, cred_t *cr)
 {
+	(void) cr;
 	vdev_file_t *vf;
 	zfs_file_t *fp;
 	zfs_file_attr_t zfa;

--- a/module/zfs/vdev_indirect.c
+++ b/module/zfs/vdev_indirect.c
@@ -945,8 +945,9 @@ vdev_indirect_close(vdev_t *vd)
 
 static int
 vdev_indirect_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
-    uint64_t *logical_ashift, uint64_t *physical_ashift)
+    uint64_t *logical_ashift, uint64_t *physical_ashift, cred_t *cr)
 {
+	(void) cr;
 	*psize = *max_psize = vd->vdev_asize +
 	    VDEV_LABEL_START_SIZE + VDEV_LABEL_END_SIZE;
 	*logical_ashift = vd->vdev_ashift;

--- a/module/zfs/vdev_mirror.c
+++ b/module/zfs/vdev_mirror.c
@@ -376,7 +376,7 @@ vdev_mirror_map_init(zio_t *zio)
 
 static int
 vdev_mirror_open(vdev_t *vd, uint64_t *asize, uint64_t *max_asize,
-    uint64_t *logical_ashift, uint64_t *physical_ashift)
+    uint64_t *logical_ashift, uint64_t *physical_ashift, cred_t *cr)
 {
 	int numerrors = 0;
 	int lasterror = 0;
@@ -386,7 +386,7 @@ vdev_mirror_open(vdev_t *vd, uint64_t *asize, uint64_t *max_asize,
 		return (SET_ERROR(EINVAL));
 	}
 
-	vdev_open_children(vd);
+	vdev_open_children(vd, cr);
 
 	for (int c = 0; c < vd->vdev_children; c++) {
 		vdev_t *cvd = vd->vdev_child[c];

--- a/module/zfs/vdev_missing.c
+++ b/module/zfs/vdev_missing.c
@@ -35,7 +35,7 @@
 
 static int
 vdev_missing_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
-    uint64_t *ashift, uint64_t *pshift)
+    uint64_t *ashift, uint64_t *pshift, cred_t *cr)
 {
 	/*
 	 * Really this should just fail.  But then the root vdev will be in the
@@ -43,7 +43,7 @@ vdev_missing_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
 	 * VDEV_AUX_BAD_GUID_SUM.  So we pretend to succeed, knowing that we
 	 * will fail the GUID sum check before ever trying to open the pool.
 	 */
-	(void) vd;
+	(void) vd, (void) cr;
 	*psize = 0;
 	*max_psize = 0;
 	*ashift = 0;

--- a/module/zfs/vdev_raidz.c
+++ b/module/zfs/vdev_raidz.c
@@ -2200,7 +2200,7 @@ vdev_raidz_reconstruct_row(raidz_map_t *rm, raidz_row_t *rr,
 
 static int
 vdev_raidz_open(vdev_t *vd, uint64_t *asize, uint64_t *max_asize,
-    uint64_t *logical_ashift, uint64_t *physical_ashift)
+    uint64_t *logical_ashift, uint64_t *physical_ashift, cred_t *cr)
 {
 	vdev_raidz_t *vdrz = vd->vdev_tsd;
 	uint64_t nparity = vdrz->vd_nparity;
@@ -2216,7 +2216,7 @@ vdev_raidz_open(vdev_t *vd, uint64_t *asize, uint64_t *max_asize,
 		return (SET_ERROR(EINVAL));
 	}
 
-	vdev_open_children(vd);
+	vdev_open_children(vd, cr);
 
 	for (c = 0; c < vd->vdev_children; c++) {
 		vdev_t *cvd = vd->vdev_child[c];

--- a/module/zfs/vdev_root.c
+++ b/module/zfs/vdev_root.c
@@ -73,7 +73,7 @@ too_many_errors(vdev_t *vd, uint64_t numerrors)
 
 static int
 vdev_root_open(vdev_t *vd, uint64_t *asize, uint64_t *max_asize,
-    uint64_t *ashift, uint64_t *pshift)
+    uint64_t *ashift, uint64_t *pshift, cred_t *cr)
 {
 	spa_t *spa = vd->vdev_spa;
 	int lasterror = 0;
@@ -84,7 +84,7 @@ vdev_root_open(vdev_t *vd, uint64_t *asize, uint64_t *max_asize,
 		return (SET_ERROR(EINVAL));
 	}
 
-	vdev_open_children(vd);
+	vdev_open_children(vd, cr);
 
 	for (int c = 0; c < vd->vdev_children; c++) {
 		vdev_t *cvd = vd->vdev_child[c];

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -738,6 +738,11 @@ tests = ['zfs_allow_001_pos', 'zfs_allow_002_pos', 'zfs_allow_003_pos',
     'zfs_unallow_006_pos', 'zfs_unallow_007_neg', 'zfs_unallow_008_neg']
 tags = ['functional', 'delegate']
 
+[tests/functional/device_access:Linux]
+tests = ['device_access_create', 'device_access_attach', 'device_access_add',
+    'device_access_import']
+tags = ['functional', 'device_access']
+
 [tests/functional/direct]
 tests = ['dio_aligned_block', 'dio_async_always', 'dio_async_fio_ioengines',
     'dio_compression', 'dio_dedup', 'dio_encryption', 'dio_grow_block',

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -273,6 +273,7 @@ nobase_dist_datadir_zfs_tests_tests_DATA += \
 	functional/deadman/deadman.cfg \
 	functional/delegate/delegate.cfg \
 	functional/delegate/delegate_common.kshlib \
+	functional/device_access/device_access.kshlib \
 	functional/devices/devices.cfg \
 	functional/devices/devices_common.kshlib \
 	functional/direct/dio.cfg \
@@ -1597,6 +1598,12 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/delegate/zfs_unallow_006_pos.ksh \
 	functional/delegate/zfs_unallow_007_neg.ksh \
 	functional/delegate/zfs_unallow_008_neg.ksh \
+	functional/device_access/cleanup.ksh \
+	functional/device_access/setup.ksh \
+	functional/device_access/device_access_create.ksh \
+	functional/device_access/device_access_attach.ksh \
+	functional/device_access/device_access_add.ksh \
+	functional/device_access/device_access_import.ksh \
 	functional/devices/cleanup.ksh \
 	functional/devices/devices_001_pos.ksh \
 	functional/devices/devices_002_neg.ksh \

--- a/tests/zfs-tests/tests/functional/device_access/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/device_access/cleanup.ksh
@@ -1,0 +1,21 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
+#
+
+#
+# Copyright (c) 2026, TrueNAS.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/device_access/device_access.kshlib
+
+log_pass

--- a/tests/zfs-tests/tests/functional/device_access/device_access.kshlib
+++ b/tests/zfs-tests/tests/functional/device_access/device_access.kshlib
@@ -1,0 +1,68 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
+#
+
+#
+# Copyright (c) 2026, TrueNAS.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+typeset -a _disks=($DISKS)
+typeset -r DEV1=/dev/${_disks[0]}
+typeset -r DEV2=/dev/${_disks[1]}
+typeset -r DEV3=/dev/${_disks[2]}
+
+typeset -A _saved_perms
+
+function save_perms { # path
+	typeset path="$1"
+	_saved_perms[$path]=$(stat -c '%a' "$path")
+}
+
+function restore_perms { #path
+	typeset path="$1"
+	if [[ -z ${_saved_perms[$path]} ]] ; then
+		log_fail "restore_perms($path): must call save_perms first"
+	fi
+	chmod ${_saved_perms[$path]} "$path"
+}
+
+function check_vdevs { #pool, vdevs...
+	typeset pool="$1"
+	typeset want=$(echo "${@:2}" | xargs -n 1 | sort | xargs)
+	typeset have=$(zpool list -HvLP -o name | grep /dev | sort | xargs)
+	log_must test "$want" == "$have"
+}
+
+function without_cap { #capability name, cmd...
+	typeset capname="$1"
+	capsh --drop=$capname -- -c "${*:2}"
+}
+
+function has_cap { #capability name
+	typeset capname="$1"
+	typeset capeff=$(grep ^CapEff /proc/self/status)
+	capsh --decode="${capeff##*:}" | grep -q $capname
+}
+
+function check_cap_support {
+	if ! command -v capsh > /dev/null ; then
+		log_unsupported "capsh program required to test device access"
+	fi
+	if ! has_cap cap_sys_admin ; then
+		log_unsupported "test user requires CAP_SYS_ADMIN capability"
+	fi
+	if ! has_cap cap_dac_override ; then
+		log_unsupported "test user requires CAP_DAC_OVERRIDE capability"
+	fi
+}

--- a/tests/zfs-tests/tests/functional/device_access/device_access_add.ksh
+++ b/tests/zfs-tests/tests/functional/device_access/device_access_add.ksh
@@ -1,0 +1,63 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
+#
+
+#
+# Copyright (c) 2026, TrueNAS.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/device_access/device_access.kshlib
+
+check_cap_support
+
+save_perms $DEV1
+save_perms $DEV2
+
+function cleanup
+{
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
+	restore_perms $DEV1
+	restore_perms $DEV2
+}
+log_onexit cleanup
+
+log_assert 'device permissions are properly checked for zpool add'
+
+# make device accessible to everyone, ensure pool can be created and devices
+# added.
+log_must chmod 666 $DEV1 $DEV2
+log_must zpool create $TESTPOOL $DEV1
+log_must zpool add $TESTPOOL spare $DEV2
+check_vdevs $TESTPOOL $DEV1 $DEV2
+log_must zpool destroy $TESTPOOL
+
+# remove perms from devices, check pool can be created and device added. this
+# is relying on the running user having CAP_DAC_OVERRIDE to bypass the
+# permission check
+log_must chmod 000 $DEV1 $DEV2
+log_must zpool create $TESTPOOL $DEV1
+log_must zpool add $TESTPOOL spare $DEV2
+check_vdevs $TESTPOOL $DEV1 $DEV2
+log_must zpool destroy $TESTPOOL
+
+# recreate the pool, then try to add it without CAP_DAC_OVERRIDE. this should
+# fail, as the user has no direct permission and has no override capability.
+log_must zpool create $TESTPOOL $DEV1
+log_mustnot without_cap cap_dac_override zpool add $TESTPOOL spare $DEV2
+
+# confirm that the device was really not added, not just that the call failed
+check_vdevs $TESTPOOL $DEV1
+
+log_must zpool destroy $TESTPOOL
+
+log_pass 'device permissions are properly checked for zpool add'

--- a/tests/zfs-tests/tests/functional/device_access/device_access_attach.ksh
+++ b/tests/zfs-tests/tests/functional/device_access/device_access_attach.ksh
@@ -1,0 +1,63 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
+#
+
+#
+# Copyright (c) 2026, TrueNAS.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/device_access/device_access.kshlib
+
+check_cap_support
+
+save_perms $DEV1
+save_perms $DEV2
+
+function cleanup
+{
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
+	restore_perms $DEV1
+	restore_perms $DEV2
+}
+log_onexit cleanup
+
+log_assert 'device permissions are properly checked for zpool attach'
+
+# make device accessible to everyone, ensure pool can be created and devices
+# attached.
+log_must chmod 666 $DEV1 $DEV2
+log_must zpool create $TESTPOOL $DEV1
+log_must zpool attach $TESTPOOL $DEV1 $DEV2
+check_vdevs $TESTPOOL $DEV1 $DEV2
+log_must zpool destroy $TESTPOOL
+
+# remove perms from devices, check pool can be created and device attached.
+# this is relying on the running user having CAP_DAC_OVERRIDE to bypass the
+# permission check
+log_must chmod 000 $DEV1 $DEV2
+log_must zpool create $TESTPOOL $DEV1
+log_must zpool attach $TESTPOOL $DEV1 $DEV2
+check_vdevs $TESTPOOL $DEV1 $DEV2
+log_must zpool destroy $TESTPOOL
+
+# recreate the pool, then try to attach without CAP_DAC_OVERRIDE. this should
+# fail, as the user has no direct permission and has no override capability.
+log_must zpool create $TESTPOOL $DEV1
+log_mustnot without_cap cap_dac_override zpool attach $TESTPOOL $DEV1 $DEV2
+
+# confirm that the device was really not attached, not just that the call failed
+check_vdevs $TESTPOOL $DEV1
+
+log_must zpool destroy $TESTPOOL
+
+log_pass 'device permissions are properly checked for zpool attach'

--- a/tests/zfs-tests/tests/functional/device_access/device_access_create.ksh
+++ b/tests/zfs-tests/tests/functional/device_access/device_access_create.ksh
@@ -1,0 +1,62 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
+#
+
+#
+# Copyright (c) 2026, TrueNAS.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/device_access/device_access.kshlib
+
+check_cap_support
+
+save_perms $DEV1
+save_perms $DEV2
+
+function cleanup
+{
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
+	restore_perms $DEV1
+	restore_perms $DEV2
+}
+log_onexit cleanup
+
+log_assert 'device permissions are properly checked for zpool create'
+
+# make device accessible to everyone, ensure pool can be created
+log_must chmod 666 $DEV1
+log_must zpool create $TESTPOOL $DEV1
+check_vdevs $TESTPOOL $DEV1
+log_must zpool destroy $TESTPOOL
+
+# remove perms from device, check pool can be created. this is relying
+# on the running user having CAP_DAC_OVERRIDE to bypass the permission check
+log_must chmod 000 $DEV1
+log_must zpool create $TESTPOOL $DEV1
+check_vdevs $TESTPOOL $DEV1
+log_must zpool destroy $TESTPOOL
+
+# now remove CAP_DAC_OVERRIDE and try again. this should fail, as the user
+# has no direct permission and has no override capability.
+log_mustnot without_cap cap_dac_override zpool create $TESTPOOL $DEV1
+
+# confirm the pool was really not created, not just that the call failed
+log_mustnot poolexists $TESTPOOL
+
+# create a pool with two devs, only one unavailable. ensure that the entire
+# entire pool fails to be created, not just rejecting the inaccessible devices
+log_must chmod 666 $DEV2
+log_mustnot without_cap cap_dac_override zpool create $TESTPOOL $DEV1 $DEV2
+log_mustnot poolexists $TESTPOOL
+
+log_pass 'device permissions are properly checked for zpool create'

--- a/tests/zfs-tests/tests/functional/device_access/device_access_import.ksh
+++ b/tests/zfs-tests/tests/functional/device_access/device_access_import.ksh
@@ -1,0 +1,69 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
+#
+
+#
+# Copyright (c) 2026, TrueNAS.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/device_access/device_access.kshlib
+
+check_cap_support
+
+save_perms $DEV1
+save_perms $DEV2
+
+typeset tmpcache=$(mktemp)
+
+function cleanup
+{
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
+	restore_perms $DEV1
+	restore_perms $DEV2
+	rm -f $tmpcache
+}
+log_onexit cleanup
+
+log_assert 'device permissions are properly checked for zpool import'
+
+# create a pool with two devices, capture the cache file, and export it
+log_must chmod 666 $DEV1 $DEV2
+log_must zpool create $TESTPOOL $DEV1 $DEV2
+check_vdevs $TESTPOOL $DEV1 $DEV2
+cp /etc/zfs/zpool.cache $tmpcache
+log_must zpool export $TESTPOOL
+
+# remove perms from devices, check pool can be imported. this is relying on the
+# running user having CAP_DAC_OVERRIDE to bypass the permission check
+log_must chmod 000 $DEV1 $DEV2
+log_must zpool import $TESTPOOL
+check_vdevs $TESTPOOL $DEV1 $DEV2
+log_must zpool export $TESTPOOL
+
+# try to import the pool without CAP_DAC_OVERRIDE. this should fail, as the
+# user has no direct permission and has no override capability.
+log_mustnot without_cap cap_dac_override zpool import $TESTPOOL
+log_mustnot poolexists $TESTPOOL
+
+# make one device accessible, and try to import again. should fail, because
+# the userspace device scan can't access all the devices
+log_must chmod 666 $DEV1
+log_mustnot without_cap cap_dac_override zpool import $TESTPOOL
+log_mustnot poolexists $TESTPOOL
+
+# try to import using the cachefile. should fail, because one of the devices
+# listed in the cachefile is not accessible to the user
+log_mustnot without_cap cap_dac_override zpool import -c $tmpcache $TESTPOOL
+log_mustnot poolexists $TESTPOOL
+
+log_pass 'device permissions are properly checked for zpool import'

--- a/tests/zfs-tests/tests/functional/device_access/setup.ksh
+++ b/tests/zfs-tests/tests/functional/device_access/setup.ksh
@@ -1,0 +1,23 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
+#
+
+#
+# Copyright (c) 2026, TrueNAS.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/device_access/device_access.kshlib
+
+verify_runnable "global"
+
+log_pass


### PR DESCRIPTION
_[Sponsors: TrueNAS]_

### Motivation and Context

OpenZFS assumes that having the ability to use pool admin operations implies permission to access any storage devices in the system. However, both Linux and FreeBSD have mechanisms to separate these permissions, leading to a situation where a carefully-constructed set of permissions can allow a user with pool admin rights to add a device to a pool that they otherwise would not be able to access or possibly even see.

This PR handles this by separately testing device access against the calling user credential before attempting to open or use the device.

### Description

The first commit sets up the infrastructure we need. `vdev_open()` gains a `cred_t*` parameter, which is wired through to `vdev_op_open()` for each vdev type. `vdev_open_children()` in particular needs a little rework; this is the "open child devices in parallel", so each task needs to take a separate cred hold. So far each vdev just swallows the extra arg, except for `vdev_root_open()` and  `vdev_draid_open()`, which passes it down to `vdev_open_children()`.

The next commits add the actual device checks to each actual vdev implementation.

#### `vdev_file`

This vdev type is simple enough. It calls out to the platform-specific `zfs_file_open()` to actually open the file, so we extend that function to take a `cred_t`. This requires a matching update to the other users of this function in `spa_config_write()` and `spa_config_remove()`, for handling the cachefile (`zpool.cache`) update. We use `kcred` as the credential there to retain existing behaviour.

The platform-specific changes are straightforward. `libzpool` has no credential concept, so its just a no-op parameter there. Linux `filp_open()` will use the current task credential for access control, so we make the passed-in credential live for the duration of the call. For FreeBSD, we switch from `vn_open()` to `vn_open_cred()`, which takes an explicit cred rather than using the task credential, and that's all of it.

Review notes:
- for Linux, since `filp_open()` would use the task credential, previously this would have produced different behaviour in some situations: internal calls and calls through `vdev_open_children()` (ie the main vdev tree startup) would be done with the kernel credential (the latter because the calling cred was not transferred to the opening tasks), while eg adding aux devices (spares, logs, etc) come directly through `zfs_ioctl.c` -> `spa.c` and so have the calling task credentials, making it possible for a file the user can't to access to be used in the main pool, but not as an aux device.

#### `vdev_disk`

`bdev_file_open_by_path()` (and its predecessors) does not itself do any credential checks, so we have to do our own first. We set the passed in credential as the temporary task credential, then call `kern_path()` to find the inode, and `inode_permission()` to see if we have access. Both of these take the task credential into account, eg `kern_path` will return `ENOENT` if the user can't see the device node.

If the caller has access, then we proceed into `bdev_file_open_by_path()` as normal.

Review notes:
- the compatibility function for `vdev_path_backing_permission()` is to handle the various idmap/userns/inode conventions. The effective purpose is to check permissions against the "backing" inode for the dentry, which is defined as "the inode you would get if you opened the file" ie the thing visible at that position at the top of the mount stack
- we use `kcred` as the credential for the reopen path. The alternative would be to not do the permission check on reopen, but that check is done inside the timeout loop, so we'd have to redo the "is reopening" check there, and its already not quite the standard check of checking `vdev_reopening`. So I've chosen the less messy option; further refactoring opportunities exist!
- the error tracing has been refactored a little, now that we can get an error that's not encoded on the device handle `bdh`

#### `vdev_geom`

GEOM itself does not have any access control facility, so we have to do our own thing. Although technically optional, all GEOM providers create a node in `/dev` named for the provider, exactly matching our existing mapping of `/dev` names to provider names. So, we use the `/dev` node as the access control point, and before attaching to the provider, we call `namei()` to lookup the node, and `VOP_ACCESS` to check access.

There's one special case to note, `vdev_geom_read_pool_label()`. We deliberately don't do a credential check, because it's using during root pool startup after handoff from the bootloader, and so `/dev` may not even exist yet.

Review notes:
- this is all dependent on the assumption that all GEOM providers (out of the box) will create a matching `/dev` node. I have asked around some trusted FreeBSD-enjoyers and no one knew what I was talking about, which I take as a good sign! I say it though because my FreeBSD is not strong
- please check that the `vdev_geom_read_pool_label()` carveout makes sense. I'm making assumptions about how the boot handoff works that I actually don't know for sure
- please also critique my bold assertions about privileges and MAC below

### Design notes

`vdev_open()` is called for two quite different situations in the life of a vdev, and we need to consider them both.

There are some operations where OpenZFS is accessing a device for the first time that it did not already know about. For these, we need to consider whether or not the calling user has access to the named device. For things like `zpool create`, `zpool add` and `zpool attach` this is obvious. Less obvious is `zpool import`, however its clearly the same thing when you consider that the list of devices used to assemble the pool come from either a device search (which should definitely not search devices the user can't see), or from a `zpool.cache` file that the user provides, and may have modified.

The other use of `vdev_open()` is to reopen an existing device. The vdev object itself doesn't change, rather, it closes/detaches and opens/reattaches the kernel's device object by whatever means. Sometimes that's in response to a user command (`zpool reopen`, `zpool offline`, `zpool online`, etc), while other times its part of some internal function (scrub, error probe, etc). For these, OpenZFS already knew about the device, and it seems to me there's no reason that OpenZFS should prevent one of its own operations on a known device because the user doesn't have access to that device; _someone_ clearly did, when getting the pool online, and if the user is asking for a pool operation, they clearly have enough access to make that request.

So, the split on how to handle device access control is on whether or not `vdev_op_open()` is called for open or reopen. Fortunately, all three vdev drivers already have handling for this case. `vdev_file` and `vdev_geom` don't actually detach/attach for reopen; they just reload the device metadata (eg size). For those, we don't need anything special.

For `vdev_disk`, it does actually close and reopen. Because of the code structure, it's difficult to not do any access checks for this case; instead, we just set the temporary task credential to `kcred` instead of the supplied cred. `kcred` can do anything, so the reopen succeeds.

### Security impact

This PR is targeting the privilege gap between the calling the pool ioctl (`zpool create` etc) and accessing the actual device.

In most environments, there is no practical gap here - people do their pool admin work as root, which can make pool calls and access devices. However, once we bring capability/privilege models into play, these two powers can become separated.

On Linux, in general, pool ops require `CAP_SYS_ADMIN`. This is _not_ the same as `root`; root's traditional power to ignore file permissions comes from a second capability, `CAP_DAC_OVERRIDE`. A process with `CAP_SYS_ADMIN` but not `CAP_DAC_OVERRIDE` is subject to file permissions as normal. This case is very easy to arrange - capabilities can be added and removed at will with the `capsh` tool, and systemd units files can specify the set of capabilities that a program should have. systemd's own security recommendations include remove `CAP_DAC_OVERRIDE` from programs that otherwise need the "root-like" permissions of `CAP_SYS_ADMIN`.

FreeBSD has a similar split: `PRIV_ZFS_POOL_CONFIG` is required for pool operations, but ignoring file permissions requires `PRIV_VFS_READ`, `PRIV_VFS_WRITE`, etc; a process with `PRIV_ZFS_POOL_CONFIG` but not `PRIV_VFS_XXX` is subject to file permissions. However, this is very much harder to arrange out of the box on FreeBSD, because privileges are "live" - they aren't granted or revoked, but rather, each check consults the kernel which says "yes" or "no" based on some active criteria. For most of them, and particularly specialised ones like `PRIV_ZFS_POOL_CONFIG`, root gets all of them, regular users get none of them. The kernel can be extended with MAC modules which can allow or deny privileges by whatever policy they wish, however, I was not able to find anything out of the box that could hand `PRIV_ZFS_POOL_CONFIG` to a non-root user, and it is extremely difficult to remove `PRIV_VFS_*` from the true root user.

All this is to say, I believe the impact of this change on existing systems to be very low. For FreeBSD, basically no out-of-the-box configurations will have separated privileges, so it will continue to be root and only root that can manage pools. For Linux, it's harder be sure because of how granular the capabilities are and how many capability variations are in play, but at least we would not see a problem unless an operator has explicitly set up a bounded capability set for a pool management program or user that does not have direct access to device, and has given them `CAP_SYS_ADMIN` but not `CAP_DAC_OVERRIDE`. This feels like a very rare situation, and  is easily remedied through permission or capability changes and doesn't represent a risk - that user or program was _expected_ to be doing pool management, suddenly not being able to in very rare circumstances (introducing a new device) is surprising at most.

I'm interested to find out if anything here is substantially wrong, but mainly, I want to know if my assessment is off regarding impact on deployed systems.

### How Has This Been Tested?

ZTS run completed successfully (+/- transient errors): Linux 7.2.0, FreeBSD 15.1-p2

Compile checked: Linux 5.4.x, 6.1.x, 6.8.x, 7.0.x.

New test tag `device_access` added, that uses `chmod` and `capsh` limit access to device nodes and test behaviour of `zpool create`, `import`, `add` and `attach` (all slightly different codepaths that involve user-supplied device nodes).
Note that this is only testing device nodes, so `vdev_disk`. They are trivially extendable to test file-backed pools, I just ran out of time tonight.

I am not intending to add tests for FreeBSD, as the only way I can see to do it is to ship a custom MAC module for the test suite, and that's more than I feel confident doing right now.

### Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).