### PR TITLE
Speed up pool rewind and allow it to tolerate minor damage

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -4348,6 +4348,9 @@ zpool_do_prefetch(int argc, char **argv)
  *
  *	-F	Attempt rewind if necessary.
  *
+ *	-M	Tolerate meta-data read errors that are not critical for the
+ *		pool operation.
+ *
  *	-n	See if rewind would work, but don't actually rewind.
  *
  *	-N	Import the pool but don't mount datasets.
@@ -4392,6 +4395,7 @@ zpool_do_import(int argc, char **argv)
 	boolean_t dryrun = B_FALSE;
 	boolean_t do_rewind = B_FALSE;
 	boolean_t xtreme_rewind = B_FALSE;
+	boolean_t relax_meta = B_FALSE;
 	boolean_t do_scan = B_FALSE;
 	boolean_t pool_exists = B_FALSE;
 	uint64_t txg = -1ULL;
@@ -4405,7 +4409,7 @@ zpool_do_import(int argc, char **argv)
 	};
 
 	/* check options */
-	while ((c = getopt_long(argc, argv, ":aCc:d:DEfFlmnNo:R:stT:VX",
+	while ((c = getopt_long(argc, argv, ":aCc:d:DEfFlmMnNo:R:stT:VX",
 	    long_options, NULL)) != -1) {
 		switch (c) {
 		case 'a':
@@ -4433,6 +4437,9 @@ zpool_do_import(int argc, char **argv)
 			break;
 		case 'm':
 			flags |= ZFS_IMPORT_MISSING_LOG;
+			break;
+		case 'M':
+			relax_meta = B_TRUE;
 			break;
 		case 'n':
 			dryrun = B_TRUE;
@@ -4477,7 +4484,9 @@ zpool_do_import(int argc, char **argv)
 				    gettext("invalid txg value\n"));
 				usage(B_FALSE);
 			}
-			rewind_policy = ZPOOL_DO_REWIND | ZPOOL_EXTREME_REWIND;
+			/* Rollback to a specific txg implies -FX. */
+			do_rewind = B_TRUE;
+			xtreme_rewind = B_TRUE;
 			break;
 		case 'V':
 			flags |= ZFS_IMPORT_VERBATIM;
@@ -4540,7 +4549,9 @@ zpool_do_import(int argc, char **argv)
 	if (nvlist_alloc(&policy, NV_UNIQUE_NAME, 0) != 0 ||
 	    nvlist_add_uint64(policy, ZPOOL_LOAD_REQUEST_TXG, txg) != 0 ||
 	    nvlist_add_uint32(policy, ZPOOL_LOAD_REWIND_POLICY,
-	    rewind_policy) != 0)
+	    rewind_policy) != 0 ||
+	    nvlist_add_boolean_value(policy, ZPOOL_LOAD_RELAX_META,
+	    relax_meta) != 0)
 		goto error;
 
 	/* check argument count */

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -826,6 +826,7 @@ typedef enum {
 
 typedef struct zpool_load_policy {
 	uint32_t	zlp_rewind;	/* rewind policy requested */
+	boolean_t	zlp_relaxmeta;	/* tolerate non-critical meta-data */
 	uint64_t	zlp_maxmeta;	/* max acceptable meta-data errors */
 	uint64_t	zlp_maxdata;	/* max acceptable data errors */
 	uint64_t	zlp_txg;	/* specific txg to load */
@@ -1012,10 +1013,12 @@ typedef struct zpool_load_policy {
 #define	ZPOOL_LOAD_POLICY		"load-policy"
 #define	ZPOOL_LOAD_REWIND_POLICY	"load-rewind-policy"
 #define	ZPOOL_LOAD_REQUEST_TXG		"load-request-txg"
+#define	ZPOOL_LOAD_RELAX_META		"load-relax-meta"
 #define	ZPOOL_LOAD_META_THRESH		"load-meta-thresh"
 #define	ZPOOL_LOAD_DATA_THRESH		"load-data-thresh"
 
 /* Rewind data discovered */
+#define	ZPOOL_CONFIG_LOAD_TXG		"rewind_txg"
 #define	ZPOOL_CONFIG_LOAD_TIME		"rewind_txg_ts"
 #define	ZPOOL_CONFIG_LOAD_META_ERRORS	"verify_meta_errors"
 #define	ZPOOL_CONFIG_LOAD_DATA_ERRORS	"verify_data_errors"

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -2044,55 +2044,75 @@ zpool_export_force(zpool_handle_t *zhp, const char *log_str)
 }
 
 static void
-zpool_rewind_exclaim(libzfs_handle_t *hdl, const char *name, boolean_t dryrun,
-    nvlist_t *config)
+zpool_rewind_exclaim(libzfs_handle_t *hdl, const char *name, nvlist_t *config)
 {
 	nvlist_t *nv = NULL;
-	uint64_t rewindto;
-	int64_t loss = -1;
-	struct tm t;
-	char timestr[128];
+	boolean_t dryrun;
+	uint64_t rewindto, rewindtxg;
+	int64_t loss = 0;
+	time_t when;
+	char timestr[26], whenstr[64];
 
 	if (!hdl->libzfs_printerr || config == NULL)
 		return;
 
-	if (nvlist_lookup_nvlist(config, ZPOOL_CONFIG_LOAD_INFO, &nv) != 0 ||
-	    nvlist_lookup_nvlist(nv, ZPOOL_CONFIG_REWIND_INFO, &nv) != 0) {
+	if (nvlist_lookup_nvlist(config, ZPOOL_CONFIG_LOAD_INFO, &nv) != 0)
 		return;
-	}
+
+	/*
+	 * The kernel reports the load it did not commit nested, so the
+	 * nesting is what tells a hypothetical rewind from a real one.
+	 */
+	dryrun = nvlist_lookup_nvlist(nv, ZPOOL_CONFIG_REWIND_INFO, &nv) == 0;
 
 	if (nvlist_lookup_uint64(nv, ZPOOL_CONFIG_LOAD_TIME, &rewindto) != 0)
 		return;
-	(void) nvlist_lookup_int64(nv, ZPOOL_CONFIG_REWIND_TIME, &loss);
 
-	if (localtime_r((time_t *)&rewindto, &t) != NULL &&
-	    ctime_r((time_t *)&rewindto, timestr) != NULL) {
-		timestr[24] = 0;
-		if (dryrun) {
-			(void) printf(dgettext(TEXT_DOMAIN,
-			    "Would be able to return %s "
-			    "to its state as of %s.\n"),
-			    name, timestr);
-		} else {
-			(void) printf(dgettext(TEXT_DOMAIN,
-			    "Pool %s returned to its state as of %s.\n"),
-			    name, timestr);
-		}
-		if (loss > 120) {
-			(void) printf(dgettext(TEXT_DOMAIN,
-			    "%s approximately %lld "),
-			    dryrun ? "Would discard" : "Discarded",
-			    ((longlong_t)loss + 30) / 60);
-			(void) printf(dgettext(TEXT_DOMAIN,
-			    "minutes of transactions.\n"));
-		} else if (loss > 0) {
-			(void) printf(dgettext(TEXT_DOMAIN,
-			    "%s approximately %lld "),
-			    dryrun ? "Would discard" : "Discarded",
-			    (longlong_t)loss);
-			(void) printf(dgettext(TEXT_DOMAIN,
-			    "seconds of transactions.\n"));
-		}
+	/*
+	 * The loss is reported only if the load fell back to an older
+	 * uberblock, so an enacted load without it discarded nothing.
+	 */
+	if (nvlist_lookup_int64(nv, ZPOOL_CONFIG_REWIND_TIME, &loss) != 0 &&
+	    !dryrun)
+		return;
+
+	if (nvlist_lookup_uint64(nv, ZPOOL_CONFIG_LOAD_TXG, &rewindtxg) != 0)
+		rewindtxg = 0;
+
+	when = (time_t)rewindto;
+	if (ctime_r(&when, timestr) != NULL) {
+		timestr[24] = '\0';
+	} else {
+		(void) snprintf(timestr, sizeof (timestr), "%llu",
+		    (u_longlong_t)rewindto);
+	}
+
+	if (rewindtxg != 0) {
+		(void) snprintf(whenstr, sizeof (whenstr), "%s (txg %llu)",
+		    timestr, (u_longlong_t)rewindtxg);
+	} else {
+		(void) strlcpy(whenstr, timestr, sizeof (whenstr));
+	}
+
+	if (dryrun) {
+		(void) printf(dgettext(TEXT_DOMAIN,
+		    "Would be able to return %s to its state as of %s.\n"),
+		    name, whenstr);
+	} else {
+		(void) printf(dgettext(TEXT_DOMAIN,
+		    "Pool %s returned to its state as of %s.\n"),
+		    name, whenstr);
+	}
+	if (loss > 120) {
+		(void) printf(dgettext(TEXT_DOMAIN,
+		    "%s approximately %lld minutes of transactions.\n"),
+		    dryrun ? "Would discard" : "Discarded",
+		    ((longlong_t)loss + 30) / 60);
+	} else if (loss > 0) {
+		(void) printf(dgettext(TEXT_DOMAIN,
+		    "%s approximately %lld seconds of transactions.\n"),
+		    dryrun ? "Would discard" : "Discarded",
+		    (longlong_t)loss);
 	}
 }
 
@@ -2352,7 +2372,7 @@ zpool_import_props(libzfs_handle_t *hdl, nvlist_t *config, const char *newname,
 		 */
 		if (policy.zlp_rewind & ZPOOL_TRY_REWIND) {
 			zpool_rewind_exclaim(hdl, newname ? origname : thename,
-			    B_TRUE, nv);
+			    nv);
 			nvlist_free(nv);
 			return (-1);
 		}
@@ -2525,7 +2545,7 @@ zpool_import_props(libzfs_handle_t *hdl, nvlist_t *config, const char *newname,
 		if (policy.zlp_rewind &
 		    (ZPOOL_DO_REWIND | ZPOOL_TRY_REWIND)) {
 			zpool_rewind_exclaim(hdl, newname ? origname : thename,
-			    ((policy.zlp_rewind & ZPOOL_TRY_REWIND) != 0), nv);
+			    nv);
 		}
 		nvlist_free(nv);
 	}
@@ -4581,9 +4601,7 @@ zpool_clear(zpool_handle_t *zhp, const char *path, nvlist_t *rewindnvl)
 		if (policy.zlp_rewind &
 		    (ZPOOL_DO_REWIND | ZPOOL_TRY_REWIND)) {
 			(void) zcmd_read_dst_nvlist(hdl, &zc, &nvi);
-			zpool_rewind_exclaim(hdl, zc.zc_name,
-			    ((policy.zlp_rewind & ZPOOL_TRY_REWIND) != 0),
-			    nvi);
+			zpool_rewind_exclaim(hdl, zc.zc_name, nvi);
 			nvlist_free(nvi);
 		}
 		zcmd_free_nvlists(&zc);

--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -621,8 +621,10 @@ Whether to traverse data blocks during an "extreme rewind"
 .Pq Fl X
 import.
 .Pp
-An extreme rewind import normally performs a full traversal of all
-blocks in the pool for verification.
+Data blocks are traversed only if the number of errors found in them is going
+to be reported, like during a dry run
+.Pq Fl nX ,
+since an actual rewind tolerates any number of them.
 If this parameter is unset, the traversal skips non-metadata blocks.
 It can be toggled once the
 import has started to stop or start the traversal of non-metadata blocks.

--- a/man/man8/zpool-import.8
+++ b/man/man8/zpool-import.8
@@ -32,7 +32,7 @@
 .Nm zpool
 .Cm import
 .Fl a
-.Op Fl DflmN
+.Op Fl DflmMN
 .Op Fl F Op Fl nTX
 .Op Fl -rewind-to-checkpoint
 .Op Fl c Ar cachefile Ns | Ns Fl d Ar dir Ns | Ns Ar device
@@ -41,7 +41,7 @@
 .Op Fl R Ar root
 .Nm zpool
 .Cm import
-.Op Fl Dflmt
+.Op Fl DflmMt
 .Op Fl F Op Fl nTX
 .Op Fl -rewind-to-checkpoint
 .Op Fl c Ar cachefile Ns | Ns Fl d Ar dir Ns | Ns Ar device
@@ -107,7 +107,7 @@ Lists destroyed pools only.
 .Nm zpool
 .Cm import
 .Fl a
-.Op Fl DflmN
+.Op Fl DflmMN
 .Op Fl F Op Fl nTX
 .Op Fl c Ar cachefile Ns | Ns Fl d Ar dir Ns | Ns Ar device
 .Op Fl o Ar mntopts
@@ -173,6 +173,15 @@ encrypted datasets will be left unavailable until the keys are loaded.
 .It Fl m
 Allows a pool to import when there is a missing log device.
 Recent transactions can be lost because the log device will be discarded.
+.It Fl M
+Allows the import to succeed with damaged metadata that is not critical for the
+pool operation, such as an indirect block of a file, a directory or a block of
+dnodes.
+The affected objects become inaccessible, leak their space and may be impossible
+to remove.
+Without this option such damage makes the pool unimportable.
+WARNING: This option can be extremely hazardous to the
+health of your pool and should only be used as a last resort.
 .It Fl n
 Used with the
 .Fl F
@@ -247,7 +256,7 @@ health of your pool and should only be used as a last resort.
 .It Xo
 .Nm zpool
 .Cm import
-.Op Fl Dflmt
+.Op Fl DflmMt
 .Op Fl F Op Fl nTX
 .Op Fl c Ar cachefile Ns | Ns Fl d Ar dir Ns | Ns Ar device
 .Op Fl o Ar mntopts
@@ -321,6 +330,15 @@ encrypted datasets will be left unavailable until the keys are loaded.
 .It Fl m
 Allows a pool to import when there is a missing log device.
 Recent transactions can be lost because the log device will be discarded.
+.It Fl M
+Allows the import to succeed with damaged metadata that is not critical for the
+pool operation, such as an indirect block of a file, a directory or a block of
+dnodes.
+The affected objects become inaccessible, leak their space and may be impossible
+to remove.
+Without this option such damage makes the pool unimportable.
+WARNING: This option can be extremely hazardous to the
+health of your pool and should only be used as a last resort.
 .It Fl n
 Used with the
 .Fl F

--- a/module/zcommon/zfs_comutil.c
+++ b/module/zcommon/zfs_comutil.c
@@ -93,6 +93,7 @@ zpool_get_load_policy(nvlist_t *nvl, zpool_load_policy_t *zlpp)
 
 	/* Defaults */
 	zlpp->zlp_rewind = ZPOOL_NO_REWIND;
+	zlpp->zlp_relaxmeta = B_FALSE;
 	zlpp->zlp_maxmeta = 0;
 	zlpp->zlp_maxdata = UINT64_MAX;
 	zlpp->zlp_txg = UINT64_MAX;
@@ -113,6 +114,9 @@ zpool_get_load_policy(nvlist_t *nvl, zpool_load_policy_t *zlpp)
 					zlpp->zlp_rewind = ZPOOL_NO_REWIND;
 		} else if (strcmp(nm, ZPOOL_LOAD_REQUEST_TXG) == 0) {
 			(void) nvpair_value_uint64(elem, &zlpp->zlp_txg);
+		} else if (strcmp(nm, ZPOOL_LOAD_RELAX_META) == 0) {
+			(void) nvpair_value_boolean_value(elem,
+			    &zlpp->zlp_relaxmeta);
 		} else if (strcmp(nm, ZPOOL_LOAD_META_THRESH) == 0) {
 			(void) nvpair_value_uint64(elem, &zlpp->zlp_maxmeta);
 		} else if (strcmp(nm, ZPOOL_LOAD_DATA_THRESH) == 0) {

--- a/module/zfs/dmu_traverse.c
+++ b/module/zfs/dmu_traverse.c
@@ -755,7 +755,7 @@ int
 traverse_pool(spa_t *spa, uint64_t txg_start, int flags,
     blkptr_cb_t func, void *arg)
 {
-	int err;
+	int err, hard_err = 0;
 	dsl_pool_t *dp = spa_get_dsl(spa);
 	objset_t *mos = dp->dp_meta_objset;
 	boolean_t hard = (flags & TRAVERSE_HARD);
@@ -773,8 +773,10 @@ traverse_pool(spa_t *spa, uint64_t txg_start, int flags,
 
 		err = dmu_object_info(mos, obj, &doi);
 		if (err != 0) {
-			if (hard)
+			if (hard) {
+				hard_err = err;
 				continue;
+			}
 			break;
 		}
 
@@ -786,8 +788,10 @@ traverse_pool(spa_t *spa, uint64_t txg_start, int flags,
 			err = dsl_dataset_hold_obj(dp, obj, FTAG, &ds);
 			dsl_pool_config_exit(dp, FTAG);
 			if (err != 0) {
-				if (hard)
+				if (hard) {
+					hard_err = err;
 					continue;
+				}
 				break;
 			}
 			if (dsl_dataset_phys(ds)->ds_prev_snap_txg > txg)
@@ -800,7 +804,13 @@ traverse_pool(spa_t *spa, uint64_t txg_start, int flags,
 	}
 	if (err == ESRCH)
 		err = 0;
-	return (err);
+
+	/*
+	 * Datasets we could not even open above were skipped, and unlike the
+	 * unreadable blocks they are not reported to the callback in any way.
+	 * Report the last such error now, once the traversal is complete.
+	 */
+	return (err != 0 ? err : hard_err);
 }
 
 EXPORT_SYMBOL(traverse_dataset);

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -2992,6 +2992,9 @@ spa_claim_notify(zio_t *zio)
 
 typedef struct spa_load_error {
 	boolean_t	sle_verify_data;
+	boolean_t	sle_relaxmeta;	/* tolerate non-critical meta-data */
+	uint64_t	sle_maxmeta;	/* max acceptable meta-data errors */
+	uint64_t	sle_maxdata;	/* max acceptable data errors */
 	uint64_t	sle_meta_count;
 	uint64_t	sle_data_count;
 } spa_load_error_t;
@@ -3007,8 +3010,23 @@ spa_load_verify_done(zio_t *zio)
 
 	abd_free(zio->io_abd);
 	if (error) {
-		if ((BP_GET_LEVEL(bp) != 0 || DMU_OT_IS_METADATA(type)) &&
-		    type != DMU_OT_INTENT_LOG)
+		boolean_t meta;
+
+		if (type == DMU_OT_INTENT_LOG) {
+			meta = B_FALSE;
+		} else if (zio->io_bookmark.zb_objset == DMU_META_OBJSET) {
+			meta = B_TRUE;
+		} else if (sle->sle_relaxmeta) {
+			/*
+			 * Losing a file or a directory costs us the affected
+			 * objects, but the pool as a whole remains operable.
+			 */
+			meta = DMU_OT_IS_CRITICAL(type, BP_GET_LEVEL(bp));
+		} else {
+			meta = BP_GET_LEVEL(bp) != 0 ||
+			    DMU_OT_IS_METADATA(type);
+		}
+		if (meta)
 			atomic_inc_64(&sle->sle_meta_count);
 		else
 			atomic_inc_64(&sle->sle_data_count);
@@ -3044,6 +3062,14 @@ spa_load_verify_cb(spa_t *spa, zilog_t *zilog, const blkptr_t *bp,
 	 */
 	if (!spa_load_verify_metadata)
 		return (0);
+
+	/*
+	 * Stop the traversal as soon as the verdict is known, there is no
+	 * point in counting the errors we are not going to tolerate anyway.
+	 */
+	if (sle->sle_meta_count > sle->sle_maxmeta ||
+	    sle->sle_data_count > sle->sle_maxdata)
+		return (SET_ERROR(ECANCELED));
 
 	/*
 	 * Sanity check the block pointer in order to detect obvious damage
@@ -3098,7 +3124,7 @@ spa_load_verify(spa_t *spa)
 	zio_t *rio;
 	spa_load_error_t sle = { 0 };
 	zpool_load_policy_t policy;
-	boolean_t verify_ok = B_FALSE;
+	boolean_t verify_ok = B_FALSE, aborted = B_FALSE;
 	int error = 0;
 
 	zpool_get_load_policy(spa->spa_config, &policy);
@@ -3116,11 +3142,29 @@ spa_load_verify(spa_t *spa)
 		return (error);
 
 	/*
-	 * Verify data only if we are rewinding or error limit was set.
-	 * Otherwise nothing except dbgmsg care about it to waste time.
+	 * Verify data only if somebody is going to look at the error count:
+	 * either the caller set a limit for it, or we are only searching for
+	 * the best txg without rewinding to it (zpool import -nF), which
+	 * reports the count back to the user.
 	 */
-	sle.sle_verify_data = (policy.zlp_rewind & ZPOOL_REWIND_MASK) ||
-	    (policy.zlp_maxdata < UINT64_MAX);
+	sle.sle_verify_data = policy.zlp_maxdata < UINT64_MAX ||
+	    ((policy.zlp_rewind & ZPOOL_REWIND_MASK) &&
+	    (spa_load_verify_dryrun ||
+	    spa->spa_load_state != SPA_LOAD_RECOVER));
+
+	sle.sle_relaxmeta = policy.zlp_relaxmeta;
+
+	/*
+	 * Dry run reports the errors instead of acting on them, so it needs
+	 * the complete counts.  Otherwise stop counting once the thresholds
+	 * are exceeded, since the result can not change after that.
+	 */
+	if (spa_load_verify_dryrun) {
+		sle.sle_maxmeta = sle.sle_maxdata = UINT64_MAX;
+	} else {
+		sle.sle_maxmeta = policy.zlp_maxmeta;
+		sle.sle_maxdata = policy.zlp_maxdata;
+	}
 
 	rio = zio_root(spa, NULL, &sle,
 	    ZIO_FLAG_CANFAIL | ZIO_FLAG_SPECULATIVE);
@@ -3129,14 +3173,24 @@ spa_load_verify(spa_t *spa)
 		if (spa->spa_extreme_rewind) {
 			spa_load_note(spa, "performing a complete scan of the "
 			    "pool since extreme rewind is on. This may take "
-			    "a very long time.\n  (spa_load_verify_data=%u, "
-			    "spa_load_verify_metadata=%u)",
-			    spa_load_verify_data, spa_load_verify_metadata);
+			    "a very long time.\n  (verifying metadata=%u, "
+			    "data=%u)", spa_load_verify_metadata,
+			    spa_load_verify_data && sle.sle_verify_data);
 		}
 
 		error = traverse_pool(spa, spa->spa_verify_min_txg,
 		    TRAVERSE_PRE | TRAVERSE_PREFETCH_METADATA |
-		    TRAVERSE_NO_DECRYPT, spa_load_verify_cb, rio);
+		    TRAVERSE_NO_DECRYPT | TRAVERSE_HARD,
+		    spa_load_verify_cb, rio);
+
+		/*
+		 * We aborted the traversal ourselves, so this is not a real
+		 * error, only the error counts below are now lower bounds.
+		 */
+		if (error == ECANCELED) {
+			error = 0;
+			aborted = B_TRUE;
+		}
 	}
 
 	(void) zio_wait(rio);
@@ -3146,25 +3200,34 @@ spa_load_verify(spa_t *spa)
 	spa->spa_load_data_errors = sle.sle_data_count;
 
 	if (sle.sle_meta_count != 0 || sle.sle_data_count != 0) {
-		spa_load_note(spa, "spa_load_verify found %llu metadata errors "
-		    "and %llu data errors", (u_longlong_t)sle.sle_meta_count,
+		spa_load_note(spa, "spa_load_verify found %s%llu metadata "
+		    "errors and %llu data errors",
+		    aborted ? "at least " : "",
+		    (u_longlong_t)sle.sle_meta_count,
 		    (u_longlong_t)sle.sle_data_count);
 	}
 
 	if (spa_load_verify_dryrun ||
 	    (!error && sle.sle_meta_count <= policy.zlp_maxmeta &&
 	    sle.sle_data_count <= policy.zlp_maxdata)) {
-		int64_t loss = 0;
-
 		verify_ok = B_TRUE;
 		spa->spa_load_txg = spa->spa_uberblock.ub_txg;
 		spa->spa_load_txg_ts = spa->spa_uberblock.ub_timestamp;
 
-		loss = spa->spa_last_ubsync_txg_ts - spa->spa_load_txg_ts;
+		fnvlist_add_uint64(spa->spa_load_info, ZPOOL_CONFIG_LOAD_TXG,
+		    spa->spa_load_txg);
 		fnvlist_add_uint64(spa->spa_load_info, ZPOOL_CONFIG_LOAD_TIME,
 		    spa->spa_load_txg_ts);
-		fnvlist_add_int64(spa->spa_load_info, ZPOOL_CONFIG_REWIND_TIME,
-		    loss);
+		/*
+		 * The loss makes sense only for a fallback to an older
+		 * uberblock, which is the only case we know the newest one in.
+		 */
+		if (spa->spa_last_ubsync_txg_ts != 0) {
+			fnvlist_add_int64(spa->spa_load_info,
+			    ZPOOL_CONFIG_REWIND_TIME,
+			    spa->spa_last_ubsync_txg_ts -
+			    spa->spa_load_txg_ts);
+		}
 		fnvlist_add_uint64(spa->spa_load_info,
 		    ZPOOL_CONFIG_LOAD_META_ERRORS, sle.sle_meta_count);
 		fnvlist_add_uint64(spa->spa_load_info,
@@ -6397,7 +6460,8 @@ spa_load_retry(spa_t *spa, spa_load_state_t state)
  * 'state' is SPA_LOAD_RECOVER and one of these loads succeeds the pool
  * will be rewound to that txg. If 'state' is not SPA_LOAD_RECOVER this
  * function will not rewind the pool and will return the same error as
- * spa_load().
+ * spa_load(), or ECANCELED if the load only probed the requested txg
+ * instead of bringing the pool up.
  */
 static int
 spa_load_best(spa_t *spa, spa_load_state_t state, uint64_t max_request,
@@ -6419,8 +6483,25 @@ spa_load_best(spa_t *spa, spa_load_state_t state, uint64_t max_request,
 	}
 
 	load_error = rewind_error = spa_load(spa, state, SPA_IMPORT_EXISTING);
-	if (load_error == 0)
+	if (load_error == 0) {
+		/*
+		 * A load of an explicitly requested txg may only probe
+		 * whether that txg is usable, finishing without a syncing
+		 * thread.  Such a pool is not functional, so it can not be
+		 * handed to the caller no matter how well it loaded.  Report
+		 * the probed txg the same way an actual rewind would.
+		 */
+		if (spa_writeable(spa) && !spa->spa_sync_on) {
+			loadinfo = fnvlist_alloc();
+			fnvlist_add_nvlist(loadinfo, ZPOOL_CONFIG_REWIND_INFO,
+			    spa->spa_load_info);
+			fnvlist_free(spa->spa_load_info);
+			spa->spa_load_info = loadinfo;
+			spa_import_progress_remove(spa_guid(spa));
+			return (SET_ERROR(ECANCELED));
+		}
 		return (0);
+	}
 
 	/* Do not attempt to load uberblocks from previous txgs when: */
 	switch (load_error) {

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -1772,6 +1772,9 @@ vdev_metaslab_fini(vdev_t *vd)
 	if (vd->vdev_checkpoint_sm != NULL) {
 		ASSERT(spa_feature_is_active(vd->vdev_spa,
 		    SPA_FEATURE_POOL_CHECKPOINT));
+		vd->vdev_spa->spa_checkpoint_info.sci_dspace -=
+		    vd->vdev_stat.vs_checkpoint_space;
+		vd->vdev_stat.vs_checkpoint_space = 0;
 		space_map_close(vd->vdev_checkpoint_sm);
 		/*
 		 * Even though we close the space map, we need to set its

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -498,8 +498,10 @@ tests = ['zpool_import_001_pos', 'zpool_import_002_pos',
     'import_cachefile_shared_device',
     'import_devices_missing', 'import_log_missing',
     'import_paths_changed',
+    'import_relax_metadata_damaged',
     'import_rewind_config_changed',
     'import_rewind_device_replaced',
+    'import_rewind_metadata_damaged',
     'zpool_import_status', 'zpool_import_parallel_pos',
     'zpool_import_parallel_neg', 'zpool_import_parallel_admin']
 tags = ['functional', 'cli_root', 'zpool_import']

--- a/tests/zfs-tests/include/blkdev.shlib
+++ b/tests/zfs-tests/include/blkdev.shlib
@@ -558,7 +558,9 @@ function list_file_blocks # input_file
 	#
 	typeset level vdev path offset length
 	sync_all_pools true
-	zdb -dddddd $ds $objnum | awk '
+	# A bare pool name would make zdb dump the MOS instead of the root
+	# dataset, the trailing slash tells it to open the dataset.
+	zdb -dddddd "$ds/" $objnum | awk '
 	    /^$/ { looking = 0 }
 	    looking {
 	        level = $2
@@ -588,13 +590,17 @@ function corrupt_blocks_at_level # input_file corrupt_level
 
 	[[ -f $input_file ]] || log_fail "Couldn't find $input_file"
 
+	typeset blocks="$(list_file_blocks $input_file)"
+	echo "$blocks" | grep -q "^$corrupt_level " ||
+	    log_fail "Couldn't find $corrupt_level blocks of $input_file"
+
 	if is_freebsd; then
 		# Temporarily allow corrupting an inuse device.
 		debugflags=$(sysctl -n kern.geom.debugflags)
 		sysctl kern.geom.debugflags=16
 	fi
 
-	list_file_blocks $input_file | \
+	echo "$blocks" | \
 	while read level path offset length; do
 		if [[ $level = $corrupt_level ]]; then
 			log_must dd if=/dev/urandom of=$path bs=512 \

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1235,8 +1235,10 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zpool_import/import_devices_missing.ksh \
 	functional/cli_root/zpool_import/import_log_missing.ksh \
 	functional/cli_root/zpool_import/import_paths_changed.ksh \
+	functional/cli_root/zpool_import/import_relax_metadata_damaged.ksh \
 	functional/cli_root/zpool_import/import_rewind_config_changed.ksh \
 	functional/cli_root/zpool_import/import_rewind_device_replaced.ksh \
+	functional/cli_root/zpool_import/import_rewind_metadata_damaged.ksh \
 	functional/cli_root/zpool_import/setup.ksh \
 	functional/cli_root/zpool_import/zpool_import_001_pos.ksh \
 	functional/cli_root/zpool_import/zpool_import_002_pos.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_import/import_relax_metadata_damaged.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_import/import_relax_metadata_damaged.ksh
@@ -1,0 +1,131 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
+#
+
+#
+# Copyright (c) 2026, TrueNAS.
+#
+
+. $STF_SUITE/tests/functional/cli_root/zpool_import/zpool_import.kshlib
+
+#
+# DESCRIPTION:
+#	Damaged file meta-data should make a txg unusable, unless the import
+#	is explicitly told to tolerate the non-critical meta-data errors.
+#
+# STRATEGY:
+#	1. Create a pool with two files and remember their hashsums.
+#	2. Corrupt every copy of the indirect block of one of them on disk.
+#	3. Checkpoint the pool, so that the blocks of the txg below are
+#	   guaranteed to stay on disk, and note the last synced txg.
+#	4. Verify that a dry run of that txg rewinds past it, and that the
+#	   same dry run with -M accepts it.
+#	5. Import that txg with -M and verify that it succeeds, that the
+#	   intact file is still readable and the damaged one is not.
+#	6. Verify that the pool is fully operable, and that -M needs neither
+#	   -F nor -X.
+#
+# NOTES:
+#	The dry runs above request a txg explicitly, which implies an extreme
+#	rewind.  A non-extreme import verifies only the blocks born within the
+#	last few txgs, and the export itself consumes exactly that many, so it
+#	would never look at the damaged block.
+#
+#	Those same txgs consumed by the export are also enough for the blocks
+#	the requested txg references to be freed and reallocated.  Without the
+#	checkpoint holding them the txg may be unloadable for reasons having
+#	nothing to do with the damage injected here, which is exactly what -M
+#	is not supposed to tolerate.
+#
+#	A dry run reports an error whether it found a usable txg or not, so
+#	only the txg it reports tells the two apart.
+#
+
+verify_runnable "global"
+
+function custom_cleanup
+{
+	log_pos restore_tunable TXG_TIMEOUT
+	cleanup
+}
+
+log_onexit custom_cleanup
+
+log_assert "Tolerate damaged file meta-data on import with -M."
+
+typeset intact="/$TESTPOOL1/intact"
+typeset damaged="/$TESTPOOL1/damaged"
+typeset -i blocks=8
+
+log_must zpool create $TESTPOOL1 $VDEV0
+
+log_must dd if=/dev/urandom of=$intact bs=128k count=$blocks
+log_must dd if=/dev/urandom of=$damaged bs=128k count=$blocks
+log_must sync_pool $TESTPOOL1
+typeset digest=$(xxh128digest $intact)
+
+corrupt_blocks_at_level $damaged 1
+
+#
+# From now on only the checkpoint below advances the txg, so the state it
+# protects is the very state the imports below request.
+#
+log_must save_tunable TXG_TIMEOUT
+log_must set_tunable32 TXG_TIMEOUT 5000
+
+log_must zpool checkpoint $TESTPOOL1
+typeset -i txg=$(get_last_txg_synced $TESTPOOL1)
+
+log_must zpool export $TESTPOOL1
+
+#
+# An indirect block of a file is fatal for the txg by default.  A dry run
+# of an explicitly requested txg never imports the pool, so the reported
+# rewind target is what tells us that the txg itself was rejected: it is
+# some older txg rather than the requested one.
+#
+typeset out
+out=$(zpool import -d $DEVICE_DIR -nFX -T $txg $TESTPOOL1 2>&1) &&
+    log_fail "Loading the damaged txg $txg unexpectedly succeeded"
+log_note "$out"
+echo "$out" | grep -q "(txg $txg)" &&
+    log_fail "The damaged txg $txg was not rejected"
+
+# The very same txg is a valid target once the caller accepts the losses.
+out=$(zpool import -d $DEVICE_DIR -nFX -M -T $txg $TESTPOOL1 2>&1)
+log_note "$out"
+echo "$out" | grep -q "(txg $txg)" ||
+    log_fail "The damaged txg $txg was not accepted with -M"
+
+# And it can be imported for real, losing only the damaged file.
+log_must zpool import -d $DEVICE_DIR -M -T $txg $TESTPOOL1
+log_must zpool checkpoint -d $TESTPOOL1
+
+if [[ "$(xxh128digest $intact)" != "$digest" ]]; then
+	log_fail "The intact file lost its content"
+fi
+log_mustnot eval "dd if=$damaged of=/dev/null bs=128k count=$blocks" \
+    "2>/dev/null"
+
+# The pool itself has to remain fully operable.
+log_must eval "zpool status $TESTPOOL1 | grep -q '$VDEV0.*ONLINE'"
+log_must dd if=/dev/urandom of=/$TESTPOOL1/new bs=128k count=1
+log_must sync_pool $TESTPOOL1
+log_must zfs snapshot $TESTPOOL1@snap
+
+log_must zpool export $TESTPOOL1
+
+# The option does not depend on a rewind being requested.
+log_must zpool import -d $DEVICE_DIR -M $TESTPOOL1
+
+log_pass "Tolerate damaged file meta-data on import with -M."

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_import/import_rewind_metadata_damaged.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_import/import_rewind_metadata_damaged.ksh
@@ -1,0 +1,118 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
+#
+
+#
+# Copyright (c) 2026, TrueNAS.
+#
+
+. $STF_SUITE/tests/functional/cli_root/zpool_import/zpool_import.kshlib
+
+#
+# DESCRIPTION:
+#	Damaged file meta-data should make a txg unusable, and it should be
+#	possible to rewind the pool to a txg preceding the damage.
+#
+# STRATEGY:
+#	1. Create a pool with a single file and remember its hashsum.
+#	2. Checkpoint the pool, so that the blocks of the txgs below are
+#	   guaranteed to stay on disk, and note the last synced txg.
+#	3. Overwrite the file in a single txg, allocating a new indirect block
+#	   for it, and note the last synced txg again.
+#	4. Corrupt every copy of that indirect block on disk.
+#	5. Verify that a dry run reports the newer txg as unusable and the
+#	   older one as a possible rewind target.
+#	6. Rewind the pool and verify that the file has its original content.
+#
+# NOTES:
+#	Both imports below request a txg explicitly, which implies an extreme
+#	rewind.  A non-extreme import verifies only the blocks born within the
+#	last few txgs, so whether it notices the damage would depend on how
+#	many txgs the export happens to consume.
+#
+#	The overwrite has to land in a single txg, otherwise the rewind could
+#	stop at an intermediate uberblock holding a partially updated file.
+#	The file is small and the txg timeout is disabled to ensure that.
+#
+#	A single zpool sync advances the pool by several txgs, so the ones
+#	between the two below are empty, but they still reference the damaged
+#	block and are rejected just like the txg that allocated it.
+#
+
+verify_runnable "global"
+
+function custom_cleanup
+{
+	log_pos restore_tunable TXG_TIMEOUT
+	cleanup
+}
+
+log_onexit custom_cleanup
+
+log_assert "Rewind past damaged file meta-data."
+
+typeset file="/$TESTPOOL1/file"
+typeset -i blocks=8
+
+log_must zpool create $TESTPOOL1 $VDEV0
+
+log_must dd if=/dev/urandom of=$file bs=128k count=$blocks
+log_must sync_pool $TESTPOOL1
+typeset digest=$(xxh128digest $file)
+
+#
+# From now on only the explicit syncs below advance the txg, so the pool
+# ends up with exactly one txg worth of damage to rewind past.
+#
+log_must save_tunable TXG_TIMEOUT
+log_must set_tunable32 TXG_TIMEOUT 5000
+
+#
+# The checkpoint keeps the blocks of the txg we are going to rewind to,
+# including the MOS ones, from being reused.
+#
+log_must zpool checkpoint $TESTPOOL1
+typeset -i goodtxg=$(get_last_txg_synced $TESTPOOL1)
+
+# This allocates a new indirect block for the file.
+log_must dd if=/dev/urandom of=$file bs=128k count=$blocks conv=notrunc
+log_must sync_pool $TESTPOOL1
+typeset -i badtxg=$(get_last_txg_synced $TESTPOOL1)
+
+# The old indirect block is protected by the checkpoint, not listed here.
+corrupt_blocks_at_level $file 1
+
+log_must zpool export $TESTPOOL1
+
+# The damaged txg can not be loaded, but the one preceding it can.
+typeset out
+out=$(zpool import -d $DEVICE_DIR -nFX -T $badtxg $TESTPOOL1 2>&1) &&
+    log_fail "Loading the damaged txg $badtxg unexpectedly succeeded"
+log_note "$out"
+echo "$out" | grep -q "(txg $goodtxg)" ||
+    log_fail "The txg $goodtxg was not reported as the rewind target"
+
+log_must zpool import -d $DEVICE_DIR -T $badtxg $TESTPOOL1
+
+# The original content is the proof that the pool was actually rewound.
+log_must check_pool_healthy $TESTPOOL1
+if [[ "$(xxh128digest $file)" != "$digest" ]]; then
+	log_fail "The file was not restored to its original content"
+fi
+
+# Nothing references the damaged block anymore.
+log_must zpool checkpoint -d $TESTPOOL1
+log_must zpool scrub -w $TESTPOOL1
+log_must check_pool_healthy $TESTPOOL1
+
+log_pass "Rewind past damaged file meta-data."


### PR DESCRIPTION
Importing a damaged pool with `-F`/`-X` could take days: every rewind attempt scanned the whole pool, and it kept scanning long after it hit an error that already disqualified the txg.  Worse, the scan is all or nothing -- a single unreadable block of file meta-data rejects a txg even when the pool itself is perfectly consistent, forcing the admin to rewind much further back and lose unrelated data for no reason.

Abort the verification scan as soon as a txg is known to be unusable, and skip the data scan entirely for attempts that are only looking for a rewind target.  Then split the errors found into those that really prevent the pool from working and those that only cost the contents of some files, and add a new `zpool import -M` asking to accept the latter.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
