### PR TITLE
linux: fix write cache detection on 6.11+ kernels

### DIFF
--- a/include/os/linux/kernel/linux/blkdev_compat.h
+++ b/include/os/linux/kernel/linux/blkdev_compat.h
@@ -60,6 +60,12 @@ blk_queue_set_write_cache(struct request_queue *q, bool on)
  *      Only controls if the operator is allowed to change _WC. Initial version
  *      buggy; aliased to QUEUE_FLAG_FUA, so unuseable.
  * 6.6.10, 6.7: QUEUE_FLAG_HW_WC fixed.
+ * 6.11: Both flags removed. BLK_FEAT_WRITE_CACHE in queue_limits.features is
+ *       the driver-set equivalent of _HW_WC, while the operator's override
+ *       lives separately in BLK_FLAG_WRITE_CACHE_DISABLED. We deliberately
+ *       ignore the override (ie don't use bdev_write_cache()): we only sample
+ *       this at vdev open, so if the operator later re-enabled the cache we
+ *       would never flush again.
  *
  * Older than 4.10 we just assume write cache, and let the normal flush fail
  * detection apply.
@@ -67,7 +73,10 @@ blk_queue_set_write_cache(struct request_queue *q, bool on)
 static inline boolean_t
 zfs_bdev_has_write_cache(struct block_device *bdev)
 {
-#if defined(QUEUE_FLAG_HW_WC) && QUEUE_FLAG_HW_WC != QUEUE_FLAG_FUA
+#if defined(HAVE_BLKDEV_QUEUE_LIMITS_FEATURES)
+	return (!!(bdev_get_queue(bdev)->limits.features &
+	    BLK_FEAT_WRITE_CACHE));
+#elif defined(QUEUE_FLAG_HW_WC) && QUEUE_FLAG_HW_WC != QUEUE_FLAG_FUA
 	return (test_bit(QUEUE_FLAG_HW_WC, &bdev_get_queue(bdev)->queue_flags));
 #elif defined(QUEUE_FLAG_WC)
 	return (test_bit(QUEUE_FLAG_WC, &bdev_get_queue(bdev)->queue_flags));


### PR DESCRIPTION
Linux 6.11 moved the write cache flag into queue_limits, removing both `QUEUE_FLAG_WC` and `QUEUE_FLAG_HW_WC`.  `zfs_bdev_has_write_cache()` only tested those two flags, so it fell through to the pre-4.10 fallback and assumed every vdev had a volatile write cache.  `vdev_nowritecache` was never set at open, and ZFS kept submitting flush BIOs to devices that report no cache, only for the kernel to discard them in `blk_insert_flush()`.

Test `queue_limits.features & BLK_FEAT_WRITE_CACHE` instead.  Read the field directly rather than using `bdev_write_cache()`, which also honors the operator's `BLK_FLAG_WRITE_CACHE_DISABLED` override: we only sample this at vdev open, so if the operator later re-enabled the cache we would never flush again.  This preserves the old `QUEUE_FLAG_HW_WC` semantics.

### How Has This Been Tested?
I did notice in profiles that existing code does not work, spending time on pointless flush ZIOs.  So once this build on all platforms, it should not be worse.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
