### PR TITLE
ZTS: bound ctime_001_pos by the time that actually elapsed

### DIFF
--- a/tests/zfs-tests/cmd/ctime.c
+++ b/tests/zfs-tests/cmd/ctime.c
@@ -33,6 +33,7 @@
 #include <fcntl.h>
 #include <libgen.h>
 #include <string.h>
+#include <time.h>
 
 #define	ST_ATIME 0
 #define	ST_CTIME 1
@@ -325,7 +326,7 @@ main(void)
 	(void) close(fd);
 
 	for (i = 0; i < NCOMMAND; i++) {
-		time_t t1, t2;
+		time_t t1, t2, before, after;
 
 		/*
 		 * Get original time before operating.
@@ -340,8 +341,10 @@ main(void)
 		/*
 		 * Sleep 2 seconds, then invoke command on given file
 		 */
+		before = time(NULL);
 		(void) sleep(2);
 		timetest_table[i].func(tfile);
+		after = time(NULL);
 
 		/*
 		 * Get time after operating.
@@ -355,14 +358,19 @@ main(void)
 
 
 		/*
-		 * Ideally, time change would be exactly two seconds, but allow
-		 * a little slack in case of scheduling delays or similar.
+		 * The operation ran no earlier than two seconds after
+		 * `before` (the sleep) and no later than `after`, so its
+		 * timestamp has to fall in that window.  Comparing against
+		 * the time that actually elapsed rather than against a fixed
+		 * tolerance keeps a loaded machine, where the operation
+		 * itself can take seconds, from failing the test.
 		 */
-		long delta = (long)t2 - (long)t1;
-		if (delta < 2 || delta > 10) {
+		if (t2 < before + 2 || t2 > after) {
 			(void) fprintf(stderr,
-			    "%s: BAD time change: t1(%ld), t2(%ld)\n",
-			    timetest_table[i].name, (long)t1, (long)t2);
+			    "%s: BAD time change: t1(%ld), t2(%ld), "
+			    "expected t2 within [%ld, %ld]\n",
+			    timetest_table[i].name, (long)t1, (long)t2,
+			    (long)before + 2, (long)after);
 			return (1);
 		} else {
 			(void) fprintf(stderr,


### PR DESCRIPTION
Seen here https://github.com/openzfs/zfs/actions/runs/33736182972/job/100587233919?pr=19034
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For each operation ctime.c reads the timestamp, sleeps two seconds, runs the operation, reads the timestamp again and requires the difference to be between 2 and 10 seconds.  The upper bound is a statement about how long the operation may take, not about the timestamp: when the machine is loaded enough for a creat() to take ten seconds, the timestamp is updated correctly and the test still fails.
### Description
<!--- Describe your changes in detail -->
That bound has already been raised once, from 4 to 10 seconds, in cc210862d ("ZTS: ctime_001_pos increase tolerance") for exactly these false positives.  It is now being hit again at 12 seconds:

    st_mtime: BAD time change: t1(1788433492), t2(1788433504)

Take the wall clock before the sleep and after the operation, and require the new timestamp to fall in that window instead.  The operation cannot have run earlier than two seconds after the first reading (the sleep) nor later than the second one, so the check no longer depends on how fast the machine is, and it is tighter than before: the window is normally one or two seconds wide rather than the eight seconds of slack the fixed bound allowed.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Verified in a VM by making do_creat() sleep nine seconds to imitate a loaded machine: the old check fails as it does in the CI, the new one passes.  With do_creat() left out entirely the new check still fails, as it should.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [X] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
