### PR TITLE
dmu_redact_snap: Do proper cleanup on ENAMETOOLONG

### DIFF
--- a/module/zfs/dmu_redact.c
+++ b/module/zfs/dmu_redact.c
@@ -1066,12 +1066,8 @@ dmu_redact_snap(const char *snapname, nvlist_t *redactnvl,
 	int n = snprintf(c, ZFS_MAX_DATASET_NAME_LEN - (c - newredactbook),
 	    "#%s", redactbook);
 	if (n >= ZFS_MAX_DATASET_NAME_LEN - (c - newredactbook)) {
-		dsl_pool_rele(dp, FTAG);
-		kmem_free(newredactbook,
-		    sizeof (char) * ZFS_MAX_DATASET_NAME_LEN);
-		if (args != NULL)
-			vmem_free(args, numsnaps * sizeof (*args));
-		return (SET_ERROR(ENAMETOOLONG));
+		err = ENAMETOOLONG;
+		goto out;
 	}
 	err = dsl_bookmark_lookup(dp, newredactbook, NULL, &bookmark);
 	if (err == 0) {


### PR DESCRIPTION
### Motivation and Context
If the redaction bookmark name exceeds ZFS_MAX_DATASET_NAME_LEN, we leak the dataset hold, long hold, and decrypt key mapping on the target snapshot, plus the same three references on each origin snapshot in args[].

The leaked long holds leave those datasets busy such that destroy, unmount, and zfs send will return EBUSY and the key mappings never drop. 

### Description
We switch to using goto out like the other error paths.

Grok 4.6 Build Beta found this bug after I asked it to look for DSL function mismatches.

### How Has This Been Tested?
The buildbot can test it.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
