### PR TITLE
unit/btree: test the negative cases

### DIFF
--- a/tests/unit/test_btree.c
+++ b/tests/unit/test_btree.c
@@ -14,8 +14,12 @@
  * Copyright (c) 2026, Christos Longros.
  */
 
+#include <signal.h>
 #include <stddef.h>
 #include <stdlib.h>
+#include <unistd.h>
+#include <sys/resource.h>
+#include <sys/wait.h>
 #include <sys/types.h>
 #include <sys/sysmacros.h>
 #include <sys/avl.h>
@@ -278,6 +282,93 @@ test_btree_drain(const MunitParameter params[], void *data)
 
 /* ========== */
 
+/*
+ * The negative tests from tests/zfs-tests/cmd/btree_test.c.  The B-Tree
+ * crashes on these rather than returning a failure, so each runs in a child
+ * process with core dumps disabled; a child that returns at all is a failure.
+ */
+static int
+do_negative_test(void (*func)(void))
+{
+	pid_t pid = fork();
+	unit_true(pid >= 0);
+
+	if (pid == 0) {
+		struct rlimit rlim = {0};
+
+		(void) setrlimit(RLIMIT_CORE, &rlim);
+		func();
+		_exit(0);
+	}
+
+	int status;
+	unit_eq(waitpid(pid, &status, 0), pid);
+	return (status);
+}
+
+/*
+ * Verify inserting a duplicate value will cause a crash.
+ * Note: negative test; the child is not expected to return.
+ */
+static void
+insert_duplicate(void)
+{
+	zfs_btree_t bt;
+	uint64_t i = 23456;
+	zfs_btree_index_t bt_idx = {0};
+
+	btree_create_u64(&bt);
+	if (zfs_btree_find(&bt, &i, &bt_idx) != NULL)
+		_exit(0);
+	zfs_btree_add_idx(&bt, &i, &bt_idx);
+	if (zfs_btree_find(&bt, &i, &bt_idx) == NULL)
+		_exit(0);
+
+	/* Crash on inserting a duplicate */
+	zfs_btree_add_idx(&bt, &i, NULL);
+}
+
+/*
+ * Verify removing a non-existent value will cause a crash.
+ * Note: negative test; the child is not expected to return.
+ */
+static void
+remove_missing(void)
+{
+	zfs_btree_t bt;
+	uint64_t i = 23456;
+	zfs_btree_index_t bt_idx = {0};
+
+	btree_create_u64(&bt);
+	if (zfs_btree_find(&bt, &i, &bt_idx) != NULL)
+		_exit(0);
+
+	/* Crash removing a nonexistent entry */
+	zfs_btree_remove(&bt, &i);
+}
+
+static MunitResult
+test_btree_insert_duplicate(const MunitParameter params[], void *data)
+{
+	(void) params, (void) data;
+
+	unit_true(WIFSIGNALED(do_negative_test(insert_duplicate)));
+	return (MUNIT_OK);
+}
+
+static MunitResult
+test_btree_remove_missing(const MunitParameter params[], void *data)
+{
+	(void) params, (void) data;
+	int status = do_negative_test(remove_missing);
+
+	unit_true(WIFSIGNALED(status));
+	unit_eq(WTERMSIG(status), SIGABRT);
+	return (MUNIT_OK);
+}
+
+/* ========== */
+
 static const MunitTest btree_tests[] = {
 	UNIT_TEST("empty",		test_btree_empty),
 	UNIT_TEST("add_find",		test_btree_add_find),
@@ -285,6 +376,8 @@ static const MunitTest btree_tests[] = {
 	UNIT_TEST("walk",		test_btree_walk),
 	UNIT_TEST("find_without_index",	test_btree_find_without_index),
 	UNIT_TEST("drain",		test_btree_drain),
+	UNIT_TEST("insert_duplicate",	test_btree_insert_duplicate),
+	UNIT_TEST("remove_missing",	test_btree_remove_missing),
 	{ 0 },
 };
 


### PR DESCRIPTION
### Motivation and Context

`tests/zfs-tests/cmd/btree_test.c` covers two cases that the unit tests do not: adding a duplicate value in the tree, and removing one that is not there. Introducing them is a step towards completely removing the ZTS test.

### Description

`insert_duplicate` and `remove_missing` are added to `tests/unit/test_btree.c`. Each runs in a child process and the parent checks that the child was killed rather than returning.

### How Has This Been Tested?

FreeBSD 16.0-CURRENT amd64:

```
$ gmake unit
  UNITTEST tests/unit/test_btree
Running test suite with seed 0x0f517a69...
btree.empty                          [ OK    ] [ 0.00000144 / 0.00000109 CPU ]
btree.add_find                       [ OK    ] [ 0.00001090 / 0.00001042 CPU ]
btree.remove                         [ OK    ] [ 0.00003155 / 0.00003113 CPU ]
btree.walk                           [ OK    ] [ 0.00001012 / 0.00000968 CPU ]
btree.find_without_index             [ OK    ] [ 0.00000699 / 0.00000691 CPU ]
btree.drain                          [ OK    ] [ 0.02722582 / 0.02722478 CPU ]
btree.insert_duplicate               [ OK    ] [ 0.00044829 / 0.00017316 CPU ]
btree.remove_missing                 [ OK    ] [ 0.00219812 / 0.00006016 CPU ]
8 of 8 (100%) tests successful, 0 (0%) test skipped.
```

### Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
