### PR TITLE
Fix UAF detected by ztest

### DIFF
--- a/module/zfs/dnode.c
+++ b/module/zfs/dnode.c
@@ -1775,6 +1775,14 @@ dnode_rele_and_unlock(dnode_t *dn, const void *tag, boolean_t evicting)
 	/* Get while the hold prevents the dnode from moving. */
 	dmu_buf_impl_t *db = dn->dn_dbuf;
 	dnode_handle_t *dnh = dn->dn_handle;
+#ifdef ZFS_DEBUG
+	/*
+	 * Capture handle ownership before dropping the hold. After the last
+	 * hold is released, another thread may destroy the dnode. Evaluating
+	 * zrl_owner() after that is a use-after-free.
+	 */
+	boolean_t handle_held = (zrl_owner(&dnh->dnh_zrlock) == curthread);
+#endif
 
 	refs = zfs_refcount_remove(&dn->dn_holds, tag);
 	if (refs == 0)
@@ -1792,7 +1800,7 @@ dnode_rele_and_unlock(dnode_t *dn, const void *tag, boolean_t evicting)
 	 * handle.
 	 */
 #ifdef ZFS_DEBUG
-	ASSERT(refs > 0 || zrl_owner(&dnh->dnh_zrlock) != curthread);
+	ASSERT(refs > 0 || !handle_held);
 #endif
 
 	/* NOTE: the DNODE_DNODE does not have a dn_dbuf */

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -2405,6 +2405,10 @@ spa_unload(spa_t *spa)
 		vdev_free(spa->spa_root_vdev);
 	ASSERT0P(spa->spa_root_vdev);
 
+	ddt_unload(spa);
+	brt_unload(spa);
+	spa_unload_log_sm_metadata(spa);
+
 	/*
 	 * Close the dsl pool.
 	 */
@@ -2413,10 +2417,6 @@ spa_unload(spa_t *spa)
 		spa->spa_dsl_pool = NULL;
 		spa->spa_meta_objset = NULL;
 	}
-
-	ddt_unload(spa);
-	brt_unload(spa);
-	spa_unload_log_sm_metadata(spa);
 
 	/*
 	 * Drop and purge level 2 cache


### PR DESCRIPTION
### Motivation and Context
This was detected by ASAN after 3 ztest runs.

### Description
We need to drop MOS dnode holds (DDT, BRT, log space map metadata) before closing the dsl pool / evicting the meta-objset. Holding them after dsl_pool_close() races with async objset eviction and can cause a use-after-free. Additionally, in dnode_rele_and_unlock(), we need to capture handle ownership for our assertion before the last hold is released.

### How Has This Been Tested?
14 ztest runs were done and the issue could no longer be reproduced.

The CI runner can finish verification of this change for us.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
