### PR TITLE
ztest: enable multihost under -M, and exercise it from zloop

### DIFF
--- a/.github/workflows/zloop.yml
+++ b/.github/workflows/zloop.yml
@@ -49,10 +49,9 @@ jobs:
         sudo modprobe zfs
     - name: Tests
       run: |
-        [ -r /etc/hostid ] && [ -s /etc/hostid ] || sudo zgenhostid -f
         sudo truncate -s 256G /mnt/vdev
         sudo zpool create cipool -m $WORK_DIR -O compression=on -o autotrim=on /mnt/vdev
-        sudo /usr/share/zfs/zloop.sh -t 600 -I 6 -l -m 1 -c $CORE_DIR -f $WORK_DIR -- -T 120 -P 60
+        sudo /usr/share/zfs/zloop.sh -t 600 -I 6 -l -m 1 -M -c $CORE_DIR -f $WORK_DIR -- -T 120 -P 60
     - name: Prepare artifacts
       if: failure()
       run: |

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -90,6 +90,7 @@
 #include <sys/dmu_objset.h>
 #include <sys/poll.h>
 #include <sys/stat.h>
+#include <sys/systeminfo.h>
 #include <sys/time.h>
 #include <sys/wait.h>
 #include <sys/mman.h>
@@ -104,6 +105,7 @@
 #include <sys/vdev_raidz.h>
 #include <sys/vdev_trim.h>
 #include <sys/spa_impl.h>
+#include <sys/mmp.h>
 #include <sys/metaslab_impl.h>
 #include <sys/dsl_prop.h>
 #include <sys/dsl_dataset.h>
@@ -785,7 +787,7 @@ static ztest_option_t option_table[] = {
 	{ 'f',	"vdev-file-directory", "PATH", "File directory for vdev files",
 	    NO_DEFAULT, DEFAULT_VDEV_DIR},
 	{ 'M',	"multi-host", NULL,
-	    "Multi-host; simulate pool imported on remote host",
+	    "Multi-host; create the pool with multihost enabled",
 	    NO_DEFAULT, NULL},
 	{ 'E',	"use-existing-pool", NULL,
 	    "Use existing pool instead of creating new one", NO_DEFAULT, NULL},
@@ -1107,6 +1109,17 @@ process_options(int argc, char **argv)
 		zo->zo_vdev_size = DEFAULT_VDEV_SIZE * 2;
 		zo->zo_raid_do_expand = B_FALSE;
 		raid_kind = "raidz";
+	}
+
+	/*
+	 * The pool is created with the multihost property under -M, and that
+	 * property cannot be set without a hostid.  Say so here rather than
+	 * aborting inside spa_create() later.  zloop.sh exports ZFS_HOSTID
+	 * for its multihost iterations.
+	 */
+	if (zo->zo_mmp_test && get_system_hostid() == 0) {
+		(void) fprintf(stderr, "-M requires a non-zero hostid\n");
+		exit(1);
 	}
 
 	if (strcmp(raid_kind, "random") == 0) {
@@ -8897,6 +8910,18 @@ ztest_init(ztest_shared_t *zs)
 	    zpool_prop_to_name(ZPOOL_PROP_FAILUREMODE),
 	    MAXFAULTS(zs) ? ZIO_FAILURE_MODE_PANIC : ZIO_FAILURE_MODE_WAIT);
 
+	/*
+	 * Set the multihost property at creation time under -M so that every
+	 * subsequent import runs the MMP activity check, which is the point
+	 * of the option.  Setting the property (rather than the in-core
+	 * spa_multihost) keeps it persistent and requires a non-zero hostid,
+	 * which zloop.sh supplies through ZFS_HOSTID.
+	 */
+	if (ztest_opts.zo_mmp_test) {
+		fnvlist_add_uint64(props,
+		    zpool_prop_to_name(ZPOOL_PROP_MULTIHOST), 1);
+	}
+
 	for (i = 0; i < SPA_FEATURES; i++) {
 		char *buf;
 
@@ -9239,6 +9264,26 @@ main(int argc, char **argv)
 		metaslab_force_ganging = ztest_opts.zo_metaslab_force_ganging;
 		metaslab_df_alloc_threshold =
 		    zs->zs_metaslab_df_alloc_threshold;
+
+		/*
+		 * Under -M the pool runs with multihost enabled for the whole
+		 * run.  Suppress the MMP write-failure suspension: ztest sets
+		 * failmode to panic whenever it can tolerate faults, so a
+		 * stalled MMP write would panic the run rather than suspend
+		 * the pool, and ztest_fault_inject() makes such stalls an
+		 * expected event.  This has to happen here rather than in
+		 * process_options(), which only the parent runs.
+		 *
+		 * Shorten the MMP interval as well.  Every pass imports the
+		 * pool, and each import watches the uberblock for
+		 * zfs_multihost_import_intervals * (interval + mmp_delay).
+		 * At the default one second interval that check can outlast
+		 * the pass itself.
+		 */
+		if (ztest_opts.zo_mmp_test) {
+			zfs_multihost_fail_intervals = 0;
+			zfs_multihost_interval = MMP_MIN_INTERVAL;
+		}
 
 		if (zs->zs_do_init)
 			ztest_run_init();

--- a/lib/libspl/os/freebsd/gethostid.c
+++ b/lib/libspl/os/freebsd/gethostid.c
@@ -23,5 +23,19 @@
 unsigned long
 get_system_hostid(void)
 {
+	char *env;
+
+	/*
+	 * Allow the hostid to be subverted for testing.  A value which
+	 * parses as zero is ignored, as it is on Linux, so that the
+	 * system hostid is used instead.
+	 */
+	env = getenv("ZFS_HOSTID");
+	if (env != NULL) {
+		unsigned long hostid = strtoull(env, NULL, 0);
+		if (hostid != 0)
+			return (hostid & HOSTID_MASK);
+	}
+
 	return (gethostid());
 }

--- a/man/man1/ztest.1
+++ b/man/man1/ztest.1
@@ -157,7 +157,7 @@ Multi-host; create the pool with the
 .Sy multihost
 property enabled, so that subsequent imports run the MMP activity check.
 Requires a non-zero hostid.
-On Linux one may be supplied through
+One may be supplied through
 .Ev ZFS_HOSTID .
 .It Fl E , -use-existing-pool
 Use existing pool (use existing pool instead of creating new one).

--- a/man/man1/ztest.1
+++ b/man/man1/ztest.1
@@ -153,7 +153,12 @@ Pool name.
 .It Fl f , -vdev-file-directory Ns = (default: Pa /tmp )
 File directory for vdev files.
 .It Fl M , -multi-host
-Multi-host; simulate pool imported on remote host.
+Multi-host; create the pool with the
+.Sy multihost
+property enabled, so that subsequent imports run the MMP activity check.
+Requires a non-zero hostid.
+On Linux one may be supplied through
+.Ev ZFS_HOSTID .
 .It Fl E , -use-existing-pool
 Use existing pool (use existing pool instead of creating new one).
 .It Fl T , -run-time Ns = (default: Sy 300 Ns s)

--- a/scripts/zloop.sh
+++ b/scripts/zloop.sh
@@ -37,7 +37,7 @@ function usage
 {
 	cat >&2 <<EOF
 
-$0 [-hl] [-c <dump directory>] [-f <vdev directory>]
+$0 [-hlM] [-c <dump directory>] [-f <vdev directory>]
   [-m <max core dumps>] [-s <vdev size>] [-t <timeout>]
   [-I <max iterations>] [-- [extra ztest parameters]]
 
@@ -52,6 +52,8 @@ $0 [-hl] [-c <dump directory>] [-f <vdev directory>]
     -f  Specify working directory for ztest vdev files.
     -h  Print this help message.
     -l  Create 'ztest.core.N' symlink to core directory.
+    -M  Enable multihost testing on a fraction of the iterations.
+        A hostid is exported through ZFS_HOSTID for those runs.
     -m  Max number of core dumps to allow before exiting.
     -s  Size of vdev devices.
     -t  Total time to loop for, in seconds. If not provided,
@@ -186,7 +188,8 @@ size="512m"
 coremax=0
 symlink=0
 iterations=0
-while getopts ":ht:m:I:s:c:f:l" opt; do
+multihost=0
+while getopts ":ht:m:I:s:c:f:lM" opt; do
 	case $opt in
 		t ) [[ $OPTARG -gt 0 ]] && timeout=$OPTARG ;;
 		m ) [[ $OPTARG -gt 0 ]] && coremax=$OPTARG ;;
@@ -195,6 +198,7 @@ while getopts ":ht:m:I:s:c:f:l" opt; do
 		c ) [[ -n $OPTARG ]] && coredir=$OPTARG ;;
 		f ) [[ -n $OPTARG ]] && basedir=$(readlink -f "$OPTARG") ;;
 		l ) symlink=1 ;;
+		M ) multihost=1 ;;
 		h ) usage
 		    exit 2
 		    ;;
@@ -257,6 +261,7 @@ while (( timeout == 0 )) || (( curtime <= (starttime + timeout) )); do
 
 	draid_data=0
 	draid_spares=0
+	expand=0
 
 	# randomly use special classes
 	class="special=random"
@@ -292,6 +297,7 @@ while (( timeout == 0 )) || (( curtime <= (starttime + timeout) )); do
 		# 1/3 of the time use a dedicated '-X' raidz expansion test
 		if [[ $((RANDOM % 3)) -eq 0 ]]; then
 			zopt="$zopt -X -t 16"
+			expand=1
 			raid_type="raidz"
 		else
 			raid_type="eraidz"
@@ -324,6 +330,26 @@ while (( timeout == 0 )) || (( curtime <= (starttime + timeout) )); do
 	zopt="$zopt -C $class"
 	zopt="$zopt -s $size"
 	zopt="$zopt -f $workdir"
+
+	#
+	# Exercise multihost on a fraction of the iterations rather than all
+	# of them: -M suppresses roughly a dozen other ztest operations, so
+	# running it everywhere would remove that coverage from the loop.
+	# A raidz expansion run is skipped because ztest forces -M off for
+	# one, which would spend a multihost iteration on a run that does
+	# no multihost testing.
+	#
+	# ztest needs a non-zero hostid to set the multihost property, and
+	# ZFS_HOSTID provides one without creating /etc/hostid, which the ZTS
+	# mmp test group requires to be absent.
+	#
+	if [[ $multihost -eq 1 ]]; then
+		unset ZFS_HOSTID
+		if [[ $expand -eq 0 ]] && [[ $((RANDOM % 5)) -eq 0 ]]; then
+			zopt="$zopt -M"
+			export ZFS_HOSTID=$((RANDOM + 1))
+		fi
+	fi
 
 	cmd="$ZTEST $zopt $*"
 	echo "$(date '+%m/%d %T') $cmd" | tee -a ztest.history ztest.out


### PR DESCRIPTION
### Motivation and Context

Issue #18918. @behlendorf laid out a five point plan there; point 1 merged as
ec779f356, and this implements points 2, 4 and 5.

`-M` advertised simulating a pool imported on a remote host, but nothing under it
enabled multihost. The only writes to `spa_multihost` were in
`ztest_mmp_enable_disable()`, the function `-M` disabled, so once that was removed
`-M` merely suppressed the operations that conflict with multihost testing.

### Description

Three commits.

**ztest** creates the pool with the `multihost` property under `-M`, so the
property persists and subsequent imports run the MMP activity check. That needs a
non-zero hostid, since `spa_prop_validate()` returns `ENOTSUP` without one and the
pool is created with `VERIFY0()`, so `-M` on a host with no hostid is now refused
with a message during option processing. The run also suppresses the MMP
write-failure suspension, because ztest sets failmode to panic whenever it can
tolerate faults and `zio_suspend()` panics before it examines the suspend reason;
the removed function did the same. Finally it shortens the MMP interval to
`MMP_MIN_INTERVAL`, because at the default one second interval the activity check
on each pass's import measured 45 to 51 seconds and can outlast the pass itself.

**zloop.sh** gains a `-M` option, off by default, that passes `-M` to one draw in
five. Running every iteration that way would cost the loop the dozen or so
operations ztest suppresses under `-M`, among them the zdb consistency check.
Raidz expansion iterations are left alone, since ztest forces `-M` off for those.
The hostid comes from `ZFS_HOSTID` rather than `/etc/hostid`, because the ZTS mmp
test group skips itself when that file exists.

**The workflow** passes `-M`, and drops the `zgenhostid` call from eb5c93fa8 that
is no longer needed.

Two decisions are still open for @behlendorf, and the numbers behind them follow
in a comment on the issue: whether the duration difference between multihost and
ordinary iterations changes the fraction he wants, and whether zloop should also
carry the `/etc/hostid` check from point 4 for the benefit of FreeBSD, where
`ZFS_HOSTID` is not consulted.

### How Has This Been Tested?

Two environments, both Linux: a userspace build (`--with-config=user
--enable-debug`) on aarch64 in a container, and a full build with the kernel
module loaded in an x86_64 Ubuntu 24.04 VM. No ASan or UBSan build, and nothing
tested on FreeBSD.

- `ztest -M` with no hostid exits 1 with a message. Without the new check it
  aborts on `VERIFY0(spa_create(...)) failed (95)`.
- `ztest -M` with a hostid runs, and `zdb -u` shows the pool carrying
  `mmp_fail = 0` and `mmp_write = 100`.
- The interval change, measured by alternating two builds three times each with
  identical vdev options (`-T 60 -P 20`): at the default interval a run took 97 to 104
  seconds of wall clock and got through 2 passes, with each activity check 45 to
  51 seconds; at `MMP_MIN_INTERVAL` the same run took 62 to 63 seconds and got
  through 4 to 6 passes, with each check 3 to 5 seconds.
- Three `zloop.sh -M` runs, 20 and 18 iterations against the userspace build and
  8 against the module in the VM, no crashes in any. Killed passes reimport: in
  one run five of six passes ended in `SIGKILL` and it still finished cleanly.
- The `store_core` path: the zdb zloop runs against a hard killed, never exported
  multihost pool completes normally, and `ztest -M -E` imports one.
- Selection rate, driving the real `zloop.sh` with a stub ztest: 563 `-M`
  iterations out of 3000, none of which also received `-X`.
- `cstyle`, `shellcheck`, `checkbashisms` and `mancheck` are clean.

On the VM, with the module loaded, I also ran the ZTS `mmp` group, since the
choice of `ZFS_HOSTID` over `/etc/hostid` exists to keep that group usable:

- With an `/etc/hostid` present, all 18 mmp tests skip, each reported as
  `(expected PASS)`. That is what a developer gets after applying the
  `zgenhostid` remedy on their own machine.
- With it absent the group runs: 17 pass, and 2 fail. The failures are
  `mmp_on_zdb` (`zdb -ed testpool` exits 1 after export) and
  `mmp_reset_interval`. Neither test refers to ztest or zloop, and none of the
  four files this PR touches contributes to zdb, zpool or the module, so they are
  independent of this change. `mmp_on_zdb` still fails on its own with
  `ZFS_HOSTID` unset, so it is not an artefact of my test environment either. I
  have not chased them further.
- After a `zloop.sh -M` run, `/etc/hostid` is still absent and the group still
  runs (setup, `mmp_on_thread`, cleanup: 3 passed).

I have not run the full ZFS Test Suite, only the group above. The change is
confined to ztest, zloop.sh, the ztest man page and the zloop workflow, and adds
no ZTS cases.

### Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
