### PR TITLE
Fix casenorm ZTS tests

### DIFF
--- a/include/os/linux/zfs/sys/zpl.h
+++ b/include/os/linux/zfs/sys/zpl.h
@@ -50,6 +50,7 @@ extern void zpl_prune_sb(uint64_t nr_to_scan, void *arg);
 
 extern const struct super_operations zpl_super_operations;
 extern const struct dentry_operations zpl_dentry_operations;
+extern const struct dentry_operations zpl_folded_dentry_operations;
 extern const struct export_operations zpl_export_operations;
 extern struct file_system_type zpl_fs_type;
 

--- a/module/os/linux/zfs/zfs_vfsops.c
+++ b/module/os/linux/zfs/zfs_vfsops.c
@@ -1343,6 +1343,7 @@ zfs_domount(struct super_block *sb, const char *osname,
 	zfsvfs_t *zfsvfs = NULL;
 	int canwrite;
 	int dataset_visible_zone;
+	int fold;
 
 	dataset_visible_zone = zone_dataset_visible(osname, &canwrite);
 
@@ -1392,10 +1393,16 @@ zfs_domount(struct super_block *sb, const char *osname,
 	sb->s_xattr = zpl_xattr_handlers;
 	sb->s_export_op = &zpl_export_operations;
 
+	fold = zfsvfs->z_norm;
+	if (zfsvfs->z_case == ZFS_CASE_MIXED)
+		fold &= ~U8_TEXTPREP_TOUPPER;
+
 #ifdef HAVE_SET_DEFAULT_D_OP
-	set_default_d_op(sb, &zpl_dentry_operations);
+	set_default_d_op(sb, (fold != 0) ? &zpl_folded_dentry_operations :
+	    &zpl_dentry_operations);
 #else
-	sb->s_d_op = &zpl_dentry_operations;
+	sb->s_d_op = (fold != 0) ? &zpl_folded_dentry_operations :
+	    &zpl_dentry_operations;
 #endif
 
 	/* Set features for file system. */

--- a/module/os/linux/zfs/zpl_inode.c
+++ b/module/os/linux/zfs/zpl_inode.c
@@ -32,12 +32,9 @@ static struct dentry *
 zpl_lookup(struct inode *dir, struct dentry *dentry, unsigned int flags)
 {
 	cred_t *cr = CRED();
-	struct inode *ip;
 	znode_t *zp;
 	int error;
 	fstrans_cookie_t cookie;
-	pathname_t *ppn = NULL;
-	pathname_t pn;
 	int zfs_flags = 0;
 	zfsvfs_t *zfsvfs = dentry->d_sb->s_fs_info;
 	dsl_dataset_t *ds = dmu_objset_ds(zfsvfs->z_os);
@@ -67,15 +64,11 @@ zpl_lookup(struct inode *dir, struct dentry *dentry, unsigned int flags)
 	crhold(cr);
 	cookie = spl_fstrans_mark();
 
-	/* If we are a case insensitive fs, we need the real name */
-	if (zfsvfs->z_case == ZFS_CASE_INSENSITIVE) {
+	if (zfsvfs->z_case == ZFS_CASE_INSENSITIVE)
 		zfs_flags = FIGNORECASE;
-		pn_alloc(&pn);
-		ppn = &pn;
-	}
 
 	error = -zfs_lookup(ITOZ(dir), dname(dentry), &zp,
-	    zfs_flags, cr, NULL, ppn);
+	    zfs_flags, cr, NULL, NULL);
 	spl_fstrans_unmark(cookie);
 	ASSERT3S(error, <=, 0);
 	crfree(cr);
@@ -85,44 +78,13 @@ zpl_lookup(struct inode *dir, struct dentry *dentry, unsigned int flags)
 	spin_unlock(&dentry->d_lock);
 
 	if (error) {
-		/*
-		 * If we have a case sensitive fs, we do not want to
-		 * insert negative entries, so return NULL for ENOENT.
-		 * Fall through if the error is not ENOENT. Also free memory.
-		 */
-		if (ppn) {
-			pn_free(ppn);
-			if (error == -ENOENT)
-				return (NULL);
-		}
-
 		if (error == -ENOENT)
 			return (d_splice_alias(NULL, dentry));
 		else
 			return (ERR_PTR(error));
 	}
-	ip = ZTOI(zp);
 
-	/*
-	 * If we are case insensitive, call the correct function
-	 * to install the name.
-	 */
-	if (ppn) {
-		struct dentry *new_dentry;
-		struct qstr ci_name;
-
-		if (strcmp(dname(dentry), pn.pn_buf) == 0) {
-			new_dentry = d_splice_alias(ip,  dentry);
-		} else {
-			ci_name.name = pn.pn_buf;
-			ci_name.len = strlen(pn.pn_buf);
-			new_dentry = d_add_ci(dentry, ip, &ci_name);
-		}
-		pn_free(ppn);
-		return (new_dentry);
-	} else {
-		return (d_splice_alias(ip, dentry));
-	}
+	return (d_splice_alias(ZTOI(zp), dentry));
 }
 
 void

--- a/module/os/linux/zfs/zpl_super.c
+++ b/module/os/linux/zfs/zpl_super.c
@@ -23,6 +23,8 @@
 #include <sys/zfs_vnops.h>
 #include <sys/zfs_ctldir.h>
 #include <sys/zpl.h>
+#include <sys/u8_textprep.h>
+#include <sys/fs/zfs.h>
 #include <linux/iversion.h>
 #include <linux/version.h>
 #include <linux/vfs_compat.h>
@@ -1054,6 +1056,211 @@ const struct super_operations zpl_super_operations = {
 };
 
 /*
+ * ->d_hash() is called from a RCU context that cannot sleep, so we cannot do
+ * KM_SLEEP allocations. ZAP_MAXNAMELEN_NEW length long names are up to 1024
+ * bytes, inclusive of the NULL terminating character. Kernel stack space is
+ * limited, and we can potentially be given even longer invalid names, so
+ * instead of allocating all memory at once, we allocate ZAP_MAXNAMELEN (256)
+ * bytes on the stack, and operate incrementally on it.
+ *
+ * The incremental hash function is slow compared to the non-incremental hash
+ * function, so we unroll the first loop iteration and check for the case that
+ * only 1 iteration is necessary. In that case, we call full_name_hash().
+ * Otherwise, we proceed to calculate the hash incrementally.
+ *
+ * These two methods of calculation do not produce the same hash, but since we
+ * have a stable partition of names on which each is used, calling this
+ * function to hash a given name will always return the same value, so using
+ * two different hash functions is fine.
+ *
+ * Incremental calculation allows us to handle special cases such as form NFKD
+ * causing us to run out of buffer space and users trying to open files with
+ * longer file names than we support. In both cases, we always return a hash.
+ * This would not be possible if we allocated a ZAP_MAXNAMELEN_NEW (1024) byte
+ * buffer.
+ *
+ * Unicode places no limit on how many combining marks can follow a base
+ * character, so a normalizer that has to buffer an entire combining sequence
+ * before it can reorder and compose has no bound on its buffer. Stream-Safe
+ * Text caps a sequence at 30 non-starters and inserts U+034F COMBINING
+ * GRAPHEME JOINER to break it. ZAP_MAXNAMELEN is a sufficiently large buffer
+ * to accommodate this.
+ *
+ * This assumes that the filesystem is a folding filesystem. It is missing the
+ * special case on flags == 0 to be used generally.
+ */
+static int
+zpl_dentry_hash(const struct dentry *dentry, struct qstr *qstr)
+{
+	zfsvfs_t *zfsvfs = dentry->d_sb->s_fs_info;
+	int flags = zfsvfs->z_norm;
+	char out[ZAP_MAXNAMELEN];
+	size_t rlen, blen, i, n;
+	unsigned long hash;
+	int err = 0;
+
+	if (qstr->len == 0) {
+		qstr->hash = full_name_hash(dentry, qstr->name, qstr->len);
+		return (0);
+	}
+
+	if (zfsvfs->z_case == ZFS_CASE_MIXED)
+		flags &= ~U8_TEXTPREP_TOUPPER;
+
+	flags |= U8_TEXTPREP_IGNORE_NULL | U8_TEXTPREP_IGNORE_INVALID;
+
+	rlen = qstr->len;
+	blen = sizeof (out);
+	(void) u8_textprep_str((char *)qstr->name, &rlen, out, &blen, flags,
+	    U8_UNICODE_LATEST, &err);
+
+	if (rlen == 0) {
+		qstr->hash = full_name_hash(dentry, out, sizeof (out) -
+		    blen);
+		return (0);
+	}
+
+	hash = init_name_hash(dentry);
+
+	n = sizeof (out) - blen;
+	for (i = 0; i < n; i++)
+		hash = partial_name_hash((unsigned char)out[i], hash);
+
+	do {
+		blen = sizeof (out);
+		(void) u8_textprep_str((char *)qstr->name + (qstr->len - rlen),
+		    &rlen, out, &blen, flags, U8_UNICODE_LATEST, &err);
+
+		n = sizeof (out) - blen;
+		for (i = 0; i < n; i++)
+			hash = partial_name_hash((unsigned char)out[i], hash);
+	} while (rlen > 0);
+
+	qstr->hash = end_name_hash(hash);
+	return (0);
+}
+
+/*
+ * ->d_compare() is called from a RCU context that cannot sleep, so we cannot
+ * do KM_SLEEP allocations. ZAP_MAXNAMELEN_NEW length long names are up to 1024
+ * bytes, inclusive of the NULL terminating character. We cannot stack allocate
+ * full buffers for those, so we implement a chunked comparison to support
+ * ZAP_MAXNAMELEN_NEW length long names.
+ *
+ * We may be given strings longer than ZAP_MAXNAMELEN_NEW-1 characters if a
+ * user tries to open a file with such a name. Additionally, strings may be
+ * path components, which are not NULL terminated. Care has been taken to
+ * handle both cases.
+ *
+ * This assumes that the filesystem is a folding filesystem. It is missing the
+ * special case on flags == 0 to be used generally.
+ */
+static int
+zpl_dentry_compare(const struct dentry *dentry, unsigned int len,
+    const char *str, const struct qstr *name)
+{
+	zfsvfs_t *zfsvfs = dentry->d_sb->s_fs_info;
+	int flags = zfsvfs->z_norm;
+	char str1[ZAP_MAXNAMELEN];
+	char str2[ZAP_MAXNAMELEN];
+	size_t rlen1, rlen2, blen1, blen2;
+	int err = 0;
+
+	/*
+	 * Names are often identical to each other pre-normalization, and when
+	 * they are, we can just memcmp() and skip normalization on a match.
+	 * When we do not have a match, we must normalize and then compare
+	 * again.
+	 */
+	if (len == name->len && memcmp(str, name->name, len) == 0)
+		return (0);
+
+	if (zfsvfs->z_case == ZFS_CASE_MIXED)
+		flags &= ~U8_TEXTPREP_TOUPPER;
+
+	flags |= U8_TEXTPREP_IGNORE_NULL | U8_TEXTPREP_IGNORE_INVALID;
+
+	rlen1 = len;
+	rlen2 = name->len;
+
+	do {
+		blen1 = sizeof (str1);
+		blen2 = sizeof (str2);
+
+		(void) u8_textprep_str((char *)&str[len - rlen1], &rlen1,
+		    str1, &blen1, flags, U8_UNICODE_LATEST, &err);
+		(void) u8_textprep_str((char *)&name->name[name->len - rlen2],
+		    &rlen2, str2, &blen2, flags, U8_UNICODE_LATEST, &err);
+
+		if (blen1 != blen2 || memcmp(str1, str2,
+		    sizeof (str1) - blen1) != 0)
+			return (1);
+
+	} while (rlen1 > 0 || rlen2 > 0);
+
+	return (0);
+}
+
+/*
+ * ->d_revalidate() is called when a dentry cache hit occurs, to check if the
+ *  entry is still valid.
+ *
+ * When dentry cache hit occurs on a negative dentry, the VFS will happily give
+ * the cached name to create/mkdir/link/symlink/mknod/rename. When we are on a
+ * filesystem that is case insensitive or normalizing, that causes us to make a
+ * file with a name other than what the user intended, which will be shown in
+ * getdents. This is a nuisance, so we implement ->d_revalidate to allow us to
+ * prevent the names of negative dentries from being reused on filesystems that
+ * are case insensitive or normalizing.
+ *
+ * This assumes that the filesystem is a folding filesystem. It is missing the
+ * special case on ->z_norm to be used generally.
+ */
+#ifdef HAVE_D_REVALIDATE_4ARGS
+static int
+zpl_dentry_revalidate(struct inode *dir, const struct qstr *name,
+    struct dentry *dentry, unsigned int flags)
+#else
+static int
+zpl_dentry_revalidate(struct dentry *dentry, unsigned int flags)
+#endif
+{
+	/* positive dentries are fine */
+	if (d_inode_rcu(dentry) != NULL)
+		return (1);
+
+	/*
+	 * NFSv2/3 calls lookup_one_len() in create, which passes flags==0.
+	 * (nfsd). When flags == 0, we cannot tell what the caller is doing, so
+	 * we must invalidate. Unfortunately, this affects some operations
+	 * where we do not want to invalidate, but we favor correctness over
+	 * speed.
+	 */
+	if (flags == 0)
+		return (0);
+
+	if (flags & (LOOKUP_CREATE | LOOKUP_RENAME_TARGET)) {
+#ifdef HAVE_D_REVALIDATE_4ARGS
+		(void) dir;
+		/*
+		 * If called from RCU, it is unsafe to check the name, so we
+		 * must return -ECHILD to be called outside of a RCU context.
+		 */
+		if (flags & LOOKUP_RCU)
+			return (-ECHILD);
+
+		if (name->len == dentry->d_name.len &&
+		    memcmp(name->name, dentry->d_name.name, name->len) == 0)
+			return (1);
+#endif
+		/* Do *NOT* reuse d_name. */
+		return (0);
+	}
+
+	return (1);
+}
+
+/*
  * ->d_delete() is called when the last reference to a dentry is released. Its
  *  return value indicates if the dentry should be destroyed immediately, or
  *  retained in the dentry cache.
@@ -1078,7 +1285,19 @@ zpl_dentry_delete(const struct dentry *dentry)
 	return (zfs_delete_dentry ? 1 : 0);
 }
 
+/*
+ * Overlayfs is incompatible with filesystems that fold filenames, so we
+ * maintain a non-folding version for non-folding filesystems, so that it might
+ * work on top of them.
+ */
 const struct dentry_operations zpl_dentry_operations = {
+	.d_delete = zpl_dentry_delete,
+};
+
+const struct dentry_operations zpl_folded_dentry_operations = {
+	.d_hash = zpl_dentry_hash,
+	.d_compare = zpl_dentry_compare,
+	.d_revalidate = zpl_dentry_revalidate,
 	.d_delete = zpl_dentry_delete,
 };
 

--- a/module/zfs/u8_textprep.c
+++ b/module/zfs/u8_textprep.c
@@ -2121,6 +2121,7 @@ u8_textprep_str(char *inarray, size_t *inlen, char *outarray, size_t *outlen,
 				ib++;
 				ob++;
 			} else {
+				uchar_t *ib_saved = ib;
 				*errnum = 0;
 				state = U8_STATE_START;
 
@@ -2141,6 +2142,7 @@ u8_textprep_str(char *inarray, size_t *inlen, char *outarray, size_t *outlen,
 				if ((obtail - ob) < j) {
 					*errnum = E2BIG;
 					ret_val = (size_t)-1;
+					ib = ib_saved;
 					break;
 				}
 

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -118,8 +118,8 @@ tests = ['case_all_values', 'norm_all_values', 'mixed_create_failure',
     'sensitive_formd_lookup', 'sensitive_formd_delete',
     'insensitive_none_lookup', 'insensitive_none_delete',
     'insensitive_formd_lookup', 'insensitive_formd_delete',
-    'mixed_none_lookup', 'mixed_none_lookup_ci', 'mixed_none_delete',
-    'mixed_formd_lookup', 'mixed_formd_lookup_ci', 'mixed_formd_delete']
+    'mixed_none_lookup', 'mixed_none_delete', 'mixed_formd_lookup',
+    'mixed_formd_delete']
 tags = ['functional', 'casenorm']
 
 [tests/functional/channel_program/lua_core]

--- a/tests/runfiles/sunos.run
+++ b/tests/runfiles/sunos.run
@@ -22,6 +22,10 @@ failsafe_user = root
 failsafe = callbacks/zfs_failsafe
 tags = ['functional']
 
+[tests/functional/casenorm:illumos]
+tests = ['mixed_none_lookup_ci', 'mixed_formd_lookup_ci']
+tags = ['functional', 'casenorm']
+
 [tests/functional/inuse:illumos]
 tests = ['inuse_001_pos', 'inuse_003_pos', 'inuse_006_pos', 'inuse_007_pos']
 post =

--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -159,8 +159,6 @@ else:
 # reasons listed above can be used.
 #
 known = {
-    'casenorm/mixed_none_lookup_ci': ['FAIL', 7633],
-    'casenorm/mixed_formd_lookup_ci': ['FAIL', 7633],
     'cli_root/zpool_import/import_rewind_device_replaced':
         ['FAIL', rewind_reason],
     'cli_user/misc/zfs_share_001_neg': ['SKIP', na_reason],
@@ -186,10 +184,6 @@ if sys.platform.startswith('freebsd'):
     })
 elif sys.platform.startswith('linux'):
     known.update({
-        'casenorm/mixed_formd_lookup': ['FAIL', 7633],
-        'casenorm/mixed_formd_delete': ['FAIL', 7633],
-        'casenorm/sensitive_formd_lookup': ['FAIL', 7633],
-        'casenorm/sensitive_formd_delete': ['FAIL', 7633],
         'removal/removal_with_zdb': ['SKIP', known_reason],
         'cli_root/zfs_unshare/zfs_unshare_002_pos': ['SKIP', na_reason],
     })


### PR DESCRIPTION
### Motivation and Context
It is about time we closed #7633.

### Description
mixed_formd_lookup_ci and mixed_none_lookup_ci rely on the VFS supporting FIGNORECASE, which is only supported on illumos-gate. As for the others, we  ->d_hash and ->d_compare in dentry_operations so the dentry cache works properly on case-insensitive filesystems on Linux.

### How Has This Been Tested?
The ZTS casenorm group has been run against it on Linux and FreeBSD.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
