### PR TITLE
dnode: fix heap-use-after-free in dnode_rele_and_unlock()

### DIFF
--- a/module/zfs/dnode.c
+++ b/module/zfs/dnode.c
@@ -1779,8 +1779,6 @@ dnode_rele_and_unlock(dnode_t *dn, const void *tag, boolean_t evicting)
 	refs = zfs_refcount_remove(&dn->dn_holds, tag);
 	if (refs == 0)
 		cv_broadcast(&dn->dn_nodnholds);
-	mutex_exit(&dn->dn_mtx);
-	/* dnode could get destroyed at this point, so don't use it anymore */
 
 	/*
 	 * It's unsafe to release the last hold on a dnode by dnode_rele() or
@@ -1794,6 +1792,12 @@ dnode_rele_and_unlock(dnode_t *dn, const void *tag, boolean_t evicting)
 #ifdef ZFS_DEBUG
 	ASSERT(refs > 0 || zrl_owner(&dnh->dnh_zrlock) != curthread);
 #endif
+
+	mutex_exit(&dn->dn_mtx);
+	/*
+	 * After the dn_mtx is released the dn and dnh may be destroyed,
+	 * they are no longer safe to use after this point.
+	 */
 
 	/* NOTE: the DNODE_DNODE does not have a dn_dbuf */
 	if (refs == 0 && db != NULL) {


### PR DESCRIPTION
The ZFS_DEBUG-only assert in `dnode_rele_and_unlock()` dereferenced `dnh`, the dnode's handle, after `mutex_exit(&dn->dn_mtx)`, below the comment stating "dnode could get destroyed at this point, so don't use it anymore".

For an objset's special dnodes that is a real use-after-free. They have no dnode block (`dn_dbuf == NULL`), so nothing pins their handle; it is embedded in the `objset_t`. Only `dn_nodnholds` orders a release against teardown, and this function is what signals it: on the last hold it broadcasts and drops `dn_mtx`, freeing `dnode_special_close()` to destroy that handle and, via `dmu_objset_evict_done()`, the objset it lives in. The assert then reads it.

Sample the `zrlock` ownership before dropping `dn_mtx` instead, where `dn_mtx` still blocks `dnode_special_close()` and, for an ordinary dnode, the reference from `dbuf_add_ref(db, dnh)` is not yet released.

ZFS_DEBUG-only, no change to non-debug builds.

---

### Motivation and Context
A ZFS_DEBUG-only assert in `dnode_rele_and_unlock()` reads the dnode handle after `mutex_exit()`. For an objset's special dnodes that is a use-after-free, crashing `zdb` during pool teardown.

### Description
Moves the `zrlock` ownership read to before `dn_mtx` is dropped, where the handle is still guaranteed live. ZFS_DEBUG-only, no change to non-debug builds.

### How Has This Been Tested?
- Locally on Alpine 3.24.
- Alpine 3.24 CI runner.
- Full ZFS test matrix.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
