### PR TITLE
Wait for the initialize and trim threads to exit

### DIFF
--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -11733,9 +11733,18 @@ spa_vdev_activity_in_progress_impl(vdev_t *vd, zpool_wait_activity_t activity)
 	mutex_enter(lock);
 	mutex_enter(&spa->spa_activities_lock);
 
+	/*
+	 * A thread that has finished still has to sync out the new state
+	 * before it exits, and until it does the vdev cannot be initialized
+	 * or trimmed again.  Wait for the thread itself, not just the state,
+	 * so that a command issued after the wait returns does not fail with
+	 * EBUSY.
+	 */
 	boolean_t in_progress = (activity == ZPOOL_WAIT_INITIALIZE) ?
-	    (vd->vdev_initialize_state == VDEV_INITIALIZE_ACTIVE) :
-	    (vd->vdev_trim_state == VDEV_TRIM_ACTIVE);
+	    (vd->vdev_initialize_state == VDEV_INITIALIZE_ACTIVE ||
+	    vd->vdev_initialize_thread != NULL) :
+	    (vd->vdev_trim_state == VDEV_TRIM_ACTIVE ||
+	    vd->vdev_trim_thread != NULL);
 	mutex_exit(lock);
 
 	if (in_progress)

--- a/module/zfs/vdev_initialize.c
+++ b/module/zfs/vdev_initialize.c
@@ -617,6 +617,7 @@ vdev_initialize_thread(void *arg)
 
 	vd->vdev_initialize_thread = NULL;
 	cv_broadcast(&vd->vdev_initialize_cv);
+	spa_notify_waiters(spa);
 	mutex_exit(&vd->vdev_initialize_lock);
 
 	thread_exit();

--- a/module/zfs/vdev_trim.c
+++ b/module/zfs/vdev_trim.c
@@ -985,6 +985,7 @@ vdev_trim_thread(void *arg)
 
 	vd->vdev_trim_thread = NULL;
 	cv_broadcast(&vd->vdev_trim_cv);
+	spa_notify_waiters(spa);
 	mutex_exit(&vd->vdev_trim_lock);
 
 	thread_exit();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix flaky tests with brand-new-_AI_-instruments, seen https://github.com/openzfs/zfs/actions/runs/33736182972/job/100587234020?pr=19034
Looks legitimate for me, small enough to ask for review.

### Description
<!--- Describe your changes in detail -->
An initializing thread marks the vdev VDEV_INITIALIZE_COMPLETE, drops vdev_initialize_lock, syncs out the new state with txg_wait_synced() and only then clears vdev_initialize_thread.  spa_vdev_activity_in_ progress_impl() looks at the state alone:

    boolean_t in_progress = (activity == ZPOOL_WAIT_INITIALIZE) ?
        (vd->vdev_initialize_state == VDEV_INITIALIZE_ACTIVE) :
        (vd->vdev_trim_state == VDEV_TRIM_ACTIVE);

so "zpool wait -t initialize" and "zpool initialize -w" return while the thread is still in that txg wait.  A command issued right after them then hits the vdev_initialize_thread != NULL checks in spa_vdev_initialize_impl() and fails with EBUSY, both for uninit and for starting another initialization:

    cannot initialize '/var/tmp/zpool_disk2.dat': currently initializing

ZTS zpool_initialize_multiple_pools fails on this: it runs "zpool initialize -u -a" right after "zpool initialize -w -a".  The window is one txg sync wide, so a loaded machine hits it and an idle one usually does not.

Wait for the thread as well as for the state, and notify the waiters once the thread has cleared itself, so that the wait covers the whole operation the way its callers already assume.  vdev_trim_thread() ends the same way and shares the predicate, so it gets the same treatment.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Verified in a VM by adding a delay(2 * hz) where the txg sync happens, to imitate the loaded machine: uninit right after the wait fails on every one of five runs before this change, and on none after it.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [X] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
