### PR TITLE
ZTS: wait for the zhack pids mmp_concurrent_import started

### DIFF
--- a/tests/zfs-tests/tests/functional/mmp/mmp_concurrent_import.ksh
+++ b/tests/zfs-tests/tests/functional/mmp/mmp_concurrent_import.ksh
@@ -49,13 +49,17 @@ function cleanup
 
 # Verify that pool was imported by at most one of the zhack processes.
 # Check both the return code and expected import message.
-function verify_zhack
+#
+# The pids are passed in rather than looked up with pgrep: a zhack which
+# has not reached its exec() yet, or which has already exited, is not
+# found by pgrep, and this would then return while it still holds the
+# pool imported.
+function verify_zhack # <pid>...
 {
 	IMPORT_COUNT=0
 	IMPORT_MSGS=0
 
-	ZHACKPIDS=$(pgrep zhack)
-	for pid in $ZHACKPIDS; do
+	for pid in "$@"; do
 		wait $pid
 		STATUS=$?
 		if [[ $STATUS -eq 0 ]]; then
@@ -96,9 +100,11 @@ log_must zpool export -F $MMP_POOL
 # Activity check required because the pool was exported with -F above, the
 # claim phase will detect the double import despite matching hostids.
 log_note "zhack import with $HOSTID1 (matching) and $HOSTID1 (matching)"
-log_must eval "ZFS_HOSTID=$HOSTID1 zhack $OPTS >$MMP_ZHACK_LOG.1 2>&1 &"
-log_must eval "ZFS_HOSTID=$HOSTID1 zhack $OPTS >$MMP_ZHACK_LOG.2 2>&1 &"
-log_must verify_zhack
+ZFS_HOSTID=$HOSTID1 zhack $OPTS >$MMP_ZHACK_LOG.1 2>&1 &
+pid1=$!
+ZFS_HOSTID=$HOSTID1 zhack $OPTS >$MMP_ZHACK_LOG.2 2>&1 &
+pid2=$!
+log_must verify_zhack $pid1 $pid2
 
 mmp_clear_hostid
 mmp_set_hostid $HOSTID1
@@ -109,9 +115,11 @@ log_must zpool export $MMP_POOL
 # Activity check skipped for HOSTID1 it is expected to import successfully.
 # zhack with HOSTID2 will run the activity check and detect the active pool.
 log_note "zhack import with $HOSTID1 (matching) and $HOSTID2 (different)"
-log_must eval "ZFS_HOSTID=$HOSTID1 zhack $OPTS >$MMP_ZHACK_LOG.1 2>&1 &"
-log_must eval "ZFS_HOSTID=$HOSTID2 zhack $OPTS >$MMP_ZHACK_LOG.2 2>&1 &"
-log_must verify_zhack
+ZFS_HOSTID=$HOSTID1 zhack $OPTS >$MMP_ZHACK_LOG.1 2>&1 &
+pid1=$!
+ZFS_HOSTID=$HOSTID2 zhack $OPTS >$MMP_ZHACK_LOG.2 2>&1 &
+pid2=$!
+log_must verify_zhack $pid1 $pid2
 
 mmp_clear_hostid
 mmp_set_hostid $HOSTID3
@@ -122,8 +130,10 @@ log_must zpool export $MMP_POOL
 # Both zhacks will run the activity checks, depending on the exact timing
 # one may succeed and the other fail, or both may fail.
 log_note "zhack import with $HOSTID1 (different) and $HOSTID2 (different)"
-log_must eval "ZFS_HOSTID=$HOSTID1 zhack $OPTS >$MMP_ZHACK_LOG.1 2>&1 &"
-log_must eval "ZFS_HOSTID=$HOSTID2 zhack $OPTS >$MMP_ZHACK_LOG.2 2>&1 &"
-log_must verify_zhack
+ZFS_HOSTID=$HOSTID1 zhack $OPTS >$MMP_ZHACK_LOG.1 2>&1 &
+pid1=$!
+ZFS_HOSTID=$HOSTID2 zhack $OPTS >$MMP_ZHACK_LOG.2 2>&1 &
+pid2=$!
+log_must verify_zhack $pid1 $pid2
 
 log_pass "multihost=on concurrent imports"


### PR DESCRIPTION
seen here https://github.com/gmelikov/zfs/actions/runs/33767181587/job/100688049277

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
### Description
<!--- Describe your changes in detail -->
verify_zhack() looks up the processes to wait for by name:

    ZHACKPIDS=$(pgrep zhack)
    for pid in $ZHACKPIDS; do
            wait $pid

so it only waits for the zhacks that pgrep happens to see.  One that has not reached its exec() yet is still named after the shell that forked it, and one that has already exited is gone; either way the test continues while a zhack may still hold the pool imported, and the import_activity_check() that follows then finds activity where it requires mmp_result: 0.  A zhack missed this way is also not counted, so IMPORT_COUNT can silently disagree with what actually happened.

A CI run failed this way.  Two zhacks were started, only one was reported, the other was still running at the end and was killed by cleanup:

    NOTE: PID 1689736 exited with status 1
    ...
    ERROR: import_activity_check expected activity check
    ...
    SUCCESS: kill -9 1689739

Start the zhacks directly, keep the pids from $!, and pass them to verify_zhack(), which then waits for exactly the processes the test started.  The log_must around a backgrounded command only checked that the fork succeeded, so nothing is lost by dropping it.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

This is a hardening: the pids in the failed run are three apart, as in the phase that reported both, so the process existed but was not yet visible to pgrep.  That window was not reproducible on an idle VM -- pgrep found the process in 20 of 20 attempts there -- so the failure above is explained by this race but was not reproduced.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [X] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
