### PR TITLE
vdev_geom: use calling cred to check for device access

### DIFF
--- a/module/os/freebsd/zfs/vdev_geom.c
+++ b/module/os/freebsd/zfs/vdev_geom.c
@@ -14,6 +14,7 @@
  * All rights reserved.
  *
  * Portions Copyright (c) 2012 Martin Matuska <mm@FreeBSD.org>
+ * Copyright (c) 2026, TrueNAS.
  */
 
 #include <sys/zfs_context.h>
@@ -198,8 +199,45 @@ vdev_geom_orphan(struct g_consumer *cp)
 	}
 }
 
+/*
+ * Ensure the supplied credential has access to the /dev node for this
+ * provider. geom itself has no access control capability, so this is all
+ * we can do. This of course won't work if there is an attempt to use a
+ * geom provider that genuinely has no node, or its tested before /dev
+ * is available. That seems better than allowing access to things they
+ * shouldn't have, We shall see.
+ */
+static bool
+vdev_geom_can_access(struct g_provider *pp, cred_t *cr)
+{
+	struct nameidata nd;
+	struct vnode *vp;
+
+	ASSERT3P(cr, !=, NULL);
+	g_topology_assert_not();
+
+	NDINIT(&nd, LOOKUP, FOLLOW, UIO_SYSSPACE, "/dev");
+	if (namei(&nd) != 0)
+		return (false);
+	NDFREE_PNBUF(&nd);
+
+	vp = nd.ni_vp;
+	NDINIT_ATVP(&nd, LOOKUP, FOLLOW, UIO_SYSSPACE, pp->name, vp);
+	if (namei(&nd) != 0)
+		return (false);
+	NDFREE_PNBUF(&nd);
+	vrele(vp);
+
+	vp = nd.ni_vp;
+	bool can_access = (VOP_ACCESS(vp, VREAD|VWRITE, cr, curthread) == 0);
+	vrele(vp);
+
+	return (can_access);
+}
+
 static struct g_consumer *
-vdev_geom_attach(struct g_provider *pp, vdev_t *vd, boolean_t sanity)
+vdev_geom_attach(struct g_provider *pp, vdev_t *vd, boolean_t sanity,
+    cred_t *cr)
 {
 	struct g_geom *gp;
 	struct g_consumer *cp;
@@ -208,6 +246,19 @@ vdev_geom_attach(struct g_provider *pp, vdev_t *vd, boolean_t sanity)
 	g_topology_assert();
 
 	ZFS_LOG(1, "Attaching to %s.", pp->name);
+
+	if (cr != NULL && cr != kcred) {
+		/* If no cred or non-kernel cred supplied, check access. */
+		g_topology_unlock();
+		bool can_access = vdev_geom_can_access(pp, cr);
+		g_topology_lock();
+		if (!can_access) {
+			ZFS_LOG(1, "Failing attach of %s. "
+			    "No access to dev node.\n",
+			    pp->name);
+			return (NULL);
+		}
+	}
 
 	if (sanity) {
 		if (pp->sectorsize > VDEV_PAD_SIZE || !ISP2(pp->sectorsize)) {
@@ -600,7 +651,11 @@ vdev_geom_read_pool_label(const char *name,
 			LIST_FOREACH(pp, &gp->provider, provider) {
 				if (pp->flags & G_PF_WITHER)
 					continue;
-				zcp = vdev_geom_attach(pp, NULL, B_TRUE);
+				/*
+				 * no cred, because this is during early boot
+				 * and there's no /dev nodes to check yet.
+				 */
+				zcp = vdev_geom_attach(pp, NULL, B_TRUE, NULL);
 				if (zcp == NULL)
 					continue;
 				g_topology_unlock();
@@ -633,14 +688,14 @@ enum match {
 };
 
 static enum match
-vdev_attach_ok(vdev_t *vd, struct g_provider *pp)
+vdev_attach_ok(vdev_t *vd, struct g_provider *pp, cred_t *cr)
 {
 	nvlist_t *config;
 	uint64_t pool_guid, top_guid, vdev_guid;
 	struct g_consumer *cp;
 	int nlabels;
 
-	cp = vdev_geom_attach(pp, NULL, B_TRUE);
+	cp = vdev_geom_attach(pp, NULL, B_TRUE, cr);
 	if (cp == NULL) {
 		ZFS_LOG(1, "Unable to attach tasting instance to %s.",
 		    pp->name);
@@ -692,7 +747,7 @@ vdev_attach_ok(vdev_t *vd, struct g_provider *pp)
 }
 
 static struct g_consumer *
-vdev_geom_attach_by_guids(vdev_t *vd)
+vdev_geom_attach_by_guids(vdev_t *vd, cred_t *cr)
 {
 	struct g_class *mp;
 	struct g_geom *gp;
@@ -714,7 +769,7 @@ vdev_geom_attach_by_guids(vdev_t *vd)
 			if (gp->flags & G_GEOM_WITHER)
 				continue;
 			LIST_FOREACH(pp, &gp->provider, provider) {
-				match = vdev_attach_ok(vd, pp);
+				match = vdev_attach_ok(vd, pp, cr);
 				if (match > best_match) {
 					best_match = match;
 					best_pp = pp;
@@ -731,7 +786,7 @@ vdev_geom_attach_by_guids(vdev_t *vd)
 
 out:
 	if (best_pp) {
-		cp = vdev_geom_attach(best_pp, vd, B_TRUE);
+		cp = vdev_geom_attach(best_pp, vd, B_TRUE, cr);
 		if (cp == NULL) {
 			printf("ZFS WARNING: Unable to attach to %s.\n",
 			    best_pp->name);
@@ -741,7 +796,7 @@ out:
 }
 
 static struct g_consumer *
-vdev_geom_open_by_guids(vdev_t *vd)
+vdev_geom_open_by_guids(vdev_t *vd, cred_t *cr)
 {
 	struct g_consumer *cp;
 	char *buf;
@@ -751,7 +806,7 @@ vdev_geom_open_by_guids(vdev_t *vd)
 
 	ZFS_LOG(1, "Searching by guids [%ju:%ju].",
 	    (uintmax_t)spa_guid(vd->vdev_spa), (uintmax_t)vd->vdev_guid);
-	cp = vdev_geom_attach_by_guids(vd);
+	cp = vdev_geom_attach_by_guids(vd, cr);
 	if (cp != NULL) {
 		len = strlen(cp->provider->name) + strlen("/dev/") + 1;
 		buf = kmem_alloc(len, KM_SLEEP);
@@ -773,7 +828,7 @@ vdev_geom_open_by_guids(vdev_t *vd)
 }
 
 static struct g_consumer *
-vdev_geom_open_by_path(vdev_t *vd, int check_guid)
+vdev_geom_open_by_path(vdev_t *vd, int check_guid, cred_t *cr)
 {
 	struct g_provider *pp;
 	struct g_consumer *cp;
@@ -784,8 +839,8 @@ vdev_geom_open_by_path(vdev_t *vd, int check_guid)
 	pp = g_provider_by_name(vd->vdev_path + sizeof ("/dev/") - 1);
 	if (pp != NULL) {
 		ZFS_LOG(1, "Found provider by name %s.", vd->vdev_path);
-		if (!check_guid || vdev_attach_ok(vd, pp) == FULL_MATCH)
-			cp = vdev_geom_attach(pp, vd, B_FALSE);
+		if (!check_guid || vdev_attach_ok(vd, pp, cr) == FULL_MATCH)
+			cp = vdev_geom_attach(pp, vd, B_FALSE, cr);
 	}
 
 	return (cp);
@@ -795,7 +850,6 @@ static int
 vdev_geom_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
     uint64_t *logical_ashift, uint64_t *physical_ashift, cred_t *cr)
 {
-	(void) cr;
 	struct g_provider *pp;
 	struct g_consumer *cp;
 	int error, has_trim;
@@ -847,13 +901,13 @@ vdev_geom_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
 		 *           unless we are doing a split, in which case we
 		 *           should allow any guid.
 		 */
-		cp = vdev_geom_open_by_path(vd, 0);
+		cp = vdev_geom_open_by_path(vd, 0, cr);
 	} else {
 		/*
 		 * Try using the recorded path for this device, but only
 		 * accept it if its label data contains the expected GUIDs.
 		 */
-		cp = vdev_geom_open_by_path(vd, 1);
+		cp = vdev_geom_open_by_path(vd, 1, cr);
 		if (cp == NULL) {
 			/*
 			 * The device at vd->vdev_path doesn't have the
@@ -861,7 +915,7 @@ vdev_geom_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
 			 * moved around so try all other GEOM providers
 			 * to find one with the right GUIDs.
 			 */
-			cp = vdev_geom_open_by_guids(vd);
+			cp = vdev_geom_open_by_guids(vd, cr);
 		}
 	}
 


### PR DESCRIPTION
_[Sponsors: TrueNAS]_

### Motivation and Context

OpenZFS assumes that having the ability to use pool admin operations implies permission to access any storage devices in the system. However, both Linux and FreeBSD have mechanisms to separate these permissions, leading to a situation where a carefully-constructed set of permissions can allow a user with pool admin rights to add a device to a pool that they otherwise would not be able to access or possibly even see.

#18960 plumbed the calling user credential down to the leaf `vdev_op_open()` call so that it could test device access before attempting to open or use it, and implemented that test for Linux. This PR implements the same shape of test for FreeBSD.

### Description

On FreeBSD, access to pool operations, including those that add devices to a pool, are restricted to `PRIV_ZFS_POOL_CONFIG`. A typical command is `zpool add tank /dev/ada0`. Although the device is specified as a `/dev` node, the node itself is never considered; the `/dev/` prefix is simply stripped off and then used to look up a GEOM provider. GEOM itself does not have any access control mechanism, meaning that any user that has this privilege implicitly has the ability to add _any_ GEOM device to a pool.

So, this commit adds a permission check before attaching the provider. We use `namei()` to look up the node, and then `VOP_ACCESS()` with the calling credential to check access. This properly gates access to the device against the normal file access control facilities: permission on the `/dev` node, or `PRIV_VFS_READ|PRIV_VFS_WRITE` to bypass the permission checks. The end effect is that a user with `PRIV_ZFS_POOL_CONFIG` but no access to the dev node will still be able to perform pool operations, but for those that add devices, only if they also have access to those devices.

There's one special case to note, `vdev_geom_read_pool_label()`. This is used during root pool startup after handoff from the bootloader, and so `/dev` may not even exist yet.

#### Reviewer notes

I am not very familiar with FreeBSD operationally; what I know is from code read and experimentation, so I need input and review from those who are, particular with GEOM and MAC. Here's a few specific areas that I would like checked.

My understanding is that GEOM providers are not required to have matching `/dev` nodes, but as best I can tell (from experimentation and from asking some heavy FreeBSD users in my orbit) they do in all common/out-of-the-box configurations. I think it is a reasonable requirement as ZFS is currently implemented, since the devices named on the command line and stored in pool config are required to have a `/dev/` prefix, but getting this wrong could break existing configs, so I want to be reasonably sure.

I don't know if the `vdev_geom_read_pool_label()` exception makes sense. I'm making some assumptions about how the boot handoff works based on only light reading of the boot support code in ZFS. If device access checks need to be performed during boot handoff, I'll need guidance on what those are and how they are applied.

This is all dependent on the assumption that all GEOM providers (out of the box) will create a matching `/dev` node. I have asked around some heavy FreeBSD users in my orbit, and they were largely unaware of a situation where a GEOM provider does _not_ have a corresponding `/dev` node, so I am hopeful this is true and does not break existing cases.

In my testing I was not able to find any way to give a user that is not the "host" root user `PRIV_ZFS_POOL_CONFIG`. I think is it possible with an appropriate MAC module, though I couldn't see a way to do it with the ones that ship with FreeBSD (unless there is one that hand out privileges by numeric value or mask, which is harder to see). If in any common config it will only ever be granted implicitly to the host root, then the only other place this matters is if the host root cannot access a device node. This, I think, requires setting `security.bsd.suser_enabled=0` on the host to disable the "root implicitly gets everything" behaviour, and then preventing access to a device node through removing permissions and (for example) a `mac_bsdextended(4)` rule. I wasn't able to get this to work though.

If its true that it is actually very difficult to "split" privileges this way in any standard config, that's actually a _good_ thing for this change, because it means that its highly unlikely there's a configuration out there this change would break, while ensuring that if someone does try it in the future, it does the right thing (by contrast, the equivalent split on Linux is uncommon, but easily achievable with standard tools).

I am uncertain if jails make a difference. As I understand it, `PRIV_ZFS_POOL_CONFIG` is _not_ one of the default privileges that a jail root user gets (discussed in `priv(9)`, implemented in `prison_priv_check()`) and I didn't see anything in `jail(8)` that suggested arbitrary privileges could be granted (the ZFS-related options like `allow.mount.zfs` are dataset- or mount-level, not pool level, so a different privilege). If a jail root can be easily given `PRIV_ZFS_POOL_CONFIG` then we likely have an entirely different shape of problem beyond device access, so definitely let me know!

### How Has This Been Tested?

ZTS runs are successful, suggesting that the check doesn't hurt standard configurations. Actually splitting the privileges appears to require a custom MAC module (see above), which may be worthwhile for the test suite but for now I have not done.

### Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).