### PR TITLE
ZTS: fix zinject argument order in mmp_write_uberblocks

### DIFF
--- a/tests/zfs-tests/tests/functional/mmp/mmp_write_uberblocks.ksh
+++ b/tests/zfs-tests/tests/functional/mmp/mmp_write_uberblocks.ksh
@@ -44,7 +44,7 @@ log_onexit cleanup
 log_must mmp_set_hostid $HOSTID1
 log_must zpool create -f $TESTPOOL mirror $DISKS
 log_must zpool set multihost=on $TESTPOOL
-log_must zinject -d ${DISK[0]} -e io -T write -f 50 $TESTPOOL -L uber
+log_must zinject -d ${DISK[0]} -e io -T write -f 50 -L uber $TESTPOOL
 clear_mmp_history
 uber_count=$(count_mmp_writes $TESTPOOL 3)
 


### PR DESCRIPTION
glibc's getopt() permutes argv by default (a GNU extension), reordering flags to the front regardless of where they appear. musl's getopt() is strict POSIX and stops parsing options at the first non-option argument. This test's zinject invocation places -L after the positional pool name ($TESTPOOL), which only glibc tolerates; under musl, zinject sees two leftover positional tokens ($TESTPOOL and the argument to the now- unparsed -L) and fails with "device (-d) injection requires a single pool name" instead of injecting the fault.

Move "-L uber" before the positional pool name. This is accepted identically under glibc's permuting getopt(), so the change is a no-op on every other platform.

Fixes the following tests on Alpine 3.24:
- mmp/mmp_write_uberblocks

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

---

### Motivation and Context
Make the Alpine runner eventually go green.

### Description
Some arguments are permuted as describted in the commit message.

### How Has This Been Tested?
- Local Alpine 3.24 VM.
- Alpine runner in GitHub Actions.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
