### PR TITLE
ZTS: replace uncompress with gunzip in history tests

### DIFF
--- a/tests/zfs-tests/tests/functional/history/history_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/history/history_001_pos.ksh
@@ -104,7 +104,7 @@ run_and_verify -p "$MPOOL" "zpool split $MPOOL ${MPOOL}_split"
 import_dir=$TEST_BASE_DIR/import_dir.$$
 log_must mkdir $import_dir
 log_must cp $STF_SUITE/tests/functional/history/zfs-pool-v4.dat.Z $import_dir
-log_must uncompress $import_dir/zfs-pool-v4.dat.Z
+log_must gunzip $import_dir/zfs-pool-v4.dat.Z
 upgrade_pool=$(zpool import -d $import_dir | awk '/pool:/ { print $2 }')
 log_must zpool import -d $import_dir $upgrade_pool
 run_and_verify -p "$upgrade_pool" "zpool upgrade $upgrade_pool"

--- a/tests/zfs-tests/tests/functional/history/history_007_pos.ksh
+++ b/tests/zfs-tests/tests/functional/history/history_007_pos.ksh
@@ -64,7 +64,7 @@ for arch in "i386" "sparc"; do
 	grep -v "^$" $orig_cmds_f > $orig_cmds_f1
 
 	log_must cp $tst_dir/${arch}.migratedpool.DAT.Z $import_dir
-	log_must uncompress -f $import_dir/${arch}.migratedpool.DAT.Z
+	log_must gunzip -f $import_dir/${arch}.migratedpool.DAT.Z
 
 	# destroy the pool with same name, so that import operation succeeds.
 	poolexists $migratedpoolname && \


### PR DESCRIPTION
Alpine Linux (musl/BusyBox) does not provide uncompress; gunzip handles .Z (LZW compress) files and accepts the same -f flag, making it a drop-in replacement on all supported platforms.

Fixes the following tests on Alpine 3.24:
- history/history_001_pos
- history/history_007_pos

---

### Motivation and Context
`history_001_pos` and `history_007_pos` both decompress pre-supplied `.Z` (LZW compress) pool image fixtures before importing and upgrading them, using the `uncompress` command. Alpine Linux's musl/BusyBox userland doesn't ship `uncompress` at all, so both tests fail immediately at that step, before ever reaching the actual history-verification logic they're meant to test.


### Description
Replace `uncompress` with `gunzip` at the two call sites (`history_001_pos.ksh`, `history_007_pos.ksh`). `gunzip` transparently handles `.Z`/LZW-compressed input in addition to gzip's own format, and accepts the same `-f` flag `history_007_pos` already passes, so this is a drop-in replacement — every platform in the test matrix ships `gunzip`, whereas `uncompress` is a legacy compress(1) companion tool that's absent by default on musl/BusyBox systems like Alpine.

### How Has This Been Tested?
- Locally, on an Alpine Linux 3.24 VM.
- GitHub Actions on Alpine 3.24 and the runner matrix.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
