### PR TITLE
zstream_selftest_queue: fix alignas(type) build failure under C99

### DIFF
--- a/cmd/zstream/zstream_selftest_queue.c
+++ b/cmd/zstream/zstream_selftest_queue.c
@@ -177,8 +177,8 @@ qtest_producer(void *arg)
 	const qtest_config_t *cfg = run->qr_cfg;
 	uint64_t local_expect = 0;
 	selftest_rng_t rng;
-	alignas(uint64_t) uint8_t item_buffer[sizeof (qtest_item_t) +
-	    cfg->qc_pattern_len];
+	alignas(__alignof__(uint64_t)) uint8_t item_buffer[
+	    sizeof (qtest_item_t) + cfg->qc_pattern_len];
 	qtest_item_t *item = (qtest_item_t *)item_buffer;
 
 	selftest_rng_init(&rng, cfg->qc_rng_stream + 1000 + pa->qp_id);
@@ -239,8 +239,8 @@ qtest_consumer(void *arg)
 	const qtest_config_t *cfg = run->qr_cfg;
 	selftest_rng_t rng;
 	uint64_t expected_seq[cfg->qc_producers];
-	alignas(uint64_t) uint8_t item_buffer[sizeof (qtest_item_t) +
-	    cfg->qc_pattern_len];
+	alignas(__alignof__(uint64_t)) uint8_t item_buffer[
+	    sizeof (qtest_item_t) + cfg->qc_pattern_len];
 	qtest_item_t *item = (qtest_item_t *)item_buffer;
 
 	memset(expected_seq, 0, sizeof (expected_seq));


### PR DESCRIPTION
`alignas()` with a type-name argument is C11 syntax; this file is compiled with `-std=gnu99` where `_Alignas` only accepts constant expressions.  Replace `alignas(uint64_t)` with `alignas(__alignof__( uint64_t))`, which is a GCC/Clang builtin available in all modes and produces the same alignment value.

Musl's `stdalign.h` defines alignas unconditionally (unlike the glibc / compiler built-in header which guards it behind a C11 version check), so this manifests when building against musl (tested on Alpine 3.24 x86_64 and Gentoo AArch64).

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context

Building against musl libc fails on both GCC and Clang because musl's `stdalign.h` defines `alignas` unconditionally as `_Alignas`, regardless of C standard version. The file is compiled with `-std=gnu99`, and neither GCC nor Clang accept `_Alignas(type-name)` in that mode — only constant expressions are valid. The glibc and compiler built-in `stdalign.h` headers guard the `alignas` definition behind a C11 version check, so the broken usage is never reached on glibc-based systems.

### Description
Replace `alignas(uint64_t)` with `alignas(__alignof__(uint64_t))` in the two VLA buffer declarations in `zstream_selftest_queue.c`. `__alignof__` is a GCC/Clang built-in available in all language modes and produces the same alignment value as the C11 type-name form.

### How Has This Been Tested?
Verified to build cleanly on Alpine 3.24 x86_64 (GCC) and Gentoo AArch64 (Clang/musl), where the failure was reproduced before the fix.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
