### PR TITLE
icp: add aarch64 asm_linkage.h and use it in the aarch64 assembly

### DIFF
--- a/include/os/freebsd/Makefile.am
+++ b/include/os/freebsd/Makefile.am
@@ -5,6 +5,7 @@ noinst_HEADERS = \
 	\
 	%D%/spl/acl/acl_common.h \
 	\
+	%D%/spl/sys/aarch64/asm_linkage.h \
 	%D%/spl/sys/ia32/asm_linkage.h \
 	\
 	%D%/spl/sys/acl.h \

--- a/include/os/freebsd/spl/sys/aarch64/asm_linkage.h
+++ b/include/os/freebsd/spl/sys/aarch64/asm_linkage.h
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: CDDL-1.0
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * https://opensource.org/license/CDDL-1.0.
+ */
+
+#ifndef _AARCH64_SYS_ASM_LINKAGE_H
+#define	_AARCH64_SYS_ASM_LINKAGE_H
+
+#define	SECTION_TEXT .text
+#define	SECTION_STATIC .section .rodata
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+#ifdef _ASM	/* The remainder of this file is only for assembly files */
+
+#define	ASM_ENTRY_ALIGN	16
+
+/*
+ * ENTRY provides the standard procedure entry code.  Note that it emits
+ * no instructions of its own: AArch64 callees differ in their prologue
+ * (BTI landing pads vs. pointer authentication), so each function states
+ * its own.
+ */
+#undef ENTRY
+#define	ENTRY(x) \
+	.text; \
+	.balign	ASM_ENTRY_ALIGN; \
+	.globl	x; \
+	.type	x, %function; \
+x:
+
+#define	ENTRY_ALIGN(x, a) \
+	.text; \
+	.balign	a; \
+	.globl	x; \
+	.type	x, %function; \
+x:
+
+#define	FUNCTION(x) \
+	.type	x, %function; \
+x:
+
+/*
+ * SET_SIZE trails a function and set the size for the ELF symbol table.
+ */
+#define	SET_SIZE(x) \
+	.size	x, [.-x]
+
+#define	SET_OBJ(x) .type	x, %object
+
+/*
+ * LOCAL_LABEL defines a label which should not appear in the symbol table.
+ */
+#define	LOCAL_LABEL(x) .L##x
+
+#endif /* _ASM */
+
+#ifdef	__cplusplus
+}
+#endif
+
+#endif	/* _AARCH64_SYS_ASM_LINKAGE_H */

--- a/include/os/linux/Makefile.am
+++ b/include/os/linux/Makefile.am
@@ -120,4 +120,8 @@ kernel_spl_sys_HEADERS = \
 kernel_spl_ia32dir = $(kernel_spl_sysdir)/ia32
 kernel_spl_ia32_HEADERS = \
 	%D%/spl/sys/ia32/asm_linkage.h
+
+kernel_spl_aarch64dir = $(kernel_spl_sysdir)/aarch64
+kernel_spl_aarch64_HEADERS = \
+	%D%/spl/sys/aarch64/asm_linkage.h
 endif

--- a/include/os/linux/spl/sys/aarch64/asm_linkage.h
+++ b/include/os/linux/spl/sys/aarch64/asm_linkage.h
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: CDDL-1.0
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * https://opensource.org/license/CDDL-1.0.
+ */
+
+#ifndef _AARCH64_SYS_ASM_LINKAGE_H
+#define	_AARCH64_SYS_ASM_LINKAGE_H
+
+#if defined(_KERNEL) && defined(__linux__)
+#include <linux/linkage.h>
+#endif
+
+#define	SECTION_TEXT .text
+#define	SECTION_STATIC .section .rodata
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+#ifdef _ASM	/* The remainder of this file is only for assembly files */
+
+#define	ASM_ENTRY_ALIGN	16
+
+/*
+ * ENTRY provides the standard procedure entry code.  Note that it emits
+ * no instructions of its own: AArch64 callees differ in their prologue
+ * (BTI landing pads vs. pointer authentication), so each function states
+ * its own.
+ */
+#undef ENTRY
+#define	ENTRY(x) \
+	.text; \
+	.balign	ASM_ENTRY_ALIGN; \
+	.globl	x; \
+	.type	x, %function; \
+x:
+
+#define	ENTRY_ALIGN(x, a) \
+	.text; \
+	.balign	a; \
+	.globl	x; \
+	.type	x, %function; \
+x:
+
+#define	FUNCTION(x) \
+	.type	x, %function; \
+x:
+
+/*
+ * SET_SIZE trails a function and set the size for the ELF symbol table.
+ */
+#define	SET_SIZE(x) \
+	.size	x, [.-x]
+
+#define	SET_OBJ(x) .type	x, %object
+
+/*
+ * LOCAL_LABEL defines a label which should not appear in the symbol table.
+ */
+#define	LOCAL_LABEL(x) .L##x
+
+#endif /* _ASM */
+
+#ifdef	__cplusplus
+}
+#endif
+
+#endif	/* _AARCH64_SYS_ASM_LINKAGE_H */

--- a/include/sys/asm_linkage.h
+++ b/include/sys/asm_linkage.h
@@ -23,6 +23,10 @@
 
 #include <sys/ia32/asm_linkage.h>	/* XX64	x86/sys/asm_linkage.h */
 
+#elif defined(__aarch64__)
+
+#include <sys/aarch64/asm_linkage.h>
+
 #endif
 
 #if defined(_KERNEL) && defined(HAVE_KERNEL_OBJTOOL)

--- a/lib/libspl/include/Makefile.am
+++ b/lib/libspl/include/Makefile.am
@@ -79,6 +79,7 @@ libspl_sys_HEADERS = \
 	%D%/sys/zone.h
 
 libspl_ia32dir = $(libspldir)/sys/ia32
+libspl_aarch64dir = $(libspldir)/sys/aarch64
 
 if BUILD_LINUX
 libspl_sys_HEADERS += \
@@ -92,6 +93,9 @@ libspl_sys_HEADERS += \
 
 libspl_ia32_HEADERS = \
 	%D%/os/linux/sys/ia32/asm_linkage.h
+
+libspl_aarch64_HEADERS = \
+	%D%/os/linux/sys/aarch64/asm_linkage.h
 endif
 
 if BUILD_FREEBSD
@@ -107,6 +111,9 @@ libspl_sys_HEADERS += \
 
 libspl_ia32_HEADERS = \
 	%D%/os/freebsd/sys/ia32/asm_linkage.h
+
+libspl_aarch64_HEADERS = \
+	%D%/os/freebsd/sys/aarch64/asm_linkage.h
 endif
 
 

--- a/lib/libspl/include/os/freebsd/sys/aarch64/asm_linkage.h
+++ b/lib/libspl/include/os/freebsd/sys/aarch64/asm_linkage.h
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: CDDL-1.0
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * https://opensource.org/license/CDDL-1.0.
+ */
+
+#ifndef _AARCH64_SYS_ASM_LINKAGE_H
+#define	_AARCH64_SYS_ASM_LINKAGE_H
+
+#define	SECTION_TEXT .text
+#define	SECTION_STATIC .section .rodata
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+#ifdef _ASM	/* The remainder of this file is only for assembly files */
+
+#define	ASM_ENTRY_ALIGN	16
+
+/*
+ * ENTRY provides the standard procedure entry code.  Note that it emits
+ * no instructions of its own: AArch64 callees differ in their prologue
+ * (BTI landing pads vs. pointer authentication), so each function states
+ * its own.
+ */
+#undef ENTRY
+#define	ENTRY(x) \
+	.text; \
+	.balign	ASM_ENTRY_ALIGN; \
+	.globl	x; \
+	.type	x, %function; \
+x:
+
+#define	ENTRY_ALIGN(x, a) \
+	.text; \
+	.balign	a; \
+	.globl	x; \
+	.type	x, %function; \
+x:
+
+#define	FUNCTION(x) \
+	.type	x, %function; \
+x:
+
+/*
+ * SET_SIZE trails a function and set the size for the ELF symbol table.
+ */
+#define	SET_SIZE(x) \
+	.size	x, [.-x]
+
+#define	SET_OBJ(x) .type	x, %object
+
+/*
+ * LOCAL_LABEL defines a label which should not appear in the symbol table.
+ */
+#define	LOCAL_LABEL(x) .L##x
+
+#endif /* _ASM */
+
+#ifdef	__cplusplus
+}
+#endif
+
+#endif	/* _AARCH64_SYS_ASM_LINKAGE_H */

--- a/lib/libspl/include/os/linux/sys/aarch64/asm_linkage.h
+++ b/lib/libspl/include/os/linux/sys/aarch64/asm_linkage.h
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: CDDL-1.0
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * https://opensource.org/license/CDDL-1.0.
+ */
+
+#ifndef _AARCH64_SYS_ASM_LINKAGE_H
+#define	_AARCH64_SYS_ASM_LINKAGE_H
+
+#if defined(_KERNEL) && defined(__linux__)
+#include <linux/linkage.h>
+#endif
+
+#define	SECTION_TEXT .text
+#define	SECTION_STATIC .section .rodata
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+#ifdef _ASM	/* The remainder of this file is only for assembly files */
+
+#define	ASM_ENTRY_ALIGN	16
+
+/*
+ * ENTRY provides the standard procedure entry code.  Note that it emits
+ * no instructions of its own: AArch64 callees differ in their prologue
+ * (BTI landing pads vs. pointer authentication), so each function states
+ * its own.
+ */
+#undef ENTRY
+#define	ENTRY(x) \
+	.text; \
+	.balign	ASM_ENTRY_ALIGN; \
+	.globl	x; \
+	.type	x, %function; \
+x:
+
+#define	ENTRY_ALIGN(x, a) \
+	.text; \
+	.balign	a; \
+	.globl	x; \
+	.type	x, %function; \
+x:
+
+#define	FUNCTION(x) \
+	.type	x, %function; \
+x:
+
+/*
+ * SET_SIZE trails a function and set the size for the ELF symbol table.
+ */
+#define	SET_SIZE(x) \
+	.size	x, [.-x]
+
+#define	SET_OBJ(x) .type	x, %object
+
+/*
+ * LOCAL_LABEL defines a label which should not appear in the symbol table.
+ */
+#define	LOCAL_LABEL(x) .L##x
+
+#endif /* _ASM */
+
+#ifdef	__cplusplus
+}
+#endif
+
+#endif	/* _AARCH64_SYS_ASM_LINKAGE_H */

--- a/lib/libspl/include/sys/asm_linkage.h
+++ b/lib/libspl/include/sys/asm_linkage.h
@@ -21,6 +21,10 @@
 
 #include <sys/ia32/asm_linkage.h>	/* XX64	x86/sys/asm_linkage.h */
 
+#elif defined(__aarch64__)
+
+#include <sys/aarch64/asm_linkage.h>
+
 #endif
 
 #if defined(_KERNEL) && defined(HAVE_KERNEL_OBJTOOL)

--- a/module/icp/asm-aarch64/blake3/b3_aarch64_sse2.S
+++ b/module/icp/asm-aarch64/blake3/b3_aarch64_sse2.S
@@ -22,6 +22,9 @@
  * see: https://github.com/mcmilk/BLAKE3-tests/blob/master/contrib/simde.sh
  */
 
+#define	_ASM
+#include <sys/asm_linkage.h>
+
 #if defined(__aarch64__)
 
 /* check for .cfi_negate_ra_state assembler support */
@@ -31,7 +34,7 @@
 #define CFI_NEGATE_RA_STATE
 #endif
 
-	.text
+SECTION_TEXT
 	.section	.note.gnu.property,"a",@note
 	.p2align	3
 	.word	4
@@ -43,11 +46,8 @@
 	.word	3
 	.word	0
 .Lsec_end0:
-	.text
-	.globl	zfs_blake3_compress_in_place_sse2
-	.p2align	2
-	.type	zfs_blake3_compress_in_place_sse2,@function
-zfs_blake3_compress_in_place_sse2:
+SECTION_TEXT
+ENTRY_ALIGN(zfs_blake3_compress_in_place_sse2, 4)
 	.cfi_startproc
 	hint	#25
 	CFI_NEGATE_RA_STATE
@@ -78,7 +78,7 @@ zfs_blake3_compress_in_place_sse2:
 	hint	#29
 	ret
 .Lfunc_end0:
-	.size	zfs_blake3_compress_in_place_sse2, .Lfunc_end0-zfs_blake3_compress_in_place_sse2
+SET_SIZE(zfs_blake3_compress_in_place_sse2)
 	.cfi_endproc
 
 	.section	.rodata.cst16,"aM",@progbits,16
@@ -86,10 +86,9 @@ zfs_blake3_compress_in_place_sse2:
 .LCPI1_0:
 	.xword	-4942790177982912921
 	.xword	-6534734903820487822
-	.text
-	.p2align	2
-	.type	compress_pre,@function
-compress_pre:
+SECTION_TEXT
+	.balign	4
+FUNCTION(compress_pre)
 	.cfi_startproc
 	hint	#34
 	fmov	s1, w3
@@ -545,13 +544,10 @@ compress_pre:
 	stp	q0, q1, [x0]
 	ret
 .Lfunc_end1:
-	.size	compress_pre, .Lfunc_end1-compress_pre
+SET_SIZE(compress_pre)
 	.cfi_endproc
 
-	.globl	zfs_blake3_compress_xof_sse2
-	.p2align	2
-	.type	zfs_blake3_compress_xof_sse2,@function
-zfs_blake3_compress_xof_sse2:
+ENTRY_ALIGN(zfs_blake3_compress_xof_sse2, 4)
 	.cfi_startproc
 	hint	#25
 	CFI_NEGATE_RA_STATE
@@ -590,7 +586,7 @@ zfs_blake3_compress_xof_sse2:
 	hint	#29
 	ret
 .Lfunc_end2:
-	.size	zfs_blake3_compress_xof_sse2, .Lfunc_end2-zfs_blake3_compress_xof_sse2
+SET_SIZE(zfs_blake3_compress_xof_sse2)
 	.cfi_endproc
 
 	.section	.rodata.cst16,"aM",@progbits,16
@@ -600,11 +596,8 @@ zfs_blake3_compress_xof_sse2:
 	.word	1
 	.word	2
 	.word	3
-	.text
-	.globl	zfs_blake3_hash_many_sse2
-	.p2align	2
-	.type	zfs_blake3_hash_many_sse2,@function
-zfs_blake3_hash_many_sse2:
+SECTION_TEXT
+ENTRY_ALIGN(zfs_blake3_hash_many_sse2, 4)
 	.cfi_startproc
 	hint	#25
 	CFI_NEGATE_RA_STATE
@@ -2054,7 +2047,7 @@ zfs_blake3_hash_many_sse2:
 	hint	#29
 	ret
 .Lfunc_end3:
-	.size	zfs_blake3_hash_many_sse2, .Lfunc_end3-zfs_blake3_hash_many_sse2
+SET_SIZE(zfs_blake3_hash_many_sse2)
 	.cfi_endproc
 	.section	".note.GNU-stack","",@progbits
 #endif

--- a/module/icp/asm-aarch64/blake3/b3_aarch64_sse41.S
+++ b/module/icp/asm-aarch64/blake3/b3_aarch64_sse41.S
@@ -22,6 +22,9 @@
  * see: https://github.com/mcmilk/BLAKE3-tests/blob/master/contrib/simde.sh
  */
 
+#define	_ASM
+#include <sys/asm_linkage.h>
+
 #if defined(__aarch64__)
 
 /* check for .cfi_negate_ra_state assembler support */
@@ -31,7 +34,7 @@
 #define CFI_NEGATE_RA_STATE
 #endif
 
-	.text
+SECTION_TEXT
 	.section	.note.gnu.property,"a",@note
 	.p2align	3
 	.word	4
@@ -43,11 +46,8 @@
 	.word	3
 	.word	0
 .Lsec_end0:
-	.text
-	.globl	zfs_blake3_compress_in_place_sse41
-	.p2align	2
-	.type	zfs_blake3_compress_in_place_sse41,@function
-zfs_blake3_compress_in_place_sse41:
+SECTION_TEXT
+ENTRY_ALIGN(zfs_blake3_compress_in_place_sse41, 4)
 	.cfi_startproc
 	hint	#25
 	CFI_NEGATE_RA_STATE
@@ -78,7 +78,7 @@ zfs_blake3_compress_in_place_sse41:
 	hint	#29
 	ret
 .Lfunc_end0:
-	.size	zfs_blake3_compress_in_place_sse41, .Lfunc_end0-zfs_blake3_compress_in_place_sse41
+SET_SIZE(zfs_blake3_compress_in_place_sse41)
 	.cfi_endproc
 
 	.section	.rodata.cst16,"aM",@progbits,16
@@ -120,10 +120,9 @@ zfs_blake3_compress_in_place_sse41:
 	.byte	14
 	.byte	15
 	.byte	12
-	.text
-	.p2align	2
-	.type	compress_pre,@function
-compress_pre:
+SECTION_TEXT
+	.balign	4
+FUNCTION(compress_pre)
 	.cfi_startproc
 	hint	#34
 	fmov	s1, w3
@@ -555,13 +554,10 @@ compress_pre:
 	stp	q2, q3, [x0]
 	ret
 .Lfunc_end1:
-	.size	compress_pre, .Lfunc_end1-compress_pre
+SET_SIZE(compress_pre)
 	.cfi_endproc
 
-	.globl	zfs_blake3_compress_xof_sse41
-	.p2align	2
-	.type	zfs_blake3_compress_xof_sse41,@function
-zfs_blake3_compress_xof_sse41:
+ENTRY_ALIGN(zfs_blake3_compress_xof_sse41, 4)
 	.cfi_startproc
 	hint	#25
 	CFI_NEGATE_RA_STATE
@@ -600,7 +596,7 @@ zfs_blake3_compress_xof_sse41:
 	hint	#29
 	ret
 .Lfunc_end2:
-	.size	zfs_blake3_compress_xof_sse41, .Lfunc_end2-zfs_blake3_compress_xof_sse41
+SET_SIZE(zfs_blake3_compress_xof_sse41)
 	.cfi_endproc
 
 	.section	.rodata.cst16,"aM",@progbits,16
@@ -649,11 +645,8 @@ zfs_blake3_compress_xof_sse41:
 	.word	3144134277
 	.word	1013904242
 	.word	2773480762
-	.text
-	.globl	zfs_blake3_hash_many_sse41
-	.p2align	2
-	.type	zfs_blake3_hash_many_sse41,@function
-zfs_blake3_hash_many_sse41:
+SECTION_TEXT
+ENTRY_ALIGN(zfs_blake3_hash_many_sse41, 4)
 	.cfi_startproc
 	hint	#34
 	stp	d15, d14, [sp, #-144]!
@@ -2391,7 +2384,7 @@ zfs_blake3_hash_many_sse41:
 	ldp	d15, d14, [sp], #144
 	ret
 .Lfunc_end3:
-	.size	zfs_blake3_hash_many_sse41, .Lfunc_end3-zfs_blake3_hash_many_sse41
+SET_SIZE(zfs_blake3_hash_many_sse41)
 	.cfi_endproc
 	.section	".note.GNU-stack","",@progbits
 #endif

--- a/module/icp/asm-aarch64/sha2/sha256-armv8.S
+++ b/module/icp/asm-aarch64/sha2/sha256-armv8.S
@@ -20,6 +20,9 @@
  * - modified assembly to fit into OpenZFS
  */
 
+#define	_ASM
+#include <sys/asm_linkage.h>
+
 #if defined(__aarch64__)
 
 	.section	.note.gnu.property,"a",@note
@@ -32,10 +35,10 @@
 	.word	4
 	.word	3
 	.word	0
-.text
+SECTION_TEXT
 
-.align	6
-.type	.LK256,%object
+.balign	64
+SET_OBJ(.LK256)
 .LK256:
 	.long	0x428a2f98,0x71374491,0xb5c0fbcf,0xe9b5dba5
 	.long	0x3956c25b,0x59f111f1,0x923f82a4,0xab1c5ed5
@@ -54,12 +57,9 @@
 	.long	0x748f82ee,0x78a5636f,0x84c87814,0x8cc70208
 	.long	0x90befffa,0xa4506ceb,0xbef9a3f7,0xc67178f2
 	.long	0	//terminator
-.size	.LK256,.-.LK256
+SET_SIZE(.LK256)
 
-.globl	zfs_sha256_block_armv7
-.type	zfs_sha256_block_armv7,%function
-.align	6
-zfs_sha256_block_armv7:
+ENTRY_ALIGN(zfs_sha256_block_armv7, 64)
 	hint	#34					// bti c
 	stp	x29,x30,[sp,#-128]!
 	add	x29,sp,#0
@@ -1021,12 +1021,9 @@ zfs_sha256_block_armv7:
 	ldp	x27,x28,[x29,#80]
 	ldp	x29,x30,[sp],#128
 	ret
-.size	zfs_sha256_block_armv7,.-zfs_sha256_block_armv7
+SET_SIZE(zfs_sha256_block_armv7)
 
-.globl	zfs_sha256_block_armv8
-.type	zfs_sha256_block_armv8,%function
-.align	6
-zfs_sha256_block_armv8:
+ENTRY_ALIGN(zfs_sha256_block_armv8, 64)
 	hint		#34				// bti c
 .Lv8_entry:
 	stp		x29,x30,[sp,#-16]!
@@ -1162,12 +1159,9 @@ zfs_sha256_block_armv8:
 
 	ldr		x29,[sp],#16
 	ret
-.size	zfs_sha256_block_armv8,.-zfs_sha256_block_armv8
+SET_SIZE(zfs_sha256_block_armv8)
 
-.globl	zfs_sha256_block_neon
-.type	zfs_sha256_block_neon,%function
-.align	4
-zfs_sha256_block_neon:
+ENTRY_ALIGN(zfs_sha256_block_neon, 16)
 	hint	#34					// bti c
 .Lneon_entry:
 	stp	x29, x30, [sp, #-16]!
@@ -2008,6 +2002,6 @@ zfs_sha256_block_neon:
 	ldr	x29,[x29]
 	add	sp,sp,#16*4+16
 	ret
-.size	zfs_sha256_block_neon,.-zfs_sha256_block_neon
+SET_SIZE(zfs_sha256_block_neon)
 
 #endif

--- a/module/icp/asm-aarch64/sha2/sha512-armv8.S
+++ b/module/icp/asm-aarch64/sha2/sha512-armv8.S
@@ -20,6 +20,9 @@
  * - modified assembly to fit into OpenZFS
  */
 
+#define	_ASM
+#include <sys/asm_linkage.h>
+
 #if defined(__aarch64__)
 
 	.section	.note.gnu.property,"a",@note
@@ -32,10 +35,10 @@
 	.word	4
 	.word	3
 	.word	0
-.text
+SECTION_TEXT
 
-.align	6
-.type	.LK512,%object
+.balign	64
+SET_OBJ(.LK512)
 .LK512:
 	.quad	0x428a2f98d728ae22,0x7137449123ef65cd
 	.quad	0xb5c0fbcfec4d3b2f,0xe9b5dba58189dbbc
@@ -78,12 +81,9 @@
 	.quad	0x4cc5d4becb3e42b6,0x597f299cfc657e2a
 	.quad	0x5fcb6fab3ad6faec,0x6c44198c4a475817
 	.quad	0	// terminator
-.size	.LK512,.-.LK512
+SET_SIZE(.LK512)
 
-.globl	zfs_sha512_block_armv7
-.type	zfs_sha512_block_armv7,%function
-.align	6
-zfs_sha512_block_armv7:
+ENTRY_ALIGN(zfs_sha512_block_armv7, 64)
 	hint	#34					// bti c
 	stp	x29,x30,[sp,#-128]!
 	add	x29,sp,#0
@@ -1045,13 +1045,10 @@ zfs_sha512_block_armv7:
 	ldp	x27,x28,[x29,#80]
 	ldp	x29,x30,[sp],#128
 	ret
-.size	zfs_sha512_block_armv7,.-zfs_sha512_block_armv7
+SET_SIZE(zfs_sha512_block_armv7)
 
 
-.globl	zfs_sha512_block_armv8
-.type	zfs_sha512_block_armv8,%function
-.align	6
-zfs_sha512_block_armv8:
+ENTRY_ALIGN(zfs_sha512_block_armv8, 64)
 	hint		#34				// bti c
 .Lv8_entry:
 	// Armv8.3-A PAuth: even though x30 is pushed to stack it is not popped later
@@ -1567,5 +1564,5 @@ zfs_sha512_block_armv8:
 
 	ldr		x29,[sp],#16
 	ret
-.size	zfs_sha512_block_armv8,.-zfs_sha512_block_armv8
+SET_SIZE(zfs_sha512_block_armv8)
 #endif

--- a/module/lua/setjmp/setjmp_aarch64.S
+++ b/module/lua/setjmp/setjmp_aarch64.S
@@ -31,20 +31,12 @@
  */
 
 
+#define	_ASM
+#include <sys/asm_linkage.h>
+
 #ifdef __aarch64__
 
-#define	ENTRY(sym) \
-	.text; \
-	.globl	sym; \
-	.balign	2; \
-	.type	sym,#function; \
-sym:
-
-#define	END(sym) \
-	.size	sym, . - sym
-
-
-ENTRY(setjmp)
+ENTRY_ALIGN(setjmp, 2)
 	/* Store the stack pointer */
 	mov	x8, sp
 	str	x8, [x0], #8
@@ -60,9 +52,9 @@ ENTRY(setjmp)
 	/* Return value */
 	mov	x0, #0
 	ret
-END(setjmp)
+SET_SIZE(setjmp)
 
-ENTRY(longjmp)
+ENTRY_ALIGN(longjmp, 2)
 	/* Restore the stack pointer */
 	ldr	x8, [x0], #8
 	mov	sp, x8
@@ -78,7 +70,7 @@ ENTRY(longjmp)
 	/* Load the return value */
 	mov	x0, x1
 	ret
-END(longjmp)
+SET_SIZE(longjmp)
 
 #ifdef __ELF__
 .section .note.GNU-stack,"",%progbits

--- a/scripts/spdxcheck.pl
+++ b/scripts/spdxcheck.pl
@@ -266,6 +266,7 @@ my %override_file_license_tags = (
 		include/os/freebsd/spl/sys/sunddi.h
 	)],
 	'CDDL-1.0' => [qw(
+		include/os/linux/spl/sys/aarch64/asm_linkage.h
 		include/os/linux/spl/sys/errno.h
 		include/os/linux/spl/sys/ia32/asm_linkage.h
 		include/os/linux/spl/sys/misc.h


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

Commit 68c0771cc9 ("Unify Assembler files between Linux and Windows") introduced sys/ia32/asm_linkage.h so that x86 assembly could be written once and share a single set of ENTRY/SET_SIZE/LOCAL_LABEL macros across platforms.  aarch64 never got the same treatment, so its assembly still spells out .globl/.type/.size by hand, and each file that needs a different object format has to be forked or #ifdef'd.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
68c0771cc9 ("Unify Assembler files between Linux and Windows") introduced
`sys/ia32/asm_linkage.h` so x86 assembly could be written once and share one set
of `ENTRY`/`SET_SIZE`/`LOCAL_LABEL` macros across platforms and object formats.

aarch64 never got the same treatment. Its assembly still spells out
`.globl`/`.type`/`.size` by hand, so any platform whose object format differs
has to fork the file or `#ifdef` around every symbol. This finishes the job for
aarch64, using the same layout as ia32.

It is also a prerequisite for adding ARMv8 AES-GCM acceleration, whose assembly
is written against these macros.


### Description
<!--- Describe your changes in detail -->

- Add `sys/aarch64/asm_linkage.h` for Linux and FreeBSD, kernel and libspl —
  four files mirroring the existing `ia32` layout, including which parts the
  FreeBSD copies omit.
- Wire the `__aarch64__` branch into both dispatchers
  (`include/sys/asm_linkage.h`, `lib/libspl/include/sys/asm_linkage.h`).
- Convert the existing aarch64 assembly to the macros: `sha256-armv8.S`,
  `sha512-armv8.S`, `b3_aarch64_sse2.S`, `b3_aarch64_sse41.S`,
  `setjmp_aarch64.S`. The last of these had its own local `ENTRY`/`END`
  definitions, now removed.

One deliberate difference from the x86 macros: aarch64 `ENTRY` emits no
instructions of its own. Callees differ in their prologue — the SHA-2 code
starts with a BTI landing pad (`hint #34`), the BLAKE3 code with pointer
authentication (`hint #25`) — so each function continues to state its own. A
macro emitting a fixed prologue would corrupt one or the other.


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
