### PR TITLE
CI: Increasing ZTS timeout as some PRs are killed by and re-balance test cases based on group count

### DIFF
--- a/.github/workflows/zfs-qemu.yml
+++ b/.github/workflows/zfs-qemu.yml
@@ -137,7 +137,7 @@ jobs:
       run: .github/workflows/scripts/qemu-5-setup.sh
 
     - name: Run tests
-      timeout-minutes: 270
+      timeout-minutes: 300
       run: .github/workflows/scripts/qemu-6-tests.sh
       env:
         CI_TYPE: ${{ needs.test-config.outputs.ci_type }}

--- a/scripts/zfs-tests.sh
+++ b/scripts/zfs-tests.sh
@@ -218,17 +218,22 @@ split_tags() {
 	#
 	# 1. Remove unneeded chars: [],\
 	# 2. Print out the last field of each tag line.  This will be the tag
-	#    for the test (like 'zpool_add').
+	#    for the test (like 'zpool_add'), along with the number of tests
+	#    for that tag.  The tests = line may list the tests over multiple
+	#    lines, so keep counting until the next key = value line.
 	# 3. Remove duplicates between the runfiles.  If the same tag is defined
 	#    in multiple runfiles, then when you do '-T <tag>' ZTS is smart
 	#    enough to know to run the tag in each runfile.  So '-T zpool_add'
 	#    will run the zpool_add from common.run and linux.run.
 	# 4. Ignore the 'functional' tag since we only want individual tests
-	# 5. Print out the tests in our faction of all tests.  This uses modulus
+	# 5. Sort the tags by the number of tests, largest first.  This way the
+	#    interleave in the next step gives each fraction a mix of large and
+	#    small tags, instead of clustering most of the long running tags in
+	#    the same fraction as the alphabetically sorted tag list does.
+	# 6. Print out the tests in our faction of all tests.  This uses modulus
 	#    so "1/3" will run tests 1,3,6,9 etc.  That way the tests are
-	#    interleaved so, say, "3/4" isn't running all the zpool_* tests that
-	#    appear alphabetically at the end.
-	# 6. Remove trailing comma from list
+	#    interleaved so, say, "3/4" isn't running all the zpool_* tests.
+	# 7. Remove trailing comma from list
 	#
 	# TAGS will then look like:
 	#
@@ -237,9 +242,31 @@ split_tags() {
 	# Change the comma to a space for easy processing
 	_RUNFILES=${RUNFILES//","/" "}
 	# shellcheck disable=SC2002,SC2086
-	cat $_RUNFILES | tr -d "[],\'" | awk '/tags = /{print $NF}' | sort | \
-		uniq | grep -v functional | \
-		awk -v num="$NUM" -v den="$DEN" '{ if(NR % den == (num - 1)) {printf "%s,",$0}}' | \
+	cat $_RUNFILES | sed -e "s/','/ /g" | tr -d "[],\'" | awk '
+		/^tests = / {
+			n = NF - 2
+			collecting = 1
+			next
+		}
+		collecting && $0 !~ /=/ {
+			n += NF
+			next
+		}
+		collecting {
+			collecting = 0
+		}
+		/^tags = / {
+			if ($NF != "functional")
+				count[$NF] += n
+			n = 0
+			next
+		}
+		END {
+			for (t in count)
+				print t, count[t]
+		}
+	' | sort -k2,2nr -k1,1 | \
+		awk -v num="$NUM" -v den="$DEN" '{ if(NR % den == (num - 1)) {printf "%s,",$1}}' | \
 		sed -E 's/,$//'
 }
 


### PR DESCRIPTION
### Motivation and Context
Just see several PRs' ZTS workflow of ubuntu22 , include mine, are killed by timeout.

### Description
Increasing timeout from 270 to 300, I guess there are many test cases are added in master branch. It may be too much? 

### How Has This Been Tested?
CI

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [X] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
