### PR TITLE
dmu_recv_begin_check: dsl_dataset_rele() should be called on ds

### DIFF
--- a/module/zfs/dmu_recv.c
+++ b/module/zfs/dmu_recv.c
@@ -850,8 +850,7 @@ dmu_recv_begin_check(void *arg, dmu_tx_t *tx)
 				if (!redact_check(drba, origin)) {
 					dsl_dataset_rele_flags(origin, dsflags,
 					    FTAG);
-					dsl_dataset_rele_flags(ds, dsflags,
-					    FTAG);
+					dsl_dataset_rele(ds, FTAG);
 					return (SET_ERROR(EINVAL));
 				}
 			}
@@ -859,7 +858,7 @@ dmu_recv_begin_check(void *arg, dmu_tx_t *tx)
 			error = recv_check_large_blocks(ds, featureflags);
 			if (error != 0) {
 				dsl_dataset_rele_flags(origin, dsflags, FTAG);
-				dsl_dataset_rele_flags(ds, dsflags, FTAG);
+				dsl_dataset_rele(ds, FTAG);
 				return (error);
 			}
 


### PR DESCRIPTION
### Motivation and Context
We call dsl_dataset_hold() to initialize ds, and are supposed to call dsl_dataset_rele() on ds when we are done. In two error paths, we call dsl_dataset_rele_flags(). If ds is an encrypted dataset, this can drop the key mapping for the dataset, which will cause run time issues. On unencrypted datasets, this is a no-op.

### Description
We switch to calling dsl_dataset_rele() instead of dsl_dataset_rele_flags(), which makes the function consistent.

Grok 4.6 Build Beta found this bug after I asked it to look for DSL function mismatches.

### How Has This Been Tested?
The buildbot can test it.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
