### PR TITLE
zstd: declare __asan_*_memory_region() for user space builds

### DIFF
--- a/module/zstd/zfs_zstd.c
+++ b/module/zstd/zfs_zstd.c
@@ -275,6 +275,8 @@ void __asan_poison_memory_region(void const volatile *addr, size_t size) {};
 
 /* User space. */
 #if defined(ADDRESS_SANITIZER) && !defined(_KERNEL)
+void __asan_unpoison_memory_region(void const volatile *addr, size_t size);
+void __asan_poison_memory_region(void const volatile *addr, size_t size);
 #define	ZSTD_ASAN_POISON(p, n)   __asan_poison_memory_region((p), (n))
 #define	ZSTD_ASAN_UNPOISON(p, n) __asan_unpoison_memory_region((p), (n))
 #else


### PR DESCRIPTION
ZSTD_ASAN_POISON() and ZSTD_ASAN_UNPOISON() call __asan_poison_memory_region() and __asan_unpoison_memory_region() directly, but nothing declares them in the user space build. The kernel block just above declares both -- and stubs them out, since KASAN does not provide them -- while the user space block was left with only the macros.

That builds where an implicit function declaration is a warning, since the real symbols come from libasan at link time, but fails on compilers that make it an error, as GCC 14 and newer do by default:

    zfs_zstd.c:278:34: error: implicit declaration of function
    '__asan_poison_memory_region' [-Wimplicit-function-declaration]

Declare both in the user space block, mirroring the kernel block.

---

### Motivation and Context
`--enable-asan` builds fail to compile on GCC 14 and newer: `zfs_zstd.c` calls `__asan_poison_memory_region()` and `__asan_unpoison_memory_region(`) without declaring them, and those compilers reject implicit function declarations by default.

### Description
Declares both functions in the user space block, mirroring the kernel block just above. Build fix only, no behavior change.

### How Has This Been Tested?
Built with `--enable-asan` on Alpine (musl, GCC 15.2.0). `module/zstd/zfs_zstd.c` fails to compile before the change and builds clean after.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
