### PR TITLE
ZTS: procfs_list_stale_read: accept Alpine's EIO error message

### DIFF
--- a/tests/zfs-tests/tests/functional/procfs/procfs_list_stale_read.ksh
+++ b/tests/zfs-tests/tests/functional/procfs/procfs_list_stale_read.ksh
@@ -67,7 +67,8 @@ function do_test
 	{
 		log_must eval "dd bs=512 count=4 >/dev/null"
 		log_must eval "$cmd"
-		log_must eval 'cat 2>&1 >/dev/null | grep "Input/output error"'
+		log_must eval 'cat 2>&1 >/dev/null | \
+		    grep -E "Input/output error|I/O error"'
 	} <$TXG_HIST
 }
 


### PR DESCRIPTION
The procfs_list_stale_read test expects `cat` to print "Input/output error", which is the wording used by GNU coreutils.  Alpine's `cat` reports the same EIO condition as "I/O error", causing the test to fail even though the expected I/O error occurred.

Accept both error message variants so the test is independent of the `cat` implementation's wording.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

---

### Motivation and Context
Make the Alpine runner go green eventually.

### Description
Use `grep -E` to support both error messages

### How Has This Been Tested?
- In a local Alpine 3.24 VM.

The GitHub Actions currently don't start up in my account for some reason.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
