### PR TITLE
vdev_disk_open: fix ENOENT retry & cleanup error handling

### DIFF
--- a/module/os/linux/zfs/vdev_disk.c
+++ b/module/os/linux/zfs/vdev_disk.c
@@ -414,7 +414,7 @@ vdev_disk_open(vdev_t *v, uint64_t *psize, uint64_t *max_psize,
 	 */
 
 	hrtime_t start = gethrtime();
-	int err = ENXIO;
+	int err = -ENXIO;
 	while (err != 0 && ((gethrtime() - start) < timeout)) {
 
 		/*
@@ -425,7 +425,7 @@ vdev_disk_open(vdev_t *v, uint64_t *psize, uint64_t *max_psize,
 		 */
 		struct path devpath;
 		err = kern_path(v->vdev_path, LOOKUP_FOLLOW, &devpath);
-		if (err == 0) {
+		if (likely(err == 0)) {
 			int mask =
 			    (smode & SPA_MODE_READ ? MAY_READ : 0) |
 			    (smode & SPA_MODE_WRITE ? MAY_WRITE : 0);
@@ -433,29 +433,46 @@ vdev_disk_open(vdev_t *v, uint64_t *psize, uint64_t *max_psize,
 			path_put(&devpath);
 		}
 
-		if (err == 0) {
+		if (likely(err == 0)) {
+			/*
+			 * Device node exists and we have access to it, so try
+			 * to open it.
+			 */
 			bdh = vdev_blkdev_get_by_path(v->vdev_path, smode,
 			    zfs_vdev_holder);
-			err = BDH_IS_ERR(bdh) ? BDH_PTR_ERR(bdh) : 0;
-		}
 
-		if (err == 0)
-			break;
-
-		if (unlikely(err == -ENOENT)) {
-			/*
-			 * There is no point of waiting since device is removed
-			 * explicitly
-			 */
-			if (v->vdev_removed)
+			if (likely(!BDH_IS_ERR(bdh)))
+				/* Device open, nothing more to consider. */
 				break;
 
+			err = BDH_PTR_ERR(bdh);
+		}
+
+		ASSERT3U(err, !=, 0);
+
+		if (err == -ENOENT) {
+			/* Device node disappeared, see above comment. */
+
+			if (v->vdev_removed) {
+				/*
+				 * There is no point of waiting since device is
+				 * removed explicitly
+				 */
+				break;
+			}
+
+			/* Wait a moment, then retry. */
 			schedule_timeout_interruptible(MSEC_TO_TICK(10));
-		} else if (unlikely(err == -ERESTARTSYS)) {
+			continue;
+		}
+
+		if (err == -ERESTARTSYS) {
+			/* zvol deadlock avoided, extend timeout and retry. */
 			timeout = MSEC2NSEC(zfs_vdev_open_timeout_ms * 10);
 			continue;
 		}
 
+		/* Consider all other errors permanent, no retry. */
 		break;
 	}
 


### PR DESCRIPTION
_[Sponsors: TrueNAS]_

### Motivation and Context

In 88261a83ae I reorganised the blockdev open error handling to accomodate the permission check. What I didn't notice was that I'd made the ENOENT case break after the timeout, rather than looping and retrying.

This commit fixes it up the right way, and this time adds a lot more commentary to make it easier to see what's happening for each case.

### Description

The fix is to add `continue` after the wait in the ENOENT block, to force it to retry.

I've also added an "early out" `break` immediately after successful device open, so that the bottom half of the loop is more clearly devoted to only error handling.

And then some more comments to hopefully make it easier to read.

### How Has This Been Tested?

ZTS run completed successfully against 7.2.0. That's not saying much though, because it passed before! @ixhamza tells me the same change on top of our internal branches pass our own testing (which caught it in the first place!) so I'm guessing its probably fine.

I don't really understand this codepath beyond what the comment says. I can look at putting together a test case for it if someone can describe a cheap way to tickle it, or I can figure it out myself. Depends on whether or not you want to take the patch to fix the regression, or wait a little.

### Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
