### PR TITLE
Linux: drop cached pages in zfs_rezget() (fix stale page cache after rollback)

### DIFF
--- a/module/os/linux/zfs/zfs_znode_os.c
+++ b/module/os/linux/zfs/zfs_znode_os.c
@@ -1201,6 +1201,15 @@ zfs_rezget(znode_t *zp)
 	if (zp->z_is_ctldir)
 		return (0);
 
+	/*
+	 * Drop cached pages before reloading the znode.  After a rollback or
+	 * a forced receive the object may hold different data under the same
+	 * inode, size and generation; stale Uptodate pages would otherwise be
+	 * served by mappedread() and mmap() (see #10931).  FreeBSD does the
+	 * same here via vn_pages_remove().
+	 */
+	truncate_inode_pages(ZTOI(zp)->i_mapping, 0);
+
 	zh = zfs_znode_hold_enter(zfsvfs, obj_num);
 
 	mutex_enter(&zp->z_acl_lock);


### PR DESCRIPTION

### Motivation and Context

After `zfs rollback` (or `zfs recv -F`) of a mounted dataset, files whose object number, generation and size are unchanged but whose data blocks differ keep serving stale data from the Linux page cache: `zfs_resume_fs()` -> `zfs_rezget()` reloads the znode's SA attributes but never invalidates `ZTOI(zp)->i_mapping`. Any page that was resident (the file had been mmap'ed) and later refreshed by `update_pages()` from a `write()` survives the rollback, and both `mappedread()` and `mmap()` return it. Reading through `.zfs/snapshot` gives the correct data, so the on-disk state is fine.

The FreeBSD port already handles this: its `zfs_rezget()` unconditionally calls `vn_pages_remove_valid()` before reloading the znode. The Linux port never got the equivalent.

Closes #10931. Same symptom as the old #2186.

### Description

Call `truncate_inode_pages(ZTOI(zp)->i_mapping, 0)` at the top of the Linux `zfs_rezget()`, right after the `z_is_ctldir` early return, before the znode is reloaded (so pages are dropped on the error paths too, as on FreeBSD).

Notes on the choice of `truncate_inode_pages` over `invalidate_inode_pages2`:
- Dirty pages: writeback goes through `zfs_enter_verify_zp()` and is blocked on `z_teardown_lock` for the whole suspend/resume window, so dirty pre-rollback pages can still exist at this point. Their content belongs to the state that is being rolled back, so discarding them is the correct semantics; `invalidate_inode_pages2()` would return EBUSY and leave them.
- Mapped pages: `truncate_inode_pages()` unmaps them; the next access faults into `zfs_getpage()`, which reads the rolled-back data from the DMU. Verified with a test that keeps a live `PROT_READ` mapping across the rollback.
- Locking: `zfs_resume_fs()` holds `z_teardown_lock` and `z_teardown_inactive_lock` for writing, all VOPs are blocked; `truncate_inode_pages()` needs neither `i_rwsem` nor the range lock.

Size changes are still handled by `zfs_znode_update_vfs()` (`i_size_write`); pages beyond the new EOF are dropped by this change as well, since the whole mapping is truncated.

### How Has This Been Tested?

- Reproducer from #10931 (attached there): file -> snapshot -> mmap and touch every page -> `pwrite()` 2000 random 4K pages -> `zfs rollback`. Before: all 2000 pages stale via `read()` and `mmap()`, 100% reproducible on 2.1.11 and 2.3.9 (kernel 6.1.90, x86_64). After: 0 stale pages, 7/7 runs, including variants with the mapping closed before the rollback and with a live mapping held across it; control without any mapping unchanged.
- Patched module (2.3.9 + this change, DKMS) has been running on a CI build host whose workflow rolls a 63 GB build-cache dataset back to a golden snapshot before every job; the previously recurring PCH corruption no longer occurs.
- No new warnings in dmesg; ZTS not run (not available on the host).

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] My code follows the OpenZFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the contributing document.
- [ ] I have added tests to cover my changes.
- [ ] I have run the ZFS test suite with this change enabled and it passed. (not run: no ZTS-capable host available; verified with the reproducer from #10931 and on a production CI host)
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
