### PR TITLE
DDT: Use proper size when calling kmem_free on ddt_prune_entry_t

### DIFF
--- a/module/zfs/ddt.c
+++ b/module/zfs/ddt.c
@@ -2722,6 +2722,9 @@ typedef struct ddt_prune_entry {
 	ddt_univ_phys_t	dpe_phys[];
 } ddt_prune_entry_t;
 
+#define	DDT_PRUNE_ENTRY_SIZE	\
+	(sizeof (ddt_prune_entry_t) + DDT_FLAT_PHYS_SIZE)
+
 typedef struct ddt_prune_info {
 	spa_t		*dpi_spa;
 	uint64_t	dpi_txg_syncs;
@@ -2754,7 +2757,7 @@ prune_candidates_sync(void *arg, dmu_tx_t *tx)
 		 */
 		if (avl_find(&ddt->ddt_tree, &dpe->dpe_key, NULL)) {
 			ddt_exit(ddt);
-			kmem_free(dpe, sizeof (*dpe));
+			kmem_free(dpe, DDT_PRUNE_ENTRY_SIZE);
 			continue;
 		}
 
@@ -2774,7 +2777,7 @@ prune_candidates_sync(void *arg, dmu_tx_t *tx)
 		}
 
 		ddt_exit(ddt);
-		kmem_free(dpe, sizeof (*dpe));
+		kmem_free(dpe, DDT_PRUNE_ENTRY_SIZE);
 	}
 
 	spa_config_exit(dpi->dpi_spa, SCL_ZIO, FTAG);
@@ -2791,8 +2794,7 @@ ddt_prune_entry(list_t *list, ddt_t *ddt, const ddt_key_t *ddk,
 {
 	ASSERT(ddt->ddt_flags & DDT_FLAG_FLAT);
 
-	size_t dpe_size = sizeof (ddt_prune_entry_t) + DDT_FLAT_PHYS_SIZE;
-	ddt_prune_entry_t *dpe = kmem_alloc(dpe_size, KM_SLEEP);
+	ddt_prune_entry_t *dpe = kmem_alloc(DDT_PRUNE_ENTRY_SIZE, KM_SLEEP);
 
 	dpe->dpe_ddt = ddt;
 	dpe->dpe_key = *ddk;


### PR DESCRIPTION
### Motivation and Context
Linux and FreeBSD do not need a correct size passed to kmem_free, but other platforms can.

### Description
We introduce a DDT_PRUNE_ENTRY_SIZE macro for kmem_free.

### How Has This Been Tested?
An out-of-tree OpenZFS platform panicked when running the ZTS. This patch was confirmed to fix the panic.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
