### PR TITLE
Linux: allow more time for snapshot automount teardown

### DIFF
--- a/module/os/linux/zfs/zfs_ctldir.c
+++ b/module/os/linux/zfs/zfs_ctldir.c
@@ -1248,7 +1248,7 @@ zfsctl_snapshot_unmount_check(const char *snapname)
  *
  * Delayed work queueing runs on a jiffy timer, so the mntput() may not be on
  * the queue yet when we call zpl_flush_delay_workqueue(). So, we sleep for one
- * jiffy each iteration, and flush the queue each time, for 20 milliseconds.
+ * jiffy each iteration, and flush the queue each time, for 40 milliseconds.
  * Most of the time we'll see the task within 2-3 jiffies so this is quite a
  * generous timeout. Worst case, we pause a while, timeout, and eventually
  * return EBUSY.
@@ -1264,7 +1264,7 @@ zfsctl_snapshot_unmount_wait(const char *snapname, taskqid_t tqid)
 
 	taskq_wait_id(system_taskq, tqid);
 
-	unsigned long deadline = jiffies + MSEC_TO_TICK(20);
+	unsigned long deadline = jiffies + MSEC_TO_TICK(40);
 
 	while (!zfsctl_snapshot_unmount_check(snapname)) {
 		if (time_after_eq(jiffies, deadline))


### PR DESCRIPTION
## Motivation and Context

This is a one-line fix.

Snapshot destruction can race with the delayed dput()/mntput() work
triggered after accessing a snapshot through .zfs/snapshot. If that
work takes longer than 20 milliseconds, the snapshot remains long-held
and zfs destroy returns EBUSY, which for example causes ZTS tests to
fail spuriously.

Relax the unmount deadline from 20 to max 40 milliseconds. The wait
continues to exit earlier than that if the teardown completes earlier.

This fixes spurious ZTS failures such as snapshot/snapshot_00
{1,2,3,5,6,7,8,12}_pos and snapshot/rollback_002_pos especially with
--enable-debug builds since e8e3076927039bc6a2094c43e3ac4e255884177f


### How Has This Been Tested?

Full OpenZFS Github CI matrix passed on all platforms (except for unrelated flakiness in fedora44 and ubuntu26)


### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)


### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

