### PR TITLE
ZTS: avoid initialize completion race

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zpool_initialize/zpool_initialize_online_offline.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_initialize/zpool_initialize_online_offline.ksh
@@ -34,7 +34,16 @@
 DISK1=${DISKS%% *}
 DISK2="$(echo $DISKS | cut -d' ' -f2)"
 
+function cleanup
+{
+	zinject -c all
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
+}
+log_onexit cleanup
+
 log_must zpool create -f $TESTPOOL mirror $DISK1 $DISK2
+# Keep initializing active while checking progress and suspending it.
+log_must zinject -d $DISK1 -D 20:1 -T write $TESTPOOL
 log_must zpool initialize $TESTPOOL $DISK1
 
 log_must zpool offline $TESTPOOL $DISK1


### PR DESCRIPTION
`zpool_initialize_online_offline.ksh` can finish initialisation before the
test checks progress and suspends it. Moving the suspend command earlier
only narrows that race window.

Inject a 20 ms write delay with one lane on the disk being initialised, as
suggested in review. Preserve the original checks that initialisation
resumes without losing progress after an offline/online cycle, and that
explicit suspension persists across another cycle. Clear the injection
during exit cleanup before destroying the pool.

The replacement commit also fixes the commit-message line-length failure.

### Validation

The repository commit-message check, patch whitespace check and Bash syntax
check pass locally. Fresh runtime validation of this 20 ms revision is
pending; the old local AlmaLinux VM is no longer available.

The earlier 1 ms revision at `c99b6616f` passed this test in the AlmaLinux 8
and 10, Fedora 43, Ubuntu 22 and 26, and FreeBSD 16 job logs inspected from
[the fork CI run](https://github.com/matthiasgoergens/zfs/actions/runs/33505566104).
That matrix failed overall in other tests and builds. Those historical
results do not constitute runtime validation of this revision.
