### PR TITLE
ZTS: fix mkbusy kill/pgrep race in zfs_destroy_001_pos, _005_neg

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_001_pos.ksh
@@ -139,9 +139,8 @@ function test_n_check
 
 	# Kill any lingering instances of mkbusy, and clear the list.
 	if is_linux ; then
-		[[ -z $pidlist ]] || log_must kill -TERM $pidlist
+		kill_mkbusy "$pidlist"
 		pidlist=""
-		log_mustnot pgrep -fl mkbusy
 	fi
 
 	# Firstly, umount ufs filesystem which was created by zfs volume.
@@ -155,9 +154,8 @@ function test_n_check
 
 	# Kill any lingering instances of mkbusy, and clear the list.
 	if ! is_linux ; then
-		[[ -z $pidlist ]] || log_must kill -TERM $pidlist
+		kill_mkbusy "$pidlist"
 		pidlist=""
-		log_mustnot pgrep -fl mkbusy
 	fi
 
 	case $dtst in

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_005_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_005_neg.ksh
@@ -117,8 +117,7 @@ negative_test "-R -rR" $FS
 check_dataset datasetexists $CTR $FS $VOL $VOLSNAP $VOLCLONE
 check_dataset datasetnonexists $FSSNAP $FSCLONE
 
-log_must kill $pidlist
-log_mustnot pgrep -fl mkbusy
+kill_mkbusy "$pidlist"
 pidlist=""
 
 #
@@ -154,8 +153,7 @@ if is_global_zone; then
 	check_dataset datasetnonexists $VOLSNAP $VOLCLONE
 fi
 
-log_must kill $pidlist
-log_mustnot pgrep -fl mkbusy
+kill_mkbusy "$pidlist"
 pidlist=""
 
 #
@@ -187,8 +185,7 @@ for option in -R -rR ; do
 	fi
 done
 
-log_must kill $pidlist
-log_mustnot pgrep -fl mkbusy
+kill_mkbusy "$pidlist"
 pidlist=""
 
 log_pass "zfs destroy -f|-r|-rf|-R|-rR <dataset>' failed in different " \

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_common.kshlib
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_destroy/zfs_destroy_common.kshlib
@@ -80,6 +80,46 @@ function setup_testenv #[dtst]
 	fi
 }
 
+# Kill a list of mkbusy pids, wait for them to go away, then verify no
+# mkbusy is left behind at all.
+#
+# mkbusy daemonizes, so the caller is not its parent and cannot wait(2)
+# for it. kill(2) only queues the signal: the target still has to be
+# scheduled to take it, and then lingers as a zombie until init reaps
+# it. It shows up in a pgrep scan the whole time, so checking once
+# immediately after the kill is racy. Poll for each pid instead, then
+# run the leak check once the pids we killed are known to be gone.
+#
+# kill -0 still succeeds on a zombie, so the poll below waits for the
+# reap, which is the point at which pgrep stops matching the pid.
+#
+# $1   pidlist, as produced by mkbusy and accumulated by the caller
+function kill_mkbusy # pidlist
+{
+	typeset pid
+	typeset -i i
+
+	# Word-split the caller's list, so that a list which is empty or
+	# all whitespace leaves nothing to kill.
+	set -- $1
+
+	if (( $# > 0 )); then
+		log_must kill -TERM "$@"
+
+		for pid in "$@"; do
+			for (( i = 0; i < 50; i++ )); do
+				kill -0 $pid 2>/dev/null || break
+				sleep 0.1
+			done
+			kill -0 $pid 2>/dev/null && log_fail \
+			    "mkbusy pid $pid still present after 5s:" \
+			    "$(pgrep -fl mkbusy)"
+		done
+	fi
+
+	log_mustnot pgrep -fl mkbusy
+}
+
 # Clean up the testing environment
 #
 function cleanup_testenv


### PR DESCRIPTION
Both tests killed their accumulated mkbusy pidlist and then immediately asserted "log_mustnot pgrep -fl mkbusy". That check is racy: kill(2) only queues the signal, so the target still has to be scheduled to take it, and it then lingers as a zombie until init reaps it. mkbusy daemonizes, so the test shell is not its parent and cannot wait(2) for it -- and pgrep lists the process for that whole window, zombie included.

Add kill_mkbusy() to zfs_destroy_common.kshlib: kill the pidlist, poll kill -0 for each pid until it is gone (up to 5s per pid), and only then run the "no mkbusy anywhere" leak check the tests already had. Scoping the wait to the pids we killed keeps the leak check meaningful -- a stale mkbusy from elsewhere is still reported, rather than silently absorbed by a global wait loop -- and names the offending pid when a kill really does fail to take.

Convert all 5 call sites in the two tests. The leak check now runs unconditionally inside the helper, matching the previous behaviour in zfs_destroy_001_pos, where it sat outside the "is the pidlist empty" guard and so ran even on iterations that started no mkbusy.

Fixes the following tests on Alpine 3.24:
- cli_root/zfs_destroy/zfs_destroy_001_pos
- cli_root/zfs_destroy/zfs_destroy_005_neg

---

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
Both tests fail reliably on Alpine 3.24, across repeated full ZTS runs. The race is described in the commit message. It is visible in the test log as:

```
21:21:22.72 SUCCESS: kill -TERM 31172
21:21:22.73 31172 mkbusy
21:21:22.73 ERROR: pgrep -fl mkbusy unexpectedly exited 0
```

`pgrep` still lists the pid 10ms after the `kill` returned successfully.

### Description
* The wait is scoped to the pids we killed rather than polling `pgrep` globally, so a stale `mkbusy` from elsewhere is still reported instead of being absorbed by the wait.
* `kill -0` succeeds on a zombie, so the poll waits for the reap which is exactly when `pgrep` stops matching.

Known and accepted: pid reuse within the 5s window would cause a false timeout, and the timeout is per pid (both tests only ever hold one).

### How Has This Been Tested?
- Alpine Linux 3.24 CI runner.
- Full GitHub Actions test matrix.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
