### PR TITLE
Add alloc factor logic

### DIFF
--- a/include/sys/vdev.h
+++ b/include/sys/vdev.h
@@ -132,6 +132,7 @@ extern uint64_t vdev_psize_to_asize_txg(vdev_t *vd, uint64_t psize,
     uint64_t txg);
 extern uint64_t vdev_psize_to_asize(vdev_t *vd, uint64_t psize);
 extern uint64_t vdev_get_min_alloc(vdev_t *vd);
+extern uint64_t vdev_alloc_factor(vdev_t *vd);
 
 /*
  * Return the amount of space allocated for a gang block header.  Note that

--- a/include/sys/vdev_impl.h
+++ b/include/sys/vdev_impl.h
@@ -84,6 +84,7 @@ typedef uint64_t vdev_rebuild_asize_func_t(vdev_t *vd, uint64_t start,
     uint64_t size, uint64_t max_segment);
 typedef void vdev_metaslab_init_func_t(vdev_t *vd, uint64_t *startp,
     uint64_t *sizep);
+typedef uint64_t vdev_alloc_factor_func_t(vdev_t *vd);
 typedef void vdev_config_generate_func_t(vdev_t *vd, nvlist_t *nv);
 typedef uint64_t vdev_nparity_func_t(vdev_t *vd);
 typedef uint64_t vdev_ndisks_func_t(vdev_t *vd);
@@ -111,6 +112,7 @@ typedef const struct vdev_ops {
 	vdev_nparity_func_t		*vdev_op_nparity;
 	vdev_ndisks_func_t		*vdev_op_ndisks;
 	vdev_kobj_post_evt_func_t	*vdev_op_kobj_evt_post;
+	vdev_alloc_factor_func_t	*vdev_op_alloc_factor;
 	char				vdev_op_type[16];
 	boolean_t			vdev_op_leaf;
 } vdev_ops_t;

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -1765,6 +1765,10 @@ metaslab_block_find(zfs_btree_t *t, zfs_range_tree_t *rt, uint64_t start,
 	return (rs);
 }
 
+#ifndef rounddown
+#define	rounddown(x, y) (((x) / (y)) * (y))
+#endif
+
 /*
  * This is a helper function that can be used by the allocator to find a
  * suitable block to allocate. This will search the specified B-tree looking
@@ -1772,7 +1776,8 @@ metaslab_block_find(zfs_btree_t *t, zfs_range_tree_t *rt, uint64_t start,
  */
 static uint64_t
 metaslab_block_picker(zfs_range_tree_t *rt, uint64_t *cursor, uint64_t size,
-    uint64_t max_size, uint64_t max_search, uint64_t *found_size)
+    uint64_t max_size, uint64_t max_search, uint_t mult,
+    uint64_t *found_size)
 {
 	if (*cursor == 0)
 		*cursor = rt->rt_start;
@@ -1790,8 +1795,15 @@ metaslab_block_picker(zfs_range_tree_t *rt, uint64_t *cursor, uint64_t size,
 	    max_search || count_searched < metaslab_min_search_count)) {
 		uint64_t offset = zfs_rs_get_start(rs, rt);
 		if (offset + size <= zfs_rs_get_end(rs, rt)) {
-			*found_size = MIN(zfs_rs_get_end(rs, rt) - offset,
-			    max_size);
+			uint64_t cand_size =  MIN(zfs_rs_get_end(rs, rt) -
+			    offset, max_size);
+			if (size != max_size)
+				cand_size = rounddown(cand_size, mult);
+			else
+				ASSERT0(cand_size % mult);
+			ASSERT3U(cand_size, >=, size);
+
+			*found_size = cand_size;
 			*cursor = offset + *found_size;
 			return (offset);
 		}
@@ -1910,7 +1922,7 @@ metaslab_df_alloc(metaslab_t *msp, uint64_t size, uint64_t max_size,
 	zfs_range_tree_t *rt = msp->ms_allocatable;
 	uint_t free_pct = zfs_range_tree_space(rt) * 100 / msp->ms_size;
 	uint64_t offset;
-
+	uint64_t mult = vdev_alloc_factor(msp->ms_group->mg_vd);
 	ASSERT(MUTEX_HELD(&msp->ms_lock));
 
 	/*
@@ -1924,12 +1936,13 @@ metaslab_df_alloc(metaslab_t *msp, uint64_t size, uint64_t max_size,
 		offset = -1;
 	} else {
 		offset = metaslab_block_picker(rt, cursor, size, max_size,
-		    metaslab_df_max_search, found_size);
+		    metaslab_df_max_search, mult, found_size);
 		if (max_size != size && offset == -1) {
 			align = size & -size;
 			cursor = &msp->ms_lbas[highbit64(align) - 1];
 			offset = metaslab_block_picker(rt, cursor, size,
-			    max_size, metaslab_df_max_search, found_size);
+			    max_size, metaslab_df_max_search, mult,
+			    found_size);
 		}
 	}
 
@@ -1950,8 +1963,15 @@ metaslab_df_alloc(metaslab_t *msp, uint64_t size, uint64_t max_size,
 		if (rs != NULL && zfs_rs_get_start(rs, rt) + size <=
 		    zfs_rs_get_end(rs, rt)) {
 			offset = zfs_rs_get_start(rs, rt);
-			*found_size = MIN(zfs_rs_get_end(rs, rt) - offset,
-			    max_size);
+			uint64_t cand_size =  MIN(zfs_rs_get_end(rs, rt) -
+			    offset, max_size);
+			if (size != max_size)
+				cand_size = rounddown(cand_size, mult);
+			else
+				ASSERT0(cand_size % mult);
+			ASSERT3U(cand_size, >=, size);
+
+			*found_size = cand_size;
 			*cursor = offset + *found_size;
 		}
 	}
@@ -1977,6 +1997,7 @@ metaslab_cf_alloc(metaslab_t *msp, uint64_t size, uint64_t max_size,
 	uint64_t *cursor = &msp->ms_lbas[0];
 	uint64_t *cursor_end = &msp->ms_lbas[1];
 	uint64_t offset = 0;
+	uint64_t mult = vdev_alloc_factor(msp->ms_group->mg_vd);
 
 	ASSERT(MUTEX_HELD(&msp->ms_lock));
 
@@ -1997,7 +2018,14 @@ metaslab_cf_alloc(metaslab_t *msp, uint64_t size, uint64_t max_size,
 	}
 
 	offset = *cursor;
-	*found_size = MIN(*cursor_end - offset, max_size);
+	uint64_t cand_size = MIN(*cursor_end - offset, max_size);
+	if (size != max_size)
+		cand_size = rounddown(cand_size, mult);
+	else
+		ASSERT0(cand_size % mult);
+	ASSERT3U(cand_size, >=, size);
+
+	*found_size = cand_size;
 	*cursor = offset + *found_size;
 
 	return (offset);
@@ -2030,6 +2058,7 @@ metaslab_ndf_alloc(metaslab_t *msp, uint64_t size, uint64_t max_size,
 	uint64_t hbit = highbit64(max_size);
 	uint64_t *cursor = &msp->ms_lbas[hbit - 1];
 	uint64_t max_possible_size = metaslab_largest_allocatable(msp);
+	uint64_t mult = vdev_alloc_factor(msp->ms_group->mg_vd);
 
 	ASSERT(MUTEX_HELD(&msp->ms_lock));
 
@@ -2064,8 +2093,14 @@ metaslab_ndf_alloc(metaslab_t *msp, uint64_t size, uint64_t max_size,
 	}
 
 	if ((zfs_rs_get_end(rs, rt) - zfs_rs_get_start(rs, rt)) >= size) {
-		*found_size = MIN(zfs_rs_get_end(rs, rt) -
+		uint64_t cand_size = MIN(zfs_rs_get_end(rs, rt) -
 		    zfs_rs_get_start(rs, rt), max_size);
+		if (size != max_size)
+			cand_size = rounddown(cand_size, mult);
+		else
+			ASSERT0(cand_size % mult);
+		ASSERT3U(cand_size, >=, size);
+		*found_size = cand_size;
 		*cursor = zfs_rs_get_start(rs, rt) + *found_size;
 		return (zfs_rs_get_start(rs, rt));
 	}

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -4446,6 +4446,14 @@ vdev_psize_to_asize(vdev_t *vd, uint64_t psize)
 	return (vdev_psize_to_asize_txg(vd, psize, 0));
 }
 
+uint64_t
+vdev_alloc_factor(vdev_t *vd)
+{
+	if (vd->vdev_ops->vdev_op_alloc_factor == NULL)
+		return (1ULL << vd->vdev_ashift);
+	return (vd->vdev_ops->vdev_op_alloc_factor(vd));
+}
+
 /*
  * Mark the given vdev faulted.  A faulted vdev behaves as if the device could
  * not be opened, and no I/O is attempted.

--- a/module/zfs/vdev_draid.c
+++ b/module/zfs/vdev_draid.c
@@ -2546,6 +2546,13 @@ vdev_draid_ndisks(vdev_t *vd)
 	return (vdc->vdc_ndisks);
 }
 
+static uint64_t
+vdev_draid_alloc_factor(vdev_t *vd)
+{
+	vdev_draid_config_t *vdc = vd->vdev_tsd;
+	return (vdc->vdc_groupwidth << vd->vdev_ashift);
+}
+
 vdev_ops_t vdev_draid_ops = {
 	.vdev_op_init = vdev_draid_init,
 	.vdev_op_fini = vdev_draid_fini,
@@ -2568,6 +2575,7 @@ vdev_ops_t vdev_draid_ops = {
 	.vdev_op_config_generate = vdev_draid_config_generate,
 	.vdev_op_nparity = vdev_draid_nparity,
 	.vdev_op_ndisks = vdev_draid_ndisks,
+	.vdev_op_alloc_factor = vdev_draid_alloc_factor,
 	.vdev_op_type = VDEV_TYPE_DRAID,
 	.vdev_op_leaf = B_FALSE,
 };

--- a/module/zfs/vdev_raidz.c
+++ b/module/zfs/vdev_raidz.c
@@ -5545,6 +5545,12 @@ vdev_raidz_ndisks(vdev_t *vd)
 	return (vd->vdev_children);
 }
 
+static uint64_t
+vdev_raidz_alloc_factor(vdev_t *vd)
+{
+	return ((vdev_raidz_nparity(vd) + 1) << vd->vdev_ashift);
+}
+
 vdev_ops_t vdev_raidz_ops = {
 	.vdev_op_init = vdev_raidz_init,
 	.vdev_op_fini = vdev_raidz_fini,
@@ -5567,6 +5573,7 @@ vdev_ops_t vdev_raidz_ops = {
 	.vdev_op_config_generate = vdev_raidz_config_generate,
 	.vdev_op_nparity = vdev_raidz_nparity,
 	.vdev_op_ndisks = vdev_raidz_ndisks,
+	.vdev_op_alloc_factor = vdev_raidz_alloc_factor,
 	.vdev_op_type = VDEV_TYPE_RAIDZ,	/* name of this vdev type */
 	.vdev_op_leaf = B_FALSE			/* not a leaf vdev */
 };


### PR DESCRIPTION
_Sponsored by: [Klara, Inc.; Wasabi Technology, Inc.]_

### Motivation and Context
RAIDz vdevs always perform allocations in multiples of nparity + 1 sectors. This is to prevent fragmentation from leaving small scattered records everywhere that cannot be allocated and just pollute the spacemaps. This rule was always preserved until the introduction of the allocation range code, which allows allocation of not just specific sizes, but anywhere in a range. The sizes that end up being allocated may not be a multiple of nparity + 1 sectors in certain cases (primarily when the allocation is at the end of a metaslab).  If that happens, when converting from the asize to the psize and back, we can end up with two different psize values, which can theoretically cause issues in a few different ways.

### Description
This PR adds logic to the metaslab code to check if there is a factor that the allocations must be a multiple of, and if we're doing a dynamically sized allocation, ensures that the allocation meets that requirement.

### How Has This Been Tested?
I have a reliable reproducer using the anyraidz vdev type from the anyraid phase 2 PR. That reproducer consistently panicked before this change, and works correctly after. That said, because it is in that PR, it is not trivial to add a test case for it here. I plan to include that test in that PR, or add it in a separate one once that PR has landed.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
