### PR TITLE
log_spacemap: make zfs_log_sm_blksz tunable

### DIFF
--- a/man/man4/zfs.4
+++ b/man/man4/zfs.4
@@ -346,6 +346,12 @@ This applies primarily to
 .It Sy zfs_keep_log_spacemaps_at_export Ns = Ns Sy 0 Ns | Ns 1 Pq int
 Prevent log spacemaps from being destroyed during pool exports and destroys.
 .
+.It Sy zfs_log_sm_blksz Ns = Ns Sy 131072 Ns B Po 128 KiB Pc Pq int
+This is used as the block size for the space maps used for the
+log space map feature.
+These space maps benefit from a bigger block size
+as we expect to be writing a lot of data to them at once.
+.
 .It Sy zfs_metaslab_segment_weight_enabled Ns = Ns Sy 1 Ns | Ns 0 Pq int
 Enable/disable segment-based metaslab selection.
 .

--- a/module/zfs/spa_log_spacemap.c
+++ b/module/zfs/spa_log_spacemap.c
@@ -170,7 +170,7 @@
  * block size as we expect to be writing a lot of data to them at
  * once.
  */
-static const unsigned long zfs_log_sm_blksz = 1ULL << 17;
+static int zfs_log_sm_blksz = (1 << 17);
 
 /*
  * Percentage of the overall system's memory that ZFS allows to be
@@ -1574,6 +1574,9 @@ ZFS_MODULE_PARAM(zfs, zfs_, max_log_walking, U64, ZMOD_RW,
 ZFS_MODULE_PARAM(zfs, zfs_, keep_log_spacemaps_at_export, INT, ZMOD_RW,
 	"Prevent the log spacemaps from being flushed and destroyed "
 	"during pool export/destroy");
+
+ZFS_MODULE_PARAM(zfs, zfs_, log_sm_blksz, INT, ZMOD_RW,
+	"Block size for the space maps used for the log space map feature");
 
 ZFS_MODULE_PARAM(zfs, zfs_, max_logsm_summary_length, U64, ZMOD_RW,
 	"Maximum number of rows allowed in the summary of the spacemap log");

--- a/module/zfs/spa_log_spacemap.c
+++ b/module/zfs/spa_log_spacemap.c
@@ -1332,6 +1332,7 @@ spa_ld_log_sm_data(spa_t *spa)
 	uint_t pn = 0;
 	uint64_t ps = 0;
 	uint64_t nsm = 0;
+	uint64_t nbytes = 0;
 	psls = sls = avl_first(&spa->spa_sm_logs_by_txg);
 	while (sls != NULL) {
 		/* Prefetch log spacemaps up to 16 TXGs or MBs ahead. */
@@ -1383,6 +1384,7 @@ spa_ld_log_sm_data(spa_t *spa)
 
 		pn--;
 		ps -= space_map_length(sls->sls_sm);
+		nbytes += space_map_length(sls->sls_sm);
 		nsm++;
 		space_map_close(sls->sls_sm);
 		sls->sls_sm = NULL;
@@ -1394,10 +1396,10 @@ spa_ld_log_sm_data(spa_t *spa)
 
 	hrtime_t read_logs_endtime = gethrtime();
 	spa_load_note(spa,
-	    "Read %lu log space maps (%llu total blocks - blksz = %llu bytes) "
+	    "Read %lu log space maps (%llu total blocks - %llu total bytes) "
 	    "in %lld ms", avl_numnodes(&spa->spa_sm_logs_by_txg),
 	    (u_longlong_t)spa_log_sm_nblocks(spa),
-	    (u_longlong_t)zfs_log_sm_blksz,
+	    (u_longlong_t)nbytes,
 	    (longlong_t)NSEC2MSEC(read_logs_endtime - read_logs_starttime));
 
 out:


### PR DESCRIPTION
Make the block size used for the log space map feature's space maps settable at runtime.

### Motivation and Context
`zfs_log_sm_blksz` was set as a constant variable in `spa_log_spacemap.c`

### Description
make the variable RW to get it tunable.

### How Has This Been Tested?
Not yet tested

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
