### PR TITLE
ZTS: fix user_namespace_001 on Alpine Linux (BusyBox)

### DIFF
--- a/tests/zfs-tests/tests/functional/user_namespace/user_namespace_001.ksh
+++ b/tests/zfs-tests/tests/functional/user_namespace/user_namespace_001.ksh
@@ -47,8 +47,8 @@ log_onexit cleanup
 
 log_assert "Check root in user namespaces"
 
-TOUCH=$(readlink -f $(command -v touch))
-CHMOD=$(readlink -f $(command -v chmod))
+TOUCH=$(command -v touch)
+CHMOD=$(command -v chmod)
 
 for i in ${files[*]}; do
 	log_must $TOUCH $TESTDIR/$i


### PR DESCRIPTION
On Alpine, touch and chmod are symlinks to /bin/busybox, a multi-call binary that determines the program to run from argv[0]. readlink -f resolves through the symlink to /bin/coreutils, losing the program name, which causes BusyBox to fail with "unknown program".

Drop readlink -f and use command -v directly, which returns the symlink path itself. On other platforms the commands are real binaries, so this is a no-op.

Fixes the following tests on Alpine 3.24:
- user_namespace/user_namespace_001

---

### Motivation and Context
Make the Alpine Linux runner eventually go green.

### Description
Written in the commit message above. Dropping `readlink` still resulted in a green CI.

### How Has This Been Tested?
- Local Alpine 3.24 VM.
- Alpine 3.24 GitHub runner.
- Full default CI run.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
