### PR TITLE
ZTS: get_prop/get_pool_prop/get_vdev_prop: fail on empty output

### DIFF
--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -1086,12 +1086,23 @@ function fill_fs # destdir dirnum filenum bytes num_writes data
 }
 
 # Get the specified dataset property in parsable format or fail
+#
+# The sentinel distinguishes a command that printed nothing at all from
+# one that printed an empty value: command substitution strips trailing
+# newlines, so both would otherwise collapse to the empty string. Only
+# the former is an error; user properties may legitimately be empty.
 function get_prop # property dataset
 {
 	typeset prop=$1
 	typeset dataset=$2
+	typeset val
 
-	zfs get -Hpo value "$prop" "$dataset" || log_fail "zfs get $prop $dataset"
+	val=$(zfs get -Hpo value "$prop" "$dataset" && print -n X) ||
+	    log_fail "zfs get $prop $dataset"
+	[[ "$val" != X ]] ||
+	    log_fail "zfs get $prop $dataset printed no output"
+	val=${val%X}
+	print -r -- "${val%$'\n'}"
 }
 
 # Get the specified pool property in parsable format or fail
@@ -1099,8 +1110,14 @@ function get_pool_prop # property pool
 {
 	typeset prop=$1
 	typeset pool=$2
+	typeset val
 
-	zpool get -Hpo value "$prop" "$pool" || log_fail "zpool get $prop $pool"
+	val=$(zpool get -Hpo value "$prop" "$pool" && print -n X) ||
+	    log_fail "zpool get $prop $pool"
+	[[ "$val" != X ]] ||
+	    log_fail "zpool get $prop $pool printed no output"
+	val=${val%X}
+	print -r -- "${val%$'\n'}"
 }
 
 # Get the specified vdev property in parsable format or fail
@@ -1109,8 +1126,14 @@ function get_vdev_prop
 	typeset prop="$1"
 	typeset pool="$2"
 	typeset vdev="$3"
+	typeset val
 
-	zpool get -Hpo value "$prop" "$pool" "$vdev" || log_fail "zpool get $prop $pool $vdev"
+	val=$(zpool get -Hpo value "$prop" "$pool" "$vdev" && print -n X) ||
+	    log_fail "zpool get $prop $pool $vdev"
+	[[ "$val" != X ]] ||
+	    log_fail "zpool get $prop $pool $vdev printed no output"
+	val=${val%X}
+	print -r -- "${val%$'\n'}"
 }
 
 # Return 0 if a pool exists; $? otherwise


### PR DESCRIPTION
get_prop(), get_pool_prop(), and get_vdev_prop() in libtest.shlib check the exit status of zfs get and zpool get but never check that it actually printed anything. If the command exits 0 but prints no value -- observed on real CI, rarely, likely under scheduling contention from the two parallel test-runner workers sharing one VM -- the helper silently returns an empty string.

Capture the command's output and log_fail if it printed nothing, the same way these helpers already log_fail on a nonzero exit status. This is narrower than testing for an empty capture: user properties may legitimately be empty, so a sentinel keeps the two apart, as command substitution strips trailing newlines. The success path is unchanged; why the call sometimes prints nothing is left open -- this only makes it diagnosable instead of a misattributed error several steps away.

---

### Motivation and Context
The `get_prop()`, `get_pool_prop()`, and `get_vdev_prop()` helpers in `libtest.shlib` only checked the exit status of `zfs get`/`zpool get`, not whether it actually printed anything. In rare CI failures, these commands can exit successfully while printing nothing at all, which the helpers silently propagated as an empty string.

This can lead to confusing failures several calls later. For example, in `send-c_stream_size_estimate.ksh`, an empty value from `get_prop()` was passed unquoted to `within_percent()`, causing arguments to shift and ultimately resulting in `bc: bad expression` and `[: argument expected` errors that did not identify the actual source of the problem.

This change makes the failure explicit and diagnosable by failing when the command succeeds but prints nothing.

### Description
- Capture the output of `zfs get`/`zpool get` in `get_prop()`, `get_pool_prop()`, and `get_vdev_prop()`, appending a sentinel character after the command via `&&` so "printed nothing" and "printed an empty value" produce distinguishable captures (command substitution strips trailing newlines, which would otherwise collapse both cases to the same empty string).
- Continue to fail with `log_fail` when the underlying command returns a nonzero status.
- `log_fail` with a specific message only when the command printed nothing at all — a legitimately empty *value* (e.g. an unset user property) is not treated as an error.
- Print the captured value on the success path, preserving existing behavior for valid results, including legitimately empty ones.

This change does not attempt to address why `zfs get`/`zpool get` may occasionally print nothing; it makes that failure mode visible at the point where it occurs.

### How Has This Been Tested?
- Locally, on an Alpine Linux 3.24 VM: verified all three outcomes directly — a real property with a real value returns unchanged; a user property explicitly set to an empty string returns empty without triggering `log_fail`; a simulated "exits 0, prints nothing" case `log_fail`s immediately with a clear message.
- GitHub Actions on Alpine 3.24 and the runner matrix.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
