### PR TITLE
ZTS: fix mmp_set_hostid on Alpine Linux (musl libc)

### DIFF
--- a/tests/zfs-tests/tests/functional/mmp/mmp.kshlib
+++ b/tests/zfs-tests/tests/functional/mmp/mmp.kshlib
@@ -65,7 +65,13 @@ function mmp_set_hostid
 
 	zgenhostid $1
 
-	[ $(hostid) = "$hostid" ]
+	# musl libc's gethostid() ignores /etc/hostid; verify the file directly.
+	if [[ $(hostid) != "$hostid" ]]; then
+		[[ -f $HOSTID_FILE ]] || return 1
+		typeset written
+		written=$(od -An -N4 -tx4 $HOSTID_FILE | tr -d ' \n')
+		[[ "$written" = "$hostid" ]]
+	fi
 }
 
 function mmp_clear_hostid


### PR DESCRIPTION
musl libc's gethostid() ignores /etc/hostid and returns 0, so the hostid verification in mmp_set_hostid always fails after zgenhostid writes the file.  Fall back to reading /etc/hostid directly with od when the hostid command disagrees, which works correctly on both glibc and musl systems.

Fixes the following tests on Alpine 3.24:
- mmp/mmp_active_import
- mmp/mmp_concurrent_import
- mmp/mmp_exported_import
- mmp/mmp_hostid
- mmp/mmp_inactive_import
- mmp/mmp_on_off
- mmp/mmp_on_thread
- mmp/mmp_on_uberblocks
- mmp/mmp_on_zdb
- mmp/mmp_reset_interval
- mmp/mmp_write_distribution
- mmp/mmp_write_slow_disk
- mmp/mmp_write_uberblocks
- mmp/multihost_history

---

### Motivation and Context
`mmp_set_hostid()` generates a hostid with `zgenhostid` and then verifies it took effect by comparing the `hostid` command's output against the value it just wrote. On musl libc, `gethostid()` (which the hostid command wraps) unconditionally returns 0 and _never_ reads `/etc/hostid` at all, so this comparison always fails regardless of whether `zgenhostid` actually worked. Every test in the `mmp/` group calls this helper during setup, so all 14 of them failed on Alpine before this fix, none of them for reasons related to MMP itself.

### Description
When `hostid` disagrees with the value `zgenhostid` just wrote, fall back to reading the raw bytes of `/etc/hostid` directly with `od` and comparing those instead of trusting the `hostid` command. This only engages as a fallback (the fast path — trusting hostid directly — is unchanged and still used on glibc systems, where it works correctly), so the fix is a no-op everywhere except where `hostid`/`gethostid()` is unreliable.

### How Has This Been Tested?
- Locally, on an Alpine Linux 3.24 VM.
- GitHub Actions on Alpine 3.24 and the runner matrix.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
