### PR TITLE
ZTS: exec_001_pos: copy the exec test binary under its own name

### DIFF
--- a/tests/zfs-tests/tests/functional/exec/exec_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/exec/exec_001_pos.ksh
@@ -39,16 +39,16 @@ verify_runnable "both"
 
 function cleanup
 {
-	log_must rm $TESTDIR/myls
+	log_must rm $TESTDIR/ls
 }
 
 log_assert "Setting exec=on on a filesystem, processes can be executed from " \
 	"this file system."
 log_onexit cleanup
 
-log_must cp $STF_PATH/ls $TESTDIR/myls
+log_must cp $STF_PATH/ls $TESTDIR/ls
 log_must zfs set exec=on $TESTPOOL/$TESTFS
-log_must $TESTDIR/myls
-log_must mmap_exec $TESTDIR/myls
+log_must $TESTDIR/ls
+log_must mmap_exec $TESTDIR/ls
 
 log_pass "Setting exec=on on filesystem testing passed."


### PR DESCRIPTION
The test copies $STF_PATH/ls to $TESTDIR/myls and executes it directly, to verify a filesystem with exec=on actually allows running a binary from it. On Alpine, ls is an applet of a multi-call binary (the "coreutils" package) that dispatches on argv[0]'s basename; invoked as "myls" it doesn't recognize any applet by that name and exits with "coreutils: unknown program 'myls'" before the exec=on behavior this test is meant to verify ever comes into play.

Copy it to $TESTDIR/ls instead of $TESTDIR/myls. Dispatch is by basename only, so this is a plain rename with no other behavior change, and continues to exercise exactly what the test intends: copy a real binary onto the pool and confirm it runs and mmap(2)s with PROT_EXEC successfully.

exec_002_neg.ksh has the identical $TESTDIR/myls pattern but sets exec=off before ever trying to run it; the kernel refuses the execve(2) itself (EACCES/126) before the binary's own argv[0] dispatch would run either way, so it isn't affected and is left as is.

Fixes the following test on Alpine 3.24:
- exec/exec_001_pos

---

### Motivation and Context
Make the Alpine CI runner eventually go green.

### Description
Yet another issue with multi-call binaries.

### How Has This Been Tested?
- Local ALpine 3.24 VM.
- Alpine 3.24 GitHub runner.
- Full GitHub Actions run.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
