### PR TITLE
dsl_crypt: validate every key change-key will rewrap

### DIFF
--- a/module/zfs/dsl_crypt.c
+++ b/module/zfs/dsl_crypt.c
@@ -1241,6 +1241,101 @@ typedef struct spa_keystore_change_key_args {
 	nvlist_t *skcka_userprops;
 } spa_keystore_change_key_args_t;
 
+/*
+ * Check that every DSL Crypto Key that spa_keystore_change_key_sync_impl()
+ * will rewrap can be unwrapped with the wrapping key it currently claims.
+ * That function cannot return an error, so a key it fails to hold there is
+ * fatal, and this recursion must visit exactly the dsl dirs that one does.
+ * A dataset whose key material no longer matches the encryption root it
+ * points at is rejected here with EACCES instead.
+ */
+static int
+spa_keystore_change_key_check_impl(uint64_t rddobj, uint64_t ddobj,
+    boolean_t skip, dmu_tx_t *tx)
+{
+	int ret;
+	zap_cursor_t *zc;
+	zap_attribute_t *za;
+	dsl_pool_t *dp = dmu_tx_pool(tx);
+	dsl_dir_t *dd = NULL;
+	dsl_crypto_key_t *dck = NULL;
+	uint64_t curr_rddobj;
+
+	ret = dsl_dir_hold_obj(dp, ddobj, NULL, FTAG, &dd);
+	if (ret != 0)
+		return (ret);
+
+	/* ignore special dsl dirs */
+	if (dd->dd_myname[0] == '$' || dd->dd_myname[0] == '%') {
+		dsl_dir_rele(dd, FTAG);
+		return (0);
+	}
+
+	ret = dsl_dir_get_encryption_root_ddobj(dd, &curr_rddobj);
+	if (ret != 0 && ret != ENOENT) {
+		dsl_dir_rele(dd, FTAG);
+		return (ret);
+	}
+
+	/*
+	 * Stop recursing if this dsl dir didn't inherit from the root
+	 * or if this dd is a clone.
+	 */
+	if (ret == ENOENT ||
+	    (!skip && (curr_rddobj != rddobj || dsl_dir_is_clone(dd)))) {
+		dsl_dir_rele(dd, FTAG);
+		return (0);
+	}
+
+	/* the sync function will rewrap this key, so it must be readable */
+	if (!skip) {
+		ret = spa_keystore_dsl_key_hold_dd(dp->dp_spa, dd, FTAG, &dck);
+		if (ret != 0) {
+			dsl_dir_rele(dd, FTAG);
+			return (ret);
+		}
+		spa_keystore_dsl_key_rele(dp->dp_spa, dck, FTAG);
+	}
+
+	zc = kmem_alloc(sizeof (zap_cursor_t), KM_SLEEP);
+	za = zap_attribute_alloc();
+
+	/* Recurse into all child dsl dirs. */
+	for (zap_cursor_init(zc, dp->dp_meta_objset,
+	    dsl_dir_phys(dd)->dd_child_dir_zapobj);
+	    ret == 0 && zap_cursor_retrieve(zc, za) == 0;
+	    zap_cursor_advance(zc)) {
+		ret = spa_keystore_change_key_check_impl(rddobj,
+		    za->za_first_integer, B_FALSE, tx);
+	}
+	zap_cursor_fini(zc);
+
+	/* Recurse into all dsl dirs of clones, skipping the clones. */
+	for (zap_cursor_init(zc, dp->dp_meta_objset,
+	    dsl_dir_phys(dd)->dd_clones);
+	    ret == 0 && zap_cursor_retrieve(zc, za) == 0;
+	    zap_cursor_advance(zc)) {
+		dsl_dataset_t *clone;
+
+		ret = dsl_dataset_hold_obj(dp, za->za_first_integer,
+		    FTAG, &clone);
+		if (ret != 0)
+			break;
+
+		ret = spa_keystore_change_key_check_impl(rddobj,
+		    clone->ds_dir->dd_object, B_TRUE, tx);
+		dsl_dataset_rele(clone, FTAG);
+	}
+	zap_cursor_fini(zc);
+
+	zap_attribute_free(za);
+	kmem_free(zc, sizeof (zap_cursor_t));
+
+	dsl_dir_rele(dd, FTAG);
+
+	return (ret);
+}
+
 static int
 spa_keystore_change_key_check(void *arg, dmu_tx_t *tx)
 {
@@ -1324,6 +1419,11 @@ spa_keystore_change_key_check(void *arg, dmu_tx_t *tx)
 			ret = dmu_objset_check_wkey_loaded(dd->dd_parent);
 			if (ret != 0)
 				goto error;
+
+			ret = spa_keystore_change_key_check_impl(rddobj,
+			    dd->dd_object, B_FALSE, tx);
+			if (ret != 0)
+				goto error;
 		}
 
 		dsl_dir_rele(dd, FTAG);
@@ -1405,6 +1505,11 @@ spa_keystore_change_key_check(void *arg, dmu_tx_t *tx)
 	if (ret != 0)
 		goto error;
 
+	ret = spa_keystore_change_key_check_impl(rddobj, dd->dd_object, B_FALSE,
+	    tx);
+	if (ret != 0)
+		goto error;
+
 	dsl_dir_rele(dd, FTAG);
 
 	return (0);
@@ -1421,7 +1526,8 @@ error:
  * key references and encryption roots recursively in the event
  * of a call to 'zfs change-key' or 'zfs promote'. The 'skip'
  * parameter should always be set to B_FALSE when called
- * externally.
+ * externally. spa_keystore_change_key_check_impl() must recurse over the
+ * same set of dsl dirs; keep the two in step.
  */
 static void
 spa_keystore_change_key_sync_impl(uint64_t rddobj, uint64_t ddobj,

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -194,7 +194,7 @@ tags = ['functional', 'cli_root', 'zfs_bookmark']
 tests = ['zfs_change-key', 'zfs_change-key_child', 'zfs_change-key_format',
     'zfs_change-key_inherit', 'zfs_change-key_load', 'zfs_change-key_location',
     'zfs_change-key_pbkdf2iters', 'zfs_change-key_clones',
-    'zfs_change-key_userprop']
+    'zfs_change-key_userprop', 'zfs_change-key_mismatch']
 tags = ['functional', 'cli_root', 'zfs_change-key']
 
 [tests/functional/cli_root/zfs_clone]

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -732,6 +732,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zfs_change-key/zfs_change-key.ksh \
 	functional/cli_root/zfs_change-key/zfs_change-key_load.ksh \
 	functional/cli_root/zfs_change-key/zfs_change-key_location.ksh \
+	functional/cli_root/zfs_change-key/zfs_change-key_mismatch.ksh \
 	functional/cli_root/zfs_change-key/zfs_change-key_pbkdf2iters.ksh \
 	functional/cli_root/zfs_change-key/zfs_change-key_userprop.ksh \
 	functional/cli_root/zfs/cleanup.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_change-key/zfs_change-key_mismatch.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_change-key/zfs_change-key_mismatch.ksh
@@ -1,0 +1,76 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zfs_load-key/zfs_load-key_common.kshlib
+
+#
+# DESCRIPTION:
+# 'zfs change-key' should fail on a dataset whose key material does not
+# match the encryption root it points at, rather than panic.
+#
+# STRATEGY:
+# 1. Create two encrypted datasets, each its own encryption root
+# 2. Raw send a child of the first one to the second one
+# 3. Load the received dataset's key and inherit the second root's key
+# 4. Raw send an incremental stream to it, which restores the sending
+#    root's key material while it still points at the local root
+# 5. Verify 'zfs change-key' on the dataset fails
+# 6. Verify 'zfs change-key' on its encryption root fails
+# 7. Verify the encryption root can be rekeyed once the dataset is gone
+#
+
+verify_runnable "both"
+
+function cleanup
+{
+	datasetexists $TESTPOOL/$TESTFS1 && \
+		destroy_dataset $TESTPOOL/$TESTFS1 -r
+	datasetexists $TESTPOOL/$TESTFS2 && \
+		destroy_dataset $TESTPOOL/$TESTFS2 -r
+}
+log_onexit cleanup
+
+log_assert "'zfs change-key' should fail on a dataset whose key material" \
+	"does not match its encryption root"
+
+log_must eval "echo $PASSPHRASE | zfs create -o encryption=on" \
+	"-o keyformat=passphrase -o keylocation=prompt $TESTPOOL/$TESTFS1"
+log_must eval "echo $PASSPHRASE1 | zfs create -o encryption=on" \
+	"-o keyformat=passphrase -o keylocation=prompt $TESTPOOL/$TESTFS2"
+
+log_must zfs create $TESTPOOL/$TESTFS1/child
+log_must zfs snapshot $TESTPOOL/$TESTFS1/child@snap1
+log_must eval "zfs send -w $TESTPOOL/$TESTFS1/child@snap1 |" \
+	"zfs receive -u $TESTPOOL/$TESTFS2/child"
+
+log_must eval "echo $PASSPHRASE | zfs load-key $TESTPOOL/$TESTFS2/child"
+log_must zfs change-key -i $TESTPOOL/$TESTFS2/child
+log_must verify_encryption_root $TESTPOOL/$TESTFS2/child "$TESTPOOL/$TESTFS2"
+
+log_must zfs snapshot $TESTPOOL/$TESTFS1/child@snap2
+log_must eval "zfs send -w -i $TESTPOOL/$TESTFS1/child@snap1" \
+	"$TESTPOOL/$TESTFS1/child@snap2 |" \
+	"zfs receive -u $TESTPOOL/$TESTFS2/child"
+
+log_mustnot eval "echo $PASSPHRASE2 | zfs change-key -o keyformat=passphrase" \
+	"-o keylocation=prompt $TESTPOOL/$TESTFS2/child"
+log_mustnot eval "echo $PASSPHRASE2 | zfs change-key -o keyformat=passphrase" \
+	"-o keylocation=prompt $TESTPOOL/$TESTFS2"
+
+log_must destroy_dataset $TESTPOOL/$TESTFS2/child -r
+log_must eval "echo $PASSPHRASE2 | zfs change-key -o keyformat=passphrase" \
+	"-o keylocation=prompt $TESTPOOL/$TESTFS2"
+
+log_pass "'zfs change-key' fails on a dataset whose key material does not" \
+	"match its encryption root"


### PR DESCRIPTION
### Motivation and Context

`spa_keystore_change_key_sync_impl()` recurses through a dataset, its children and its
clones, and `VERIFY0()`s `spa_keystore_dsl_key_hold_dd()` on every dsl dir it will rewrap.
`spa_keystore_change_key_check()` checks only that the wrapping key of the target's
encryption root is loaded, which is a weaker condition: `dmu_objset_check_wkey_loaded()`
asks whether that wrapping key is in the keystore and never tries to unwrap the dataset's
own DSL Crypto Key.

A dataset whose key material no longer matches the encryption root it points at therefore
passes the check and panics the sync task:

```
VERIFY0(spa_keystore_dsl_key_hold_dd(dp->dp_spa, dd, FTAG, &dck)) failed (13)
PANIC at dsl_crypt.c:1475:spa_keystore_change_key_sync_impl()
```

`txg_sync` is left blocked and the pool is unusable until the machine is rebooted.

#17425 is one way to reach that state: an incremental raw receive into a dataset that was
rewrapped locally with `zfs change-key -i` keeps the local `rddobj` and overwrites the
master key, IV, MAC, keyformat, salt and iters from the stream, so the dataset ends up
claiming a local encryption root while carrying the sending pool's key material. That
receive behaviour is a separate question and is not addressed here; the analysis is in the
issue. Since the assertion fires for any dataset the recursion cannot hold a key for, this
is worth fixing on its own.

### Description

Add `spa_keystore_change_key_check_impl()`, which walks the same dsl dirs
`spa_keystore_change_key_sync_impl()` will and holds each DSL Crypto Key that will be
rewrapped, so an unusable key comes back to the caller as EACCES.

It is called for `DCP_CMD_NEW_KEY` and `DCP_CMD_INHERIT`. The `FORCE` variants pass a NULL
wrapping key to the sync function, which then only updates `DSL_CRYPTO_KEY_ROOT_DDOBJ` and
never unwraps anything, so they need no extra check.

Two things I would like a view on:

* The subtree is now walked in the open context check, again in the syncing context check,
  and then by the sync function. Guarding the walk with `dmu_tx_is_syncing()` would drop it
  to two at the cost of failing a doomed `change-key` one txg later. I left it walking in
  both, since `change-key` is rare, but I do not have a feel for how large a rewrapped
  subtree gets in practice.
* The check returns whatever the key hold returned, which for a key that cannot be unwrapped
  is EACCES, so the user sees `Key change error: Key is not currently loaded.` That reads
  oddly next to `keystatus=available`, but the contradiction comes from `keystatus` itself
  being derived from `dmu_objset_check_wkey_loaded()`, so inventing a new errno here felt
  like papering over it.

### How Has This Been Tested?

On a VM running master (`7e1cb1374`), Linux 6.8.0-136:

* The reproducer from #17425, reduced to a single host and two file-backed pools. Before
  this change `zfs change-key` on the received dataset panics as above and `txg_sync` stays
  in D state. After it, the command fails with `Key change error: Key is not currently
  loaded.` and the pool stays healthy, with no `PANIC` or `VERIFY` in `dmesg`.
* `zfs change-key` on the *encryption root* above the broken dataset, which reaches it
  through the recursion, is rejected as well.
* An A/B on one command: with the broken dataset present the re-key of the encryption root
  fails; after `zfs destroy -r` on it the identical command succeeds and the healthy sibling
  is rewrapped correctly, its `pbkdf2salt` following the root's new salt.
* The new test case panics the kernel without the first commit and passes with it.
* ZTS `-T zfs_change-key,zfs_load-key,zfs_unload-key`: 26 tests, all passing, including
  `zfs_change-key_child`, `_clones` and `_inherit`.
* `make cstyle` and `scripts/commitcheck.sh` are clean.

### Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
