### PR TITLE
Fix metaslab count assertion in metaslab_group_alloc() for small vdevs

### DIFF
--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -3102,7 +3102,11 @@ vdev_metaslab_set_size(vdev_t *vd)
 	 */
 
 	if (ms_count < zfs_vdev_min_ms_count)
-		ms_shift = highbit64(asize / zfs_vdev_min_ms_count);
+		/*
+		 * Subtract 1 from highbit64() to ensure ms_shift yields
+		 * at least zfs_vdev_min_ms_count metaslabs.
+		 */
+		ms_shift = highbit64(asize / zfs_vdev_min_ms_count) - 1;
 	else if (ms_count > zfs_vdev_default_ms_count)
 		ms_shift = highbit64(asize / zfs_vdev_default_ms_count);
 	else

--- a/tests/zfs-tests/tests/functional/replacement/replace_resilver_sit_out.ksh
+++ b/tests/zfs-tests/tests/functional/replacement/replace_resilver_sit_out.ksh
@@ -130,7 +130,7 @@ function replace_test
 	verify_pool $TESTPOOL1
 }
 
-DEVSIZE="150M"
+DEVSIZE="256M"
 specials_list=""
 i=0
 while [[ $i != 10 ]]; do

--- a/tests/zfs-tests/tests/functional/trim/autotrim_config.ksh
+++ b/tests/zfs-tests/tests/functional/trim/autotrim_config.ksh
@@ -71,7 +71,7 @@ typeset vdev_min_ms_count=$(get_tunable VDEV_MIN_MS_COUNT)
 log_must set_tunable64 VDEV_MIN_MS_COUNT 32
 
 typeset VDEV_MAX_MB=$(( floor(4 * MINVDEVSIZE * 0.75 / 1024 / 1024) ))
-typeset VDEV_MIN_MB=$(( floor(4 * MINVDEVSIZE * 0.30 / 1024 / 1024) ))
+typeset VDEV_MIN_MB=$(( floor(4 * MINVDEVSIZE * 0.40 / 1024 / 1024) ))
 
 for type in "" "mirror" "raidz2" "draid"; do
 
@@ -85,8 +85,9 @@ for type in "" "mirror" "raidz2" "draid"; do
 		VDEVS="$TRIM_VDEV1 $TRIM_VDEV2 $TRIM_VDEV3 $TRIM_VDEV4"
 
 		# The per-vdev utilization is lower due to the capacity
-		# resilverd for the distributed spare.
+		# reserved for the distributed spare.
 		VDEV_MAX_MB=$(( floor(4 * MINVDEVSIZE * 0.50 / 1024 / 1024) ))
+		VDEV_MIN_MB=$(( floor(4 * MINVDEVSIZE * 0.45 / 1024 / 1024) ))
 	fi
 
 	log_must truncate -s $((4 * MINVDEVSIZE)) $VDEVS


### PR DESCRIPTION
When creating a pool on a small vdev (< 1GB) with a low zfs_vdev_min_ms_count value (e.g., 2), vdev_metaslab_set_size() could compute a metaslab shift that results in fewer metaslabs than zfs_vdev_min_ms_count, triggering an assertion failure in metaslab_group_alloc():
ASSERT3U(mg->mg_vd->vdev_ms_count, >=, 2) failed (1 >= 2)

The root cause is that highbit64(asize / zfs_vdev_min_ms_count) returns last set bit, which can yield a metaslab size larger than asize / zfs_vdev_min_ms_count. For example, with a 500MB vdev and zfs_vdev_min_ms_count=2:
- asize / 2 = 250MB
- highbit64(250MB) = 28, giving 256MB metaslabs
- 500MB / 256MB = 1 metaslab (violates minimum of 2)

Fix by subtracting 1 from highbit64() result to ensure the metaslab size is at most asize / zfs_vdev_min_ms_count, guaranteeing at least zfs_vdev_min_ms_count metaslabs are created

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
While creating zpool with zfs_vdev_min_ms_count = 2 and disk size=500MB
    It ends up with 1 metaslab only on vdev and so it hits an assert
    ASSERT3U(mg->mg_vd->vdev_ms_count, >=, 2) in metaslab_group_alloc().
    

```
    $ truncate -s 500M disk.1
    
    $ cat /sys/module/zfs/parameters/zfs_vdev_min_ms_count
    16
    $ sudo sh -c "echo 2 > /sys/module/zfs/parameters/zfs_vdev_min_ms_count"
    $ cat /sys/module/zfs/parameters/zfs_vdev_min_ms_count
    2
    $ sudo zpool create mytestpool disk.1
    
    [ 1737.298321] VERIFY3U(mg->mg_vd->vdev_ms_count, >=, 2) failed (1 >= 2)
    [ 1737.298327] PANIC at metaslab.c:5059:metaslab_group_alloc()
    [ 1737.298344] Showing stack for process 44021
    …...
    [ 1737.298356] Call Trace:
    [ 1737.298359]  <TASK>
    [ 1737.298366]  dump_stack_lvl+0x34/0x48
    [ 1737.298375]  spl_panic+0xd1/0xf6 [spl]
    [ 1737.298407] VERIFY3U(mg->mg_vd->vdev_ms_count, >=, 2) failed (1 >= 2)
    [ 1737.298409] PANIC at metaslab.c:5059:metaslab_group_alloc()
    [ 1737.298411] Showing stack for process 44019
    [ 1737.299290]  metaslab_group_alloc.isra.0+0xcee/0xde0 [zfs]
    [ 1737.299582]  metaslab_alloc_dva_range.isra.0+0x233/0x970 [zfs]
    [ 1737.299870]  metaslab_alloc_range+0x213/0x700 [zfs]
    [ 1737.300161]  metaslab_alloc+0x2d/0x40 [zfs]
    [ 1737.300455]  zio_dva_allocate+0x196/0x870 [zfs]
    [ 1737.301029]  zio_execute+0xdb/0x2c0 [zfs]
    [ 1737.301300]  taskq_thread+0x35d/0x8f0 [spl]
```
    
With the fix, zpool create succeeds and  vdev gets 3 metaslabs of 128MB size
    
 ```
$sudo zdb -m mytestpool

    Metaslabs:
            vdev          0      ms_unflushed_phys object 136
            metaslabs     3   offset                spacemap          free
            ---------------   -------------------   ---------------   ------------
            metaslab      0   offset            0   spacemap    138   free     128M
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
