### PR TITLE
CI: boot linux-stable instead of linux-virt on the Alpine runner

### DIFF
--- a/.github/workflows/scripts/qemu-3-deps-vm.sh
+++ b/.github/workflows/scripts/qemu-3-deps-vm.sh
@@ -20,15 +20,27 @@ function alpine() {
     cpio cryptsetup curl curl-dev dhcpcd eudev eudev-dev eudev-libs findutils \
     fio gawk gdb gettext-dev git grep jq libaio libaio-dev libcurl \
     libtirpc-dev libtool libunwind libunwind-dev linux-headers linux-tools \
-    linux-virt linux-virt-dev lsscsi m4 make nfs-utils openssl-dev parted \
-    pax procps py3-cffi py3-distlib py3-packaging py3-setuptools python3 \
-    python3-dev qemu-guest-agent rng-tools rsync samba samba-server sed \
-    strace sysstat util-linux util-linux-dev wget words xfsprogs xxhash \
-    zlib-dev pamtester@testing
+    linux-stable linux-stable-dev lsscsi m4 make nfs-utils openssl-dev \
+    parted pax procps py3-cffi py3-distlib py3-packaging py3-setuptools \
+    python3 python3-dev qemu-guest-agent rng-tools rsync samba \
+    samba-server sed strace sysstat util-linux util-linux-dev wget words \
+    xfsprogs xxhash zlib-dev pamtester@testing
   echo "##[endgroup]"
 
   echo "##[group]Switch to eudev"
   sudo setup-devd udev
+  echo "##[endgroup]"
+
+  echo "##[group]Boot the -stable kernel instead of -virt"
+  # -virt has CONFIG_SCSI_DEBUG disabled, which several ZTS tests
+  # (zpool_expand, zpool_reopen, fault/auto_*, ...) need to simulate
+  # disks that support expand/fault-injection scenarios real static
+  # disks can't easily provide.  -stable has it enabled.  This takes
+  # effect on the VM's next boot, which happens naturally when this
+  # deps step powers off and qemu-prepare-for-build.sh starts the VM
+  # back up for the build step -- no explicit reboot needed here.
+  sudo sed -i 's/^default=virt$/default=stable/' /etc/update-extlinux.conf
+  sudo update-extlinux
   echo "##[endgroup]"
 
   echo "##[group]Install ksh93 from Source"


### PR DESCRIPTION
The Alpine runner's linux-virt kernel has `CONFIG_SCSI_DEBUG` disabled. Several ZTS tests use the `scsi_debug` kernel module to simulate disks that support expand and fault-injection scenarios real static disks can't easily provide. Without it, `load_scsi_debug()` in `blkdev.shlib` calls `log_unsupported` and they SKIP instead of running.

`linux-stable` has `CONFIG_SCSI_DEBUG=m`. Swap `linux-virt`/`linux-virt-dev` for `linux-stable`/`linux-stable-dev`, and switch the extlinux default kernel from "virt" to "stable" in `/etc/update-extlinux.conf`.

Fixes the following tests on Alpine 3.24 (SKIP -> PASS):
- cli_root/zpool_expand/zpool_expand_001_pos
- cli_root/zpool_expand/zpool_expand_003_neg
- cli_root/zpool_expand/zpool_expand_005_pos
- cli_root/zpool_expand/zpool_expand_006_pos
- cli_root/zpool_reopen/* (7 tests)
- cli_root/zpool_split/zpool_split_wholedisk
- cli_root/zpool_import/zpool_import_aux_paths
- fault/auto_offline_001_pos
- fault/auto_online_001_pos
- fault/auto_online_002_pos
- fault/auto_replace_001_pos
- fault/auto_replace_002_pos
- fault/auto_spare_ashift
- fault/auto_spare_shared
- fault/suspend_draid_fgroups
- fault/suspend_on_probe_errors
- fault/suspend_resume_single
- procfs/pool_state

---

### Motivation and Context
`load_scsi_debug()` in `tests/zfs-tests/tests/functional/tests/functional/cmd/blkdev.shlib` needs the `scsi_debug` kernel module to simulate disks for expand/fault-injection scenarios that real static disks can't easily provide. The Alpine CI runner boots `linux-virt`, which has `CONFIG_SCSI_DEBUG` disabled, so every test depending on it was silently SKIPping rather than actually exercising the code path it's meant to test.

### Description
Swap the `linux-virt`/`linux-virt-dev` packages for `linux-stable`/`linux-stable-dev` (which has `CONFIG_SCSI_DEBUG=m`) in the Alpine dependency-install step, and switch `/etc/update-extlinux.conf`'s default kernel from `virt` to `stable` so the VM actually boots it. No explicit reboot is needed: the deps step already powers off at the end, and the next pipeline stage boots the VM fresh for the build step, so the new default kernel takes effect naturally.

### How Has This Been Tested?
- Locally, on an Alpine Linux 3.24 VM.
- GitHub Actions on Alpine 3.24 and the runner matrix.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
