### PR TITLE
zcp: support bookmarks in zfs.sync.destroy

### DIFF
--- a/include/sys/dsl_bookmark.h
+++ b/include/sys/dsl_bookmark.h
@@ -18,6 +18,7 @@
 
 #include <sys/zfs_context.h>
 #include <sys/zfs_refcount.h>
+#include <sys/dmu_tx.h>
 #include <sys/dsl_dataset.h>
 #include <sys/dsl_pool.h>
 
@@ -115,6 +116,12 @@ typedef struct dsl_bookmark_create_redacted_arg {
 	const void	*dbcra_tag;
 } dsl_bookmark_create_redacted_arg_t;
 
+typedef struct dsl_bookmark_destroy_arg {
+	nvlist_t *dbda_bmarks;
+	nvlist_t *dbda_success;
+	nvlist_t *dbda_errors;
+} dsl_bookmark_destroy_arg_t;
+
 int dsl_bookmark_create(nvlist_t *, nvlist_t *);
 int dsl_bookmark_create_nvl_validate(nvlist_t *);
 int dsl_bookmark_create_check(void *arg, dmu_tx_t *tx);
@@ -125,6 +132,8 @@ int dsl_get_bookmarks(const char *, nvlist_t *, nvlist_t *);
 int dsl_get_bookmarks_impl(dsl_dataset_t *, nvlist_t *, nvlist_t *);
 int dsl_get_bookmark_props(const char *, const char *, nvlist_t *);
 int dsl_bookmark_destroy(nvlist_t *, nvlist_t *);
+int dsl_bookmark_destroy_check(void *, dmu_tx_t *);
+void dsl_bookmark_destroy_sync(void *, dmu_tx_t *);
 int dsl_bookmark_lookup(struct dsl_pool *, const char *,
     struct dsl_dataset *, zfs_bookmark_phys_t *);
 int dsl_bookmark_lookup_impl(dsl_dataset_t *, const char *,

--- a/module/zfs/dsl_bookmark.c
+++ b/module/zfs/dsl_bookmark.c
@@ -969,12 +969,6 @@ out:
 	return (err);
 }
 
-typedef struct dsl_bookmark_destroy_arg {
-	nvlist_t *dbda_bmarks;
-	nvlist_t *dbda_success;
-	nvlist_t *dbda_errors;
-} dsl_bookmark_destroy_arg_t;
-
 static void
 dsl_bookmark_destroy_sync_impl(dsl_dataset_t *ds, const char *name,
     dmu_tx_t *tx)
@@ -1082,7 +1076,7 @@ dsl_bookmark_destroy_sync_impl(dsl_dataset_t *ds, const char *name,
 	VERIFY0(zap_remove_norm(mos, bmark_zapobj, name, mt, tx));
 }
 
-static int
+int
 dsl_bookmark_destroy_check(void *arg, dmu_tx_t *tx)
 {
 	dsl_bookmark_destroy_arg_t *dbda = arg;
@@ -1147,7 +1141,7 @@ dsl_bookmark_destroy_check(void *arg, dmu_tx_t *tx)
 	return (rv);
 }
 
-static void
+void
 dsl_bookmark_destroy_sync(void *arg, dmu_tx_t *tx)
 {
 	dsl_bookmark_destroy_arg_t *dbda = arg;

--- a/module/zfs/zcp_synctask.c
+++ b/module/zfs/zcp_synctask.c
@@ -158,7 +158,8 @@ static const zcp_synctask_info_t zcp_synctask_destroy_info = {
 	.name = "destroy",
 	.func = zcp_synctask_destroy,
 	.pargs = {
-	    {.za_name = "filesystem | snapshot", .za_lua_type = LUA_TSTRING },
+	    {.za_name = "filesystem | snapshot | bookmark",
+	    .za_lua_type = LUA_TSTRING },
 	    {NULL, 0}
 	},
 	.kwargs = {
@@ -172,11 +173,11 @@ static const zcp_synctask_info_t zcp_synctask_destroy_info = {
 static int
 zcp_synctask_destroy(lua_State *state, boolean_t sync, nvlist_t *err_details)
 {
-	(void) err_details;
 	int err;
 	const char *dsname = lua_tostring(state, 1);
 
 	boolean_t issnap = (strchr(dsname, '@') != NULL);
+	boolean_t isbookmark = (strchr(dsname, '#') != NULL);
 
 	if (!issnap && !lua_isnil(state, 2)) {
 		return (luaL_error(state,
@@ -195,6 +196,25 @@ zcp_synctask_destroy(lua_State *state, boolean_t sync, nvlist_t *err_details)
 
 		err = zcp_sync_task(state, dsl_destroy_snapshot_check,
 		    dsl_destroy_snapshot_sync, &ddsa, sync, dsname);
+	} else if (isbookmark) {
+		dsl_bookmark_destroy_arg_t dbda = { 0 };
+		dbda.dbda_bmarks = fnvlist_alloc();
+		dbda.dbda_success = fnvlist_alloc();
+		dbda.dbda_errors = err_details;
+		fnvlist_add_boolean(dbda.dbda_bmarks, dsname);
+
+		zcp_cleanup_handler_t *zch = zcp_register_cleanup(state,
+		    zcp_synctask_cleanup, dbda.dbda_bmarks);
+		zcp_cleanup_handler_t *zch2 = zcp_register_cleanup(state,
+		    zcp_synctask_cleanup, dbda.dbda_success);
+
+		err = zcp_sync_task(state, dsl_bookmark_destroy_check,
+		    dsl_bookmark_destroy_sync, &dbda, sync, dsname);
+
+		zcp_deregister_cleanup(state, zch2);
+		zcp_deregister_cleanup(state, zch);
+		fnvlist_free(dbda.dbda_success);
+		fnvlist_free(dbda.dbda_bmarks);
 	} else {
 		dsl_destroy_head_arg_t ddha = { 0 };
 		ddha.ddha_name = dsname;

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -133,7 +133,8 @@ tests = ['tst.args_to_lua', 'tst.divide_by_zero', 'tst.exists', 'tst.encryption'
 tags = ['functional', 'channel_program', 'lua_core']
 
 [tests/functional/channel_program/synctask_core]
-tests = ['tst.destroy_fs', 'tst.destroy_snap', 'tst.get_count_and_limit',
+tests = ['tst.destroy_fs', 'tst.destroy_snap',
+    'tst.destroy_bookmark', 'tst.get_count_and_limit',
     'tst.get_index_props', 'tst.get_mountpoint', 'tst.get_neg',
     'tst.get_number_props', 'tst.get_string_props', 'tst.get_type',
     'tst.get_userquota', 'tst.get_written', 'tst.inherit', 'tst.list_bookmarks',

--- a/tests/runfiles/sanity.run
+++ b/tests/runfiles/sanity.run
@@ -74,7 +74,8 @@ tests = ['tst.args_to_lua', 'tst.divide_by_zero', 'tst.exists', 'tst.encryption'
 tags = ['functional', 'channel_program', 'lua_core']
 
 [tests/functional/channel_program/synctask_core]
-tests = ['tst.destroy_fs', 'tst.destroy_snap', 'tst.get_count_and_limit',
+tests = ['tst.destroy_fs', 'tst.destroy_snap',
+    'tst.destroy_bookmark', 'tst.get_count_and_limit',
     'tst.get_index_props', 'tst.get_mountpoint', 'tst.get_neg',
     'tst.get_number_props', 'tst.get_string_props', 'tst.get_type',
     'tst.get_userquota', 'tst.get_written', 'tst.inherit', 'tst.list_bookmarks',

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -642,6 +642,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/channel_program/synctask_core/tst.bookmark.create.ksh \
 	functional/channel_program/synctask_core/tst.clone.ksh \
 	functional/channel_program/synctask_core/tst.destroy_fs.ksh \
+	functional/channel_program/synctask_core/tst.destroy_bookmark.ksh \
 	functional/channel_program/synctask_core/tst.destroy_snap.ksh \
 	functional/channel_program/synctask_core/tst.get_count_and_limit.ksh \
 	functional/channel_program/synctask_core/tst.get_index_props.ksh \

--- a/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.destroy_bookmark.ksh
+++ b/tests/zfs-tests/tests/functional/channel_program/synctask_core/tst.destroy_bookmark.ksh
@@ -1,0 +1,45 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
+#
+
+. $STF_SUITE/tests/functional/channel_program/channel_common.kshlib
+
+verify_runnable "global"
+
+fs=$TESTPOOL/$TESTFS/testchild
+snapname=testsnap
+bookname=testbookmark
+bookmark=$fs#$bookname
+snap=$fs@$snapname
+
+function cleanup
+{
+	destroy_dataset $fs "-R"
+}
+
+log_onexit cleanup
+
+log_must zfs create $fs
+log_must zfs snapshot $snap
+log_must zfs bookmark $snap $bookmark
+
+log_must_program_sync $TESTPOOL - $bookmark <<-EOF
+	arg = ...
+	bookmark = arg["argv"][1]
+	err = zfs.sync.destroy(bookmark)
+	msg = "destroying " .. bookmark .. " err=" .. err
+	return msg
+EOF
+
+log_mustnot zfs list -H -o name -t bookmark $bookmark
+
+log_pass "Destroying bookmark with channel program works."


### PR DESCRIPTION
Teach the channel-program synctask destroy path to recognize bookmark
targets and route them through the existing bookmark-destroy
implementation. This enables zfs.sync.destroy() to remove bookmarks from
Lua channel programs, matching the behavior already available for
datasets and snapshots. A functional regression test was added to cover
bookmark destruction from a channel program.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context

ZFS channel programs can currently destroy datasets and snapshots, but not bookmarks. I needed to delete a _lot_ of bookmarks, and I assume channel programs will delete them a _lot_ faster than many invocations of the CLI.

### Description

See the description above.

### How Has This Been Tested?

I added a test to the ZFS test suite. I ran the ZFS test suite in a VM. The added tests (and indeed most tests) all passed.

There were some test failures in areas unrelated to this patch. I assume that these failures were pre-existing. A complete list is below. I ran on Ubuntu 26.04 with kernel 7.0.0-29-generic #29-Ubuntu, under qemu.

```
FAIL      67
    FAIL casenorm/mixed_formd_delete (https://github.com/openzfs/zfs/issues/7633)
    FAIL casenorm/mixed_formd_lookup (https://github.com/openzfs/zfs/issues/7633)
    FAIL casenorm/mixed_formd_lookup_ci (https://github.com/openzfs/zfs/issues/7633)
    FAIL casenorm/mixed_none_lookup_ci (https://github.com/openzfs/zfs/issues/7633)
    FAIL casenorm/sensitive_formd_delete (https://github.com/openzfs/zfs/issues/7633)
    FAIL casenorm/sensitive_formd_lookup (https://github.com/openzfs/zfs/issues/7633)
    FAIL cli_root/zpool_import/import_rewind_device_replaced (Arbitrary pool rewind is not guaranteed)
    FAIL cli_root/zpool_reopen/zpool_reopen_003_pos (Known issue)
    FAIL fault/auto_replace_001_pos (https://github.com/openzfs/zfs/issues/14851)
    FAIL fault/auto_replace_002_pos (Known issue)
    FAIL fault/auto_spare_multiple (https://github.com/openzfs/zfs/issues/11889)
    FAIL refreserv/refreserv_004_pos (Known issue)
    FAIL vdev_zaps/vdev_zaps_007_pos (Known issue)
    FAIL acl/off/dosmode (expected PASS)
    FAIL acl/off/posixmode (expected PASS)
    FAIL acl/posix-sa/posix_001_pos (expected PASS)
    FAIL acl/posix-sa/posix_002_pos (expected PASS)
    FAIL acl/posix/posix_001_pos (expected PASS)
    FAIL acl/posix/posix_002_pos (expected PASS)
    FAIL acl/posix/posix_005_pos (expected PASS)
    FAIL bclone/cleanup (expected PASS)
    FAIL bclone/setup (expected PASS)
    FAIL cli_root/zfs_load-key/zfs_load-key_all (expected PASS)
    FAIL cli_root/zfs_load-key/zfs_load-key_https (expected PASS)
    FAIL cli_root/zfs_load-key/zfs_load-key_location (expected PASS)
    FAIL cli_root/zfs_load-key/zfs_load-key_recursive (expected PASS)
    FAIL cli_root/zpool_create/zpool_create_tempname (expected PASS)
    FAIL cli_root/zpool_get/zpool_get_006_pos (expected PASS)
    FAIL cli_root/zpool_reopen/zpool_reopen_001_pos (expected PASS)
    FAIL cli_root/zpool_reopen/zpool_reopen_002_pos (expected PASS)
    FAIL cli_root/zpool_reopen/zpool_reopen_004_pos (expected PASS)
    FAIL cli_root/zpool_reopen/zpool_reopen_005_pos (expected PASS)
    FAIL device_access/device_access_add (expected PASS)
    FAIL device_access/device_access_attach (expected PASS)
    FAIL device_access/device_access_create (expected PASS)
    FAIL device_access/device_access_import (expected PASS)
    FAIL fault/auto_online_001_pos (expected PASS)
    FAIL limits/filesystem_limit (expected PASS)
    FAIL limits/snapshot_limit (expected PASS)
    FAIL reservation/reservation_015_pos (expected PASS)
    FAIL vdev_zaps/vdev_zaps_002_pos (expected PASS)
    FAIL vdev_zaps/vdev_zaps_003_pos (expected PASS)
    FAIL xattr/xattr_003_neg (expected PASS)
    FAIL zoned_uid/zoned_uid_006_pos (expected PASS)
    FAIL zoned_uid/zoned_uid_007_pos (expected PASS)
    FAIL zoned_uid/zoned_uid_008_pos (expected PASS)
    FAIL zoned_uid/zoned_uid_009_pos (expected PASS)
    FAIL zoned_uid/zoned_uid_010_pos (expected PASS)
    FAIL zoned_uid/zoned_uid_012_pos (expected PASS)
    FAIL zoned_uid/zoned_uid_013_pos (expected PASS)
    FAIL zoned_uid/zoned_uid_014_pos (expected PASS)
    FAIL zoned_uid/zoned_uid_015_pos (expected PASS)
    FAIL zoned_uid/zoned_uid_016_pos (expected PASS)
    FAIL zoned_uid/zoned_uid_018_pos (expected PASS)
    FAIL zoned_uid/zoned_uid_019_neg (expected PASS)
    FAIL zoned_uid/zoned_uid_020_neg (expected PASS)
    FAIL zoned_uid/zoned_uid_022_neg (expected PASS)
    FAIL zoned_uid/zoned_uid_023_pos (expected PASS)
    FAIL zoned_uid/zoned_uid_024_neg (expected PASS)
    FAIL zoned_uid/zoned_uid_025_pos (expected PASS)
    FAIL zoned_uid/zoned_uid_026_pos (expected PASS)
    FAIL zoned_uid/zoned_uid_027_pos (expected PASS)
    FAIL zoned_uid/zoned_uid_028_neg (expected PASS)
    FAIL zoned_uid/zoned_uid_030_pos (expected PASS)
    FAIL zoned_uid/zoned_uid_031_pos (expected PASS)
    FAIL zstream/zstream_raw_001_pos (expected PASS)```


### Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
