### PR TITLE
ZTS: give mmp_reset_interval headroom above the suspend window

### DIFF
--- a/tests/zfs-tests/tests/functional/mmp/mmp.cfg
+++ b/tests/zfs-tests/tests/functional/mmp/mmp.cfg
@@ -38,6 +38,13 @@ export MMP_INTERVAL_HOUR=$((60*60*1000))
 export MMP_INTERVAL_DEFAULT=1000
 export MMP_INTERVAL_MIN=100
 
+# A pool suspends when no MMP write succeeds for fail_intervals * interval ms.
+# Driving the interval down to MMP_INTERVAL_MIN leaves a window of a couple of
+# hundred milliseconds, which a loaded test machine can exceed without anything
+# being wrong.  mmp_reset_interval, which also lowers fail_intervals, uses
+# this floor instead.
+export MMP_INTERVAL_TEST_MIN=$((MMP_INTERVAL_DEFAULT / 2))
+
 export MMP_IMPORT_INTERVALS=20
 export MMP_FAIL_INTERVALS_DEFAULT=10
 export MMP_FAIL_INTERVALS_MIN=2

--- a/tests/zfs-tests/tests/functional/mmp/mmp.kshlib
+++ b/tests/zfs-tests/tests/functional/mmp/mmp.kshlib
@@ -73,6 +73,19 @@ function mmp_clear_hostid
 	rm -f $HOSTID_FILE
 }
 
+# A pool suspended by MMP cannot be destroyed, which would leave it behind
+# and affect subsequent tests.  Such a pool can be resumed, so clear it
+# before the caller destroys it.
+function mmp_clear_suspended # pool
+{
+	typeset pool=${1:-$MMP_POOL}
+
+	if poolexists $pool && \
+	    [[ $(zpool list -H -o health $pool) == "SUSPENDED" ]]; then
+		log_must zpool clear $pool
+	fi
+}
+
 function mmp_pool_create_simple # pool dir enriched
 {
 	typeset pool=${1:-$MMP_POOL}

--- a/tests/zfs-tests/tests/functional/mmp/mmp_reset_interval.ksh
+++ b/tests/zfs-tests/tests/functional/mmp/mmp_reset_interval.ksh
@@ -66,7 +66,7 @@ fi
 # 7. Verify mmp_write and mmp_fail are written
 log_note "Verify mmp_write and mmp_fail are written"
 for fails in $(seq $MMP_FAIL_INTERVALS_MIN $((MMP_FAIL_INTERVALS_MIN*2))); do
-	for interval in $(seq $MMP_INTERVAL_MIN 200 $MMP_INTERVAL_DEFAULT); do
+	for interval in $(seq $MMP_INTERVAL_TEST_MIN 200 $MMP_INTERVAL_DEFAULT); do
 		log_must set_tunable64 MULTIHOST_FAIL_INTERVALS $fails
 		log_must set_tunable64 MULTIHOST_INTERVAL $interval
 		sync_pool $TESTPOOL
@@ -87,7 +87,8 @@ done
 # 8. Repeatedly change MULTIHOST_INTERVAL and fail_intervals
 log_note "Repeatedly change MULTIHOST_INTERVAL and fail_intervals"
 for x in $(seq 3); do
-	typeset new_interval=$(( (RANDOM % 20 + 1) * $MMP_INTERVAL_MIN ))
+	typeset new_interval=$(( $MMP_INTERVAL_TEST_MIN + \
+	    (RANDOM % 16) * $MMP_INTERVAL_MIN ))
 	log_must set_tunable64 MULTIHOST_INTERVAL $new_interval
 	typeset action=$((RANDOM %10))
 	if [ $action -eq 0 ]; then
@@ -105,7 +106,7 @@ for x in $(seq 3); do
 		log_must zpool import -f $TESTPOOL
 	elif [ $action -eq 3 ]; then
 		log_must zpool export -F $TESTPOOL
-		log_must set_tunable64 MULTIHOST_INTERVAL $MMP_INTERVAL_MIN
+		log_must set_tunable64 MULTIHOST_INTERVAL $MMP_INTERVAL_TEST_MIN
 		log_must zpool import $TESTPOOL
 	elif [ $action -eq 4 ]; then
 		log_must set_tunable64 MULTIHOST_FAIL_INTERVALS \

--- a/tests/zfs-tests/tests/functional/mmp/mmp_reset_interval.ksh
+++ b/tests/zfs-tests/tests/functional/mmp/mmp_reset_interval.ksh
@@ -39,6 +39,7 @@ verify_runnable "both"
 
 function cleanup
 {
+	mmp_clear_suspended $TESTPOOL
 	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
 	log_must set_tunable64 MULTIHOST_INTERVAL $MMP_INTERVAL_DEFAULT
 	log_must set_tunable64 MULTIHOST_FAIL_INTERVALS \


### PR DESCRIPTION
### Motivation and Context

A pool suspends when no MMP write succeeds for `fail_intervals * multihost_interval` ms.
`mmp_reset_interval` drives the interval down to `MMP_INTERVAL_MIN` while `fail_intervals`
is as low as `MMP_FAIL_INTERVALS_MIN`, which arms a window of 200 ms. A test machine which
stalls for longer than that suspends the pool, and the suspended pool then keeps its
devices, so the test which runs next cannot create its own pool either. That is the failure
seen on #18964, where a 4547 ms gap with no successful write took `testpool` down and
`mmp_on_zdb` then failed on the still-held `loop0`.

Suggested by @behlendorf in #18964.

### Description

Add `MMP_INTERVAL_TEST_MIN`, half the default interval, and use it as the floor in the three
places this test lowers the interval. The smallest window it can arm becomes 1000 ms. That
bound holds on every path: `MMP_FAIL_INTVS_OK()` clamps a nonzero `fail_intervals` up to 2
and zero disarms the suspend check, so step 8's action 4 cannot get underneath it.

The floor is needed in the second loop as well as the first. Step 7 keeps resetting the
interval to the bottom of its range, and `mmp_thread()` smooths `mmp_fail_ns` toward each
new target by a 32nd each iteration, so the window actually armed lags well above the
tunable product. An import
restarts the mmp thread, which initialises `mmp_fail_ns` flat at `fail_intervals * interval`
with no smoothing, so the export and import actions could otherwise still arm 200 ms
directly.

### How Has This Been Tested?

On a VM running master, Linux 6.8.0-136, taking `mmp_fail_ns` from `zfs_dbgmsg` over a full
run of the test each way:

```
                     smallest window   samples < 1 s   samples < 3 s
before                    449 ms            123             213
after                    7575 ms              0               0
```

* Both runs pass. A second run of the patched test gave 6400 ms, so the run minimum is
  happenstance and the 1000 ms above is the figure which holds by construction.
* The whole `mmp` group passes with the change, 19 of 19.
* The before column reproduces in aggregate against a run two days earlier: same sample
  count, same 449 ms minimum to the nanosecond, same two counts, with the individual
  samples differing.

Worth stating plainly: 1000 ms would not have survived the 4547 ms stall which prompted
this. The change buys margin against ordinary jitter, and a host which stalls for several
seconds could still take the pool down.

### Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
