### PR TITLE
ZTS: let the zvol settle before alloc_class_016_pos destroys the pool

### DIFF
--- a/tests/zfs-tests/tests/functional/alloc_class/alloc_class_016_pos.ksh
+++ b/tests/zfs-tests/tests/functional/alloc_class/alloc_class_016_pos.ksh
@@ -41,6 +41,10 @@ log_must zfs create -V 100M -b 32K -o special_small_blocks=32K \
 block_device_wait "$ZVOL_DEVDIR/$TESTPOOL/$TESTVOL"
 log_must dd if=/dev/urandom of=$ZVOL_DEVDIR/$TESTPOOL/$TESTVOL bs=1M count=10
 
+# Closing the zvol makes udev rescan it, and while it does the pool cannot
+# be destroyed.  Let that settle before the destroy below.
+block_device_wait "$ZVOL_DEVDIR/$TESTPOOL/$TESTVOL"
+
 sync_pool $TESTPOOL
 zpool list -v $TESTPOOL
 
@@ -56,5 +60,5 @@ then
 	log_fail "$allocated on special vdev $CLASS_DISK0, but expecting 20M"
 fi
 
-log_must zpool destroy -f "$TESTPOOL"
+log_must_busy zpool destroy -f "$TESTPOOL"
 log_pass $claim


### PR DESCRIPTION
seen in https://github.com/openzfs/zfs/actions/runs/33772309986/job/100705461466?pr=19039

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->


### Description
<!--- Describe your changes in detail -->
The test writes 10M to a zvol and then destroys the pool a few tens of milliseconds later:

    cannot destroy 'testpool': pool is busy
    ERROR: zpool destroy -f testpool exited 1

Closing the zvol makes the kernel emit a change uevent, udev opens the device to scan it, and a destroy issued while that scan is in flight gets EBUSY.  The test already waits for udev after creating the volume but not after writing to it, and it destroys the pool with log_must rather than log_must_busy.

Wait for udev again after the write, and destroy the pool the way destroy_pool() does, retrying while it reports "busy".


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Verified in a VM.  The race does not reproduce on an idle machine, so udev was imitated by holding the zvol open for three seconds before the destroy: the test as it stands fails all five runs with the error above, and passes all five with this change.  Unmodified, it passes 20 runs.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [X] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
