### PR TITLE
Inherit the project ID for every object type, and allow same-directory renames

### DIFF
--- a/module/os/freebsd/zfs/zfs_vnops_os.c
+++ b/module/os/freebsd/zfs/zfs_vnops_os.c
@@ -3384,8 +3384,16 @@ zfs_do_rename_impl(vnode_t *sdvp, vnode_t **svpp, struct componentname *scnp,
 	 * not only the project ID, but also the ZFS_PROJINHERIT flag. Under
 	 * such case, we only allow renames into our tree when the project
 	 * IDs are the same.
+	 *
+	 * A rename within a single directory leaves the object exactly where
+	 * it already is, so it cannot move it between projects and is always
+	 * allowed.  Objects created before symlinks and other non-regular
+	 * files began inheriting a project ID carry none of their own, and
+	 * would otherwise not be renameable within the very directory that
+	 * holds them -- which breaks "ln -sfn", implemented as
+	 * create-under-a-temporary-name-then-rename.
 	 */
-	if (tdzp->z_pflags & ZFS_PROJINHERIT &&
+	if (sdzp != tdzp && tdzp->z_pflags & ZFS_PROJINHERIT &&
 	    tdzp->z_projid != szp->z_projid) {
 		error = SET_ERROR(EXDEV);
 		goto out;

--- a/module/os/freebsd/zfs/zfs_vnops_os.c
+++ b/module/os/freebsd/zfs/zfs_vnops_os.c
@@ -1119,8 +1119,7 @@ zfs_create(znode_t *dzp, const char *name, vattr_t *vap, int excl, int mode,
 	    cr, vsecp, &acl_ids, NULL)) != 0)
 		goto out;
 
-	if (S_ISREG(vap->va_mode) || S_ISDIR(vap->va_mode))
-		projid = zfs_inherit_projid(dzp);
+	projid = zfs_inherit_projid(dzp);
 	if (zfs_acl_ids_overquota(zfsvfs, &acl_ids, projid)) {
 		zfs_acl_ids_free(&acl_ids);
 		error = SET_ERROR(EDQUOT);
@@ -3659,7 +3658,7 @@ zfs_symlink(znode_t *dzp, const char *name, vattr_t *vap,
 		return (error);
 	}
 
-	if (zfs_acl_ids_overquota(zfsvfs, &acl_ids, ZFS_DEFAULT_PROJID)) {
+	if (zfs_acl_ids_overquota(zfsvfs, &acl_ids, zfs_inherit_projid(dzp))) {
 		zfs_acl_ids_free(&acl_ids);
 		zfs_exit(zfsvfs, FTAG);
 		return (SET_ERROR(EDQUOT));

--- a/module/os/freebsd/zfs/zfs_znode_os.c
+++ b/module/os/freebsd/zfs/zfs_znode_os.c
@@ -667,22 +667,28 @@ zfs_mknode(znode_t *dzp, vattr_t *vap, dmu_tx_t *tx, cred_t *cr,
 	if (flag & IS_XATTR)
 		pflags |= ZFS_XATTR;
 
-	if (vap->va_type == VREG || vap->va_type == VDIR) {
-		/*
-		 * With ZFS_PROJID flag, we can easily know whether there is
-		 * project ID stored on disk or not. See zpl_get_file_info().
-		 */
-		if (obj_type != DMU_OT_ZNODE &&
-		    dmu_objset_projectquota_enabled(zfsvfs->z_os))
-			pflags |= ZFS_PROJID;
+	/*
+	 * With ZFS_PROJID flag, we can easily know whether there is
+	 * project ID stored on disk or not. See zpl_get_file_info().
+	 */
+	if (obj_type != DMU_OT_ZNODE &&
+	    dmu_objset_projectquota_enabled(zfsvfs->z_os))
+		pflags |= ZFS_PROJID;
 
-		/*
-		 * Inherit project ID from parent if required.
-		 */
-		projid = zfs_inherit_projid(dzp);
-		if (dzp_pflags & ZFS_PROJINHERIT)
-			pflags |= ZFS_PROJINHERIT;
-	}
+	/*
+	 * Inherit project ID from parent if required.  Every object type
+	 * takes part, as ext4 and XFS do: an object that carried no project
+	 * ID of its own would be treated as belonging to a different project
+	 * than the directory holding it, so zfs_rename() and zfs_link()
+	 * would refuse it with EXDEV even within its own project.
+	 *
+	 * The ZFS_PROJINHERIT flag itself keeps passing to regular files and
+	 * directories only, as before, so that lsattr(1) output is unchanged.
+	 */
+	projid = zfs_inherit_projid(dzp);
+	if ((vap->va_type == VREG || vap->va_type == VDIR) &&
+	    (dzp_pflags & ZFS_PROJINHERIT))
+		pflags |= ZFS_PROJINHERIT;
 
 	/*
 	 * No execs denied will be determined when zfs_mode_compute() is called.

--- a/module/os/linux/zfs/zfs_vnops_os.c
+++ b/module/os/linux/zfs/zfs_vnops_os.c
@@ -736,8 +736,7 @@ top:
 			goto out;
 		have_acl = B_TRUE;
 
-		if (S_ISREG(vap->va_mode) || S_ISDIR(vap->va_mode))
-			projid = zfs_inherit_projid(dzp);
+		projid = zfs_inherit_projid(dzp);
 		if (zfs_acl_ids_overquota(zfsvfs, &acl_ids, projid)) {
 			zfs_acl_ids_free(&acl_ids);
 			error = SET_ERROR(EDQUOT);
@@ -930,8 +929,7 @@ top:
 		goto out;
 	have_acl = B_TRUE;
 
-	if (S_ISREG(vap->va_mode) || S_ISDIR(vap->va_mode))
-		projid = zfs_inherit_projid(dzp);
+	projid = zfs_inherit_projid(dzp);
 	if (zfs_acl_ids_overquota(zfsvfs, &acl_ids, projid)) {
 		zfs_acl_ids_free(&acl_ids);
 		error = SET_ERROR(EDQUOT);
@@ -3057,11 +3055,8 @@ top:
 
 	/* Set up inode creation for RENAME_WHITEOUT. */
 	if (rflags & RENAME_WHITEOUT) {
-		/*
-		 * Whiteout files are not regular files or directories, so to
-		 * match zfs_create() we do not inherit the project id.
-		 */
-		uint64_t wo_projid = ZFS_DEFAULT_PROJID;
+		/* Match zfs_create(): the whiteout joins its directory. */
+		uint64_t wo_projid = zfs_inherit_projid(sdzp);
 
 		error = zfs_zaccess(sdzp, ACE_ADD_FILE, 0, B_FALSE, cr, mnt_ns);
 		if (error)
@@ -3389,7 +3384,7 @@ top:
 		return (error);
 	}
 
-	if (zfs_acl_ids_overquota(zfsvfs, &acl_ids, ZFS_DEFAULT_PROJID)) {
+	if (zfs_acl_ids_overquota(zfsvfs, &acl_ids, zfs_inherit_projid(dzp))) {
 		zfs_acl_ids_free(&acl_ids);
 		zfs_dirent_unlock(dl);
 		zfs_exit(zfsvfs, FTAG);

--- a/module/os/linux/zfs/zfs_vnops_os.c
+++ b/module/os/linux/zfs/zfs_vnops_os.c
@@ -2993,8 +2993,16 @@ top:
 	 * not only the project ID, but also the ZFS_PROJINHERIT flag. Under
 	 * such case, we only allow renames into our tree when the project
 	 * IDs are the same.
+	 *
+	 * A rename within a single directory leaves the object exactly where
+	 * it already is, so it cannot move it between projects and is always
+	 * allowed.  Objects created before symlinks and other non-regular
+	 * files began inheriting a project ID carry none of their own, and
+	 * would otherwise not be renameable within the very directory that
+	 * holds them -- which breaks "ln -sfn", implemented as
+	 * create-under-a-temporary-name-then-rename.
 	 */
-	if (tdzp->z_pflags & ZFS_PROJINHERIT &&
+	if (sdzp != tdzp && tdzp->z_pflags & ZFS_PROJINHERIT &&
 	    tdzp->z_projid != szp->z_projid) {
 		error = SET_ERROR(EXDEV);
 		goto out;

--- a/module/os/linux/zfs/zfs_znode_os.c
+++ b/module/os/linux/zfs/zfs_znode_os.c
@@ -775,22 +775,28 @@ zfs_mknode(znode_t *dzp, vattr_t *vap, dmu_tx_t *tx, cred_t *cr,
 	if (flag & IS_XATTR)
 		pflags |= ZFS_XATTR;
 
-	if (S_ISREG(vap->va_mode) || S_ISDIR(vap->va_mode)) {
-		/*
-		 * With ZFS_PROJID flag, we can easily know whether there is
-		 * project ID stored on disk or not. See zpl_get_file_info().
-		 */
-		if (obj_type != DMU_OT_ZNODE &&
-		    dmu_objset_projectquota_enabled(zfsvfs->z_os))
-			pflags |= ZFS_PROJID;
+	/*
+	 * With ZFS_PROJID flag, we can easily know whether there is
+	 * project ID stored on disk or not. See zpl_get_file_info().
+	 */
+	if (obj_type != DMU_OT_ZNODE &&
+	    dmu_objset_projectquota_enabled(zfsvfs->z_os))
+		pflags |= ZFS_PROJID;
 
-		/*
-		 * Inherit project ID from parent if required.
-		 */
-		projid = zfs_inherit_projid(dzp);
-		if (dzp->z_pflags & ZFS_PROJINHERIT)
-			pflags |= ZFS_PROJINHERIT;
-	}
+	/*
+	 * Inherit project ID from parent if required.  Every object type
+	 * takes part, as ext4 and XFS do: an object that carried no project
+	 * ID of its own would be treated as belonging to a different project
+	 * than the directory holding it, so zfs_rename() and zfs_link()
+	 * would refuse it with EXDEV even within its own project.
+	 *
+	 * The ZFS_PROJINHERIT flag itself keeps passing to regular files and
+	 * directories only, as before, so that lsattr(1) output is unchanged.
+	 */
+	projid = zfs_inherit_projid(dzp);
+	if ((S_ISREG(vap->va_mode) || S_ISDIR(vap->va_mode)) &&
+	    (dzp->z_pflags & ZFS_PROJINHERIT))
+		pflags |= ZFS_PROJINHERIT;
 
 	/*
 	 * No execs denied will be determined when zfs_mode_compute() is called.

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -193,6 +193,7 @@ tags = ['functional', 'procfs']
 [tests/functional/projectquota:Linux]
 tests = ['defaultprojectquota_001_pos', 'defaultprojectquota_005_pos',
     'projectid_001_pos', 'projectid_002_pos', 'projectid_003_pos',
+    'projectid_004_pos',
     'projectquota_001_pos', 'projectquota_003_pos', 'projectquota_006_pos',
     'projectspace_001_pos', 'projectspace_002_pos', 'projectspace_003_pos',
     'projectspace_004_pos', 'projectspace_005_pos', 'projecttree_001_pos']

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1835,6 +1835,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/projectquota/projectid_001_pos.ksh \
 	functional/projectquota/projectid_002_pos.ksh \
 	functional/projectquota/projectid_003_pos.ksh \
+	functional/projectquota/projectid_004_pos.ksh \
 	functional/projectquota/projectquota_001_pos.ksh \
 	functional/projectquota/projectquota_002_pos.ksh \
 	functional/projectquota/projectquota_003_pos.ksh \

--- a/tests/zfs-tests/tests/functional/projectquota/projectid_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/projectquota/projectid_004_pos.ksh
@@ -1,0 +1,139 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
+#
+
+#
+# Copyright (c) 2026 by Matt Turner. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/projectquota/projectquota_common.kshlib
+
+#
+# DESCRIPTION:
+#	Every object type inherits the project ID, and renaming within a
+#	project directory is always allowed
+#
+#
+# STRATEGY:
+#	1. Create a regular file and a symlink in a directory, then set the
+#	   directory's project ID with the inherit flag, leaving the two
+#	   objects carrying no project ID of their own
+#	2. Rename each of them within that directory, which has to be allowed
+#	   whatever project ID they carry
+#	3. Rename a regular file and a symlink created after the directory was
+#	   tagged, and replace a symlink with "ln -sfn", which creates the new
+#	   symlink under a temporary name and renames it into place
+#	4. Check that a new symlink and a new FIFO are accounted to the
+#	   directory's project, which they only are if they inherited its
+#	   project ID
+#	5. Rename a symlink into a different directory carrying the same
+#	   project ID, which rename(2) only permits if the symlink carries
+#	   that project ID too
+#	6. Check that a rename into a different project is still refused,
+#	   and that a symlink carrying no project ID cannot be renamed into
+#	   one, which shows the check in step 5 is reached and enforced
+#
+
+function cleanup
+{
+	log_must rm -rf $PRJDIR1 $PRJDIR2 $PRJDIR3 $TESTDIR/tlink6
+}
+
+if ! lsattr -pd > /dev/null 2>&1; then
+	log_unsupported "Current e2fsprogs does not support set/show project ID"
+fi
+
+# renameat2(1) is used throughout rather than mv(1), which falls back to
+# copying on EXDEV and would report success either way.
+if ! renameat2 -C; then
+	log_unsupported "renameat2 not supported on this (pre-3.15) linux kernel"
+fi
+
+log_onexit cleanup
+
+log_assert "Every object type inherits the project ID, and renaming within" \
+    "a project directory is always allowed"
+
+log_must mkdir $PRJDIR1
+
+#
+# Objects created before the directory was tagged carry no project ID of
+# their own, as every symlink on an existing pool does. This is the case
+# the same-directory exemption exists for: renaming within one directory
+# cannot move an object between projects, so it has to be allowed whatever
+# project ID the object carries -- including none at all.
+#
+log_must touch $PRJDIR1/tofile1
+log_must ln -s target $PRJDIR1/tolink1
+
+log_must chattr +P -p $PRJID1 $PRJDIR1
+
+log_must renameat2 $PRJDIR1/tofile1 $PRJDIR1/tofile2
+log_must renameat2 $PRJDIR1/tolink1 $PRJDIR1/tolink2
+
+# Objects created after the directory was tagged inherit its project ID, and
+# renaming those within it has to keep working too.
+log_must touch $PRJDIR1/tfile1
+log_must renameat2 $PRJDIR1/tfile1 $PRJDIR1/tfile2
+
+log_must ln -s target $PRJDIR1/tlink1
+log_must renameat2 $PRJDIR1/tlink1 $PRJDIR1/tlink2
+
+log_must ln -sfn other $PRJDIR1/tlink2
+log_must eval '[[ $(readlink $PRJDIR1/tlink2) == other ]]'
+
+# A subdirectory inherits both the project ID and the inherit flag, so it
+# has to behave the same way.
+log_must mkdir $PRJDIR1/subdir
+log_must ln -s target $PRJDIR1/subdir/tlink3
+log_must renameat2 $PRJDIR1/subdir/tlink3 $PRJDIR1/subdir/tlink4
+
+#
+# A symlink and a FIFO are not regular files or directories, and used to be
+# left at the default project ID. Creating one now adds an object to the
+# directory's project.
+#
+sync_pool
+typeset prj_bef=$(project_obj_count $QFS $PRJID1)
+
+log_must ln -s target $PRJDIR1/tlink5
+log_must mkfifo $PRJDIR1/tfifo1
+
+sync_pool
+typeset prj_aft=$(project_obj_count $QFS $PRJID1)
+
+[[ $prj_aft -eq $((prj_bef + 2)) ]] ||
+	log_fail "new value ($prj_aft) is NOT 2 larger than old one ($prj_bef)"
+
+#
+# rename(2) into a different directory is allowed only when the project IDs
+# match, so this passes only if the symlink really did inherit one.
+#
+log_must mkdir $PRJDIR2
+log_must chattr +P -p $PRJID1 $PRJDIR2
+log_must renameat2 $PRJDIR1/tlink5 $PRJDIR2/tlink5
+
+# Crossing into a different project is still refused.
+log_must mkdir $PRJDIR3
+log_must chattr +P -p $PRJID2 $PRJDIR3
+log_mustnot renameat2 $PRJDIR2/tlink5 $PRJDIR3/tlink5
+
+# And a symlink created outside any project carries no project ID, so it
+# cannot be renamed into one. This is what makes the check above meaningful:
+# it shows the cross-project test is reached and enforced, so the rename that
+# succeeded did so because the symlink had inherited a project ID.
+log_must ln -s target $TESTDIR/tlink6
+log_mustnot renameat2 $TESTDIR/tlink6 $PRJDIR1/tlink6
+log_must rm -f $TESTDIR/tlink6
+
+log_pass "Every object type inherits the project ID, and renaming within" \
+    "a project directory is always allowed"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context

Backport of the patches from #18932 to the zfs-2.4.5-staging branch.

### Description

Cherry-pick of the following commits from master, now merged via #18932:

- Inherit the project ID for every object type
- Allow renames within a single directory under project inheritance
- ZTS: check project ID inheritance and renames within a project directory

### How Has This Been Tested?

Cherry-picked cleanly with no conflicts. CI will run the ZFS Test Suite against this change.

### Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).