### PR TITLE
Fault the write source in outside the range lock, do not cut the write

### DIFF
--- a/module/os/linux/zfs/zfs_uio.c
+++ b/module/os/linux/zfs/zfs_uio.c
@@ -227,10 +227,19 @@ zfs_uiomove_iter(void *p, size_t n, zfs_uio_rw_t rw, zfs_uio_t *uio,
 	size_t oldcnt = cnt;
 	int error = 0;
 
-	if (rw == UIO_READ)
+	if (rw == UIO_READ) {
 		cnt = copy_to_iter(p, cnt, uio->uio_iter);
-	else
+	} else if (uio->uio_fault_disable) {
+		/*
+		 * The caller prefaulted this range. Do not fault while a
+		 * transaction or range lock is held.
+		 */
+		pagefault_disable();
 		cnt = copy_from_iter(p, cnt, uio->uio_iter);
+		pagefault_enable();
+	} else {
+		cnt = copy_from_iter(p, cnt, uio->uio_iter);
+	}
 
 	/*
 	 * When operating on a full pipe no bytes are processed.

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -675,11 +675,13 @@ zfs_write(znode_t *zp, zfs_uio_t *uio, int ioflag, cred_t *cr)
 	}
 
 	/*
-	 * Pre-fault the pages to ensure slow (eg NFS) pages
-	 * don't hold up txg.
+	 * Pre-fault one transaction-sized chunk before acquiring the range
+	 * lock.  Copying later chunks with page faults disabled may produce a
+	 * short write, but it must not fault while holding this lock: if the
+	 * source is an mmap of this file, that fault would enter zfs_getpage()
+	 * and deadlock on the same lock.
 	 */
-	ssize_t pfbytes = MIN(n, DMU_MAX_ACCESS >> 1);
-	if (zfs_uio_prefaultpages(pfbytes, uio)) {
+	if (zfs_uio_prefaultpages(MIN(n, DMU_MAX_ACCESS >> 1), uio)) {
 		zfs_exit(zfsvfs, FTAG);
 		return (SET_ERROR(EFAULT));
 	}
@@ -826,22 +828,19 @@ zfs_write(znode_t *zp, zfs_uio_t *uio, int ioflag, cred_t *cr)
 			    blksz);
 			ASSERT(abuf != NULL);
 			ASSERT(arc_buf_size(abuf) == blksz);
-			if ((error = zfs_uiocopy(abuf->b_data, blksz,
-			    UIO_WRITE, uio, &nbytes))) {
+			zfs_uio_fault_disable(uio, B_TRUE);
+			error = zfs_uiocopy(abuf->b_data, blksz, UIO_WRITE,
+			    uio, &nbytes);
+			zfs_uio_fault_disable(uio, B_FALSE);
+			if (error != 0 || nbytes != blksz) {
+				if (error == 0)
+					error = SET_ERROR(EFAULT);
 				dmu_return_arcbuf(abuf);
 				break;
 			}
-			ASSERT3S(nbytes, ==, blksz);
 		} else {
 			nbytes = MIN(n, (DMU_MAX_ACCESS >> 1) -
 			    P2PHASE(woff, blksz));
-			if (pfbytes < nbytes) {
-				if (zfs_uio_prefaultpages(nbytes, uio)) {
-					error = SET_ERROR(EFAULT);
-					break;
-				}
-				pfbytes = nbytes;
-			}
 		}
 
 		/*
@@ -891,32 +890,12 @@ zfs_write(znode_t *zp, zfs_uio_t *uio, int ioflag, cred_t *cr)
 			error = dmu_write_uio_dbuf(sa_get_db(zp->z_sa_hdl),
 			    uio, nbytes, tx, dflags);
 			zfs_uio_fault_disable(uio, B_FALSE);
-#ifdef __linux__
-			if (error == EFAULT) {
-				zfs_clear_setid_bits_if_necessary(zfsvfs, zp,
-				    cr, &clear_setid_bits_txg, tx);
-				dmu_tx_commit(tx);
-				/*
-				 * Account for partial writes before
-				 * continuing the loop.
-				 * Update needs to occur before the next
-				 * zfs_uio_prefaultpages, or prefaultpages may
-				 * error, and we may break the loop early.
-				 */
-				n -= tx_bytes - zfs_uio_resid(uio);
-				/*
-				 * The prefaulted pages still faulted, so force
-				 * a re-prefault on the next pass.  If they can
-				 * no longer be faulted in (e.g. the calling
-				 * process is exiting), zfs_uio_prefaultpages()
-				 * fails and the loop breaks with EFAULT instead
-				 * of spinning on them forever.
-				 */
-				pfbytes = 0;
-				continue;
-			}
-#endif
 			/*
+			 * Account for any partial EFAULT below.  On Linux,
+			 * retrying needs another prefault while the range lock
+			 * is held.  That can deadlock when the source maps this
+			 * file.
+			 *
 			 * On FreeBSD, EFAULT should be propagated back to the
 			 * VFS, which will handle faulting and will retry.
 			 */
@@ -1047,7 +1026,6 @@ zfs_write(znode_t *zp, zfs_uio_t *uio, int ioflag, cred_t *cr)
 			break;
 		ASSERT3S(tx_bytes, ==, nbytes);
 		n -= nbytes;
-		pfbytes -= nbytes;
 	}
 
 	if (o_direct_defer) {
@@ -1064,6 +1042,14 @@ zfs_write(znode_t *zp, zfs_uio_t *uio, int ioflag, cred_t *cr)
 	 */
 	if (uio->uio_extflg & UIO_DIRECT)
 		zfs_uio_free_dio_pages(uio, UIO_WRITE);
+
+#ifdef __linux__
+	/*
+	 * Linux write(2) reports a short copy as progress instead of EFAULT.
+	 */
+	if (error == EFAULT && zfs_uio_resid(uio) != start_resid)
+		error = 0;
+#endif
 
 	/*
 	 * If we're in replay mode, or we made no progress, or the

--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -729,6 +729,12 @@ zfs_write(znode_t *zp, zfs_uio_t *uio, int ioflag, cred_t *cr)
 
 	const rlim64_t limit = MAXOFFSET_T;
 
+	/*
+	 * How much to copy at a time.  Halved when a retry brings nothing
+	 * in, see the fault handling at the end of the loop below.
+	 */
+	ssize_t maxcopy = DMU_MAX_ACCESS >> 1;
+
 	if (woff >= limit) {
 		zfs_rangelock_exit(lr);
 		zfs_exit(zfsvfs, FTAG);
@@ -813,8 +819,12 @@ zfs_write(znode_t *zp, zfs_uio_t *uio, int ioflag, cred_t *cr)
 
 		arc_buf_t *abuf = NULL;
 		ssize_t nbytes = n;
+#ifdef __linux__
+		/* How much this pass copied, see the fault handling below. */
+		ssize_t copied = 0;
+#endif
 		if (n >= blksz && woff >= zp->z_size &&
-		    P2PHASE(woff, blksz) == 0 &&
+		    P2PHASE(woff, blksz) == 0 && blksz <= maxcopy &&
 		    !(uio->uio_extflg & UIO_DIRECT) &&
 		    (blksz >= SPA_OLD_MAXBLOCKSIZE || n < 4 * blksz)) {
 			/*
@@ -836,11 +846,16 @@ zfs_write(znode_t *zp, zfs_uio_t *uio, int ioflag, cred_t *cr)
 				if (error == 0)
 					error = SET_ERROR(EFAULT);
 				dmu_return_arcbuf(abuf);
+#ifdef __linux__
+				if (error == EFAULT)
+					goto refault;
+#endif
 				break;
 			}
 		} else {
 			nbytes = MIN(n, (DMU_MAX_ACCESS >> 1) -
 			    P2PHASE(woff, blksz));
+			nbytes = MIN(nbytes, maxcopy);
 		}
 
 		/*
@@ -968,6 +983,10 @@ zfs_write(znode_t *zp, zfs_uio_t *uio, int ioflag, cred_t *cr)
 			    (void *)&zp->z_size, sizeof (uint64_t), tx);
 			dmu_tx_commit(tx);
 			ASSERT(error != 0);
+#ifdef __linux__
+			if (error == EFAULT)
+				goto refault;
+#endif
 			break;
 		}
 
@@ -1022,10 +1041,59 @@ zfs_write(znode_t *zp, zfs_uio_t *uio, int ioflag, cred_t *cr)
 			o_direct_defer = B_FALSE;
 		}
 
+#ifdef __linux__
+		if (error == EFAULT) {
+			copied = tx_bytes;
+			n -= tx_bytes;
+			goto refault;
+		}
+#endif
 		if (error != 0)
 			break;
 		ASSERT3S(tx_bytes, ==, nbytes);
 		n -= nbytes;
+		/* This chunk was copied whole, go back to copying big. */
+		maxcopy = DMU_MAX_ACCESS >> 1;
+		continue;
+#ifdef __linux__
+refault:
+		/*
+		 * The copy above ran with page faults disabled, because
+		 * faulting while the range lock is held deadlocks when the
+		 * source maps this file.  Fault the source in with the lock
+		 * dropped and resume where the copy stopped, rather than
+		 * cutting the write short.
+		 *
+		 * Copy less on the next pass when this one brought nothing
+		 * in, as the page cache does, since a source which faults in
+		 * but still cannot be copied would loop here forever.  Give
+		 * up once a single page cannot be copied: what was written
+		 * so far is returned as a short write.
+		 */
+		if (copied == 0) {
+			if (maxcopy <= (ssize_t)PAGE_SIZE) {
+				error = SET_ERROR(EFAULT);
+				break;
+			}
+			maxcopy >>= 1;
+		} else {
+			maxcopy = DMU_MAX_ACCESS >> 1;
+		}
+
+		if (issig()) {
+			error = SET_ERROR(EINTR);
+			break;
+		}
+
+		zfs_rangelock_exit(lr);
+		error = zfs_uio_prefaultpages(MIN(n, maxcopy), uio);
+		lr = zfs_rangelock_enter(&zp->z_rangelock,
+		    zfs_uio_offset(uio), n, RL_WRITER);
+		if (error != 0) {
+			error = SET_ERROR(EFAULT);
+			break;
+		}
+#endif
 	}
 
 	if (o_direct_defer) {

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -841,7 +841,7 @@ tags = ['functional', 'migration']
 [tests/functional/mmap]
 tests = ['mmap_mixed', 'mmap_read_001_pos', 'mmap_seek_001_pos',
     'mmap_sync_001_pos', 'mmap_write_001_pos', 'mmap_ftruncate',
-    'mmap_read_truncate']
+    'mmap_read_truncate', 'mmap_write_source']
 tags = ['functional', 'mmap']
 
 [tests/functional/mount]

--- a/tests/zfs-tests/cmd/.gitignore
+++ b/tests/zfs-tests/cmd/.gitignore
@@ -31,6 +31,7 @@
 /mmap_read_truncate
 /mmap_seek
 /mmap_sync
+/mmap_write_source
 /mmapwrite
 /mmap_write_sync
 /mount_null_source

--- a/tests/zfs-tests/cmd/Makefile.am
+++ b/tests/zfs-tests/cmd/Makefile.am
@@ -79,7 +79,7 @@ scripts_zfs_tests_bin_PROGRAMS += %D%/mkbusy %D%/mkfile %D%/mkfiles %D%/mktree
 scripts_zfs_tests_bin_PROGRAMS += \
 	%D%/mmap_exec %D%/mmap_ftruncate %D%/mmap_seek \
 	%D%/mmap_sync %D%/mmapwrite %D%/readmmap %D%/mmap_write_sync \
-	%D%/mmap_read_truncate
+	%D%/mmap_read_truncate %D%/mmap_write_source
 
 if WANT_MMAP_LIBAIO
 scripts_zfs_tests_bin_PROGRAMS += %D%/mmap_libaio

--- a/tests/zfs-tests/cmd/mmap_write_source.c
+++ b/tests/zfs-tests/cmd/mmap_write_source.c
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: CDDL-1.0
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * https://opensource.org/license/CDDL-1.0.
+ */
+
+/*
+ * Copyright (c) 2026 by George Melikov.
+ */
+
+/*
+ * Write to a file from a source which is a private mapping of another,
+ * not yet resident, file.  The write has to transfer everything it was
+ * given: a source page which is not resident is only a reason to fault
+ * it in, not to cut the write short.
+ *
+ * usage: mmap_write_source <src> <dst> <size>
+ */
+
+#include <sys/mman.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+int
+main(int argc, char *argv[])
+{
+	if (argc != 4) {
+		(void) fprintf(stderr,
+		    "usage: %s <src> <dst> <size>\n", argv[0]);
+		return (2);
+	}
+
+	size_t size = strtoull(argv[3], NULL, 0);
+	if (size == 0) {
+		(void) fprintf(stderr, "invalid size: %s\n", argv[3]);
+		return (2);
+	}
+
+	/*
+	 * The source is a hole, so none of its pages are resident and
+	 * reading them faults.
+	 */
+	int sfd = open(argv[1], O_RDWR | O_CREAT | O_TRUNC, 0666);
+	if (sfd < 0 || ftruncate(sfd, size) != 0) {
+		perror(argv[1]);
+		return (1);
+	}
+
+	void *src = mmap(NULL, size, PROT_READ, MAP_PRIVATE, sfd, 0);
+	if (src == MAP_FAILED) {
+		perror("mmap");
+		return (1);
+	}
+
+	int dfd = open(argv[2], O_RDWR | O_CREAT | O_TRUNC, 0666);
+	if (dfd < 0) {
+		perror(argv[2]);
+		return (1);
+	}
+
+	ssize_t written = write(dfd, src, size);
+	if (written < 0) {
+		(void) fprintf(stderr, "write of %zu bytes failed: %s\n",
+		    size, strerror(errno));
+		return (1);
+	}
+
+	if ((size_t)written != size) {
+		(void) fprintf(stderr,
+		    "short write: %zd of %zu bytes\n", written, size);
+		return (1);
+	}
+
+	if (close(dfd) != 0) {
+		perror("close");
+		return (1);
+	}
+
+	return (0);
+}

--- a/tests/zfs-tests/include/commands.cfg
+++ b/tests/zfs-tests/include/commands.cfg
@@ -217,6 +217,7 @@ export ZFSTEST_FILES_COMMON='badsend
     mmap_read_truncate
     mmap_seek
     mmap_sync
+    mmap_write_source
     mmapwrite
     mmap_write_sync
     mount_null_source

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1839,6 +1839,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/mmap/mmap_write_001_pos.ksh \
 	functional/mmap/mmap_ftruncate.ksh \
 	functional/mmap/mmap_read_truncate.ksh \
+	functional/mmap/mmap_write_source.ksh \
 	functional/mmap/setup.ksh \
 	functional/mmp/cleanup.ksh \
 	functional/mmp/mmp_active_import.ksh \

--- a/tests/zfs-tests/tests/functional/mmap/mmap_write_source.ksh
+++ b/tests/zfs-tests/tests/functional/mmap/mmap_write_source.ksh
@@ -1,0 +1,50 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
+#
+
+#
+# Copyright (c) 2026 by George Melikov.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+#	A write whose source is a mapped file transfers all of its data.
+#
+# STRATEGY:
+#	1. Write from a private mapping of a hole, so that no source page
+#	   is resident and every one of them has to be faulted in.
+#	2. Do this for a size which fits in the window zfs_write() faults
+#	   in before it takes the range lock, and for one which does not.
+#	3. Verify the destination has the size that was written.
+#
+
+verify_runnable "global"
+
+srcfile=$TESTDIR/mmap_write_source.src
+dstfile=$TESTDIR/mmap_write_source.dst
+
+function cleanup
+{
+	log_must rm -f $srcfile $dstfile
+}
+
+log_assert "A write from a mapped source transfers all of its data"
+log_onexit cleanup
+
+for size in $((16 * 1024 * 1024)) $((64 * 1024 * 1024)); do
+	log_must mmap_write_source $srcfile $dstfile $size
+	log_must test $(stat_size $dstfile) -eq $size
+done
+
+log_pass "A write from a mapped source transfers all of its data"


### PR DESCRIPTION
seen efault here https://github.com/openzfs/zfs/actions/runs/33803391217/job/100808052795?pr=19043

On my ongoning quest to fix CI flakiness tried to fix it with AI, looks legit and now we have tests too!

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
zfs_write() faults in the first DMU_MAX_ACCESS/2 bytes of the source before it takes the file range lock, and copies every chunk with page faults disabled, since a fault taken under that lock deadlocks when the source maps the file being written.  43bb1614d ("Linux: avoid prefaulting under the ZFS range lock") stopped there: a source page which is not resident when it is copied now ends the write.  What has been copied is reported as a short write, and if the very first chunk fails, write(2) returns EFAULT for a perfectly valid buffer.

Both are easy to reach.  A write larger than the prefaulted window from a mapping which is not resident stops at that window:

    write returned 33554432 of 67108864 (SHORT)

and ZTS hit the EFAULT form, where mkfile reported the write of a plain heap buffer as:

    initialized 424148992 of 1073741824 bytes: Bad address

The page cache does not end a write there.  generic_perform_write(), which is what ext4 uses for buffered writes, faults the source in for every chunk before it takes the folio lock, copies with faults disabled under it, and treats a failed copy as a reason to try again:

	if (unlikely(fault_in_iov_iter_readable(i, bytes) == bytes)) {
		status = -EFAULT;
		break;
	}
	...
	copied = copy_folio_from_iter_atomic(folio, offset, bytes, i);
	...
	if (unlikely(status == 0)) {
		if (chunk > PAGE_SIZE)
			chunk /= 2;
		if (copied) {
			bytes = copied;
			goto retry;
		}
	}

iomap_write_iter(), used by XFS, is the same loop, and btrfs states the rule as "if we have trouble faulting in the pages, fall back to one page at a time".  EFAULT is what these return when nothing at all can be faulted in; a short write is what is left when the copy cannot make progress, not the first answer to a page which is merely cold.

Do the same here.  Fault the source in with the range lock dropped -- that deadlock is the whole reason the copy cannot fault -- and resume the write where the copy stopped.  Nothing is written while the lock is not held, so a reader can only observe a state the short write already exposes today: the application would retake the lock on its next write(2) anyway.  Copy less on the next pass when a pass brought nothing in, down to a page, so that a source which faults in but still cannot be copied (sub-page faults) does not loop here forever, and check for a fatal signal so the loop stays interruptible.  FreeBSD propagates EFAULT to the VFS, which retries, and is left alone.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
The new test writes to a file from a private mapping of a hole, once within the prefaulted window and once past it; without this change the second write comes back short.  Verified in a VM: the test fails on 43bb1614d and passes here, functional/mmap passes as a whole, and the reproducer from #18872, which writes a file onto itself, completes all 33554433 bytes instead of deadlocking (before 43bb1614d) or stopping a byte short (after it).

### Interesting links:
Kernel references (v6.12 tag permalinks, line numbers stable):

Reference buffered-write loop — generic_perform_write(), mm/filemap.c:
- whole function: https://github.com/torvalds/linux/blob/v6.12/mm/filemap.c#L4015-L4102
- source faulted in before the lock, EFAULT only when nothing could be faulted in: https://github.com/torvalds/linux/blob/v6.12/mm/filemap.c#L4038-L4047
- copy with page faults disabled: https://github.com/torvalds/linux/blob/v6.12/mm/filemap.c#L4066
- shrink the chunk and retry instead of ending the write: https://github.com/torvalds/linux/blob/v6.12/mm/filemap.c#L4078-L4092

ext4 uses exactly that — ext4_buffered_write_iter():
- https://github.com/torvalds/linux/blob/v6.12/fs/ext4/file.c#L285
- the call: https://github.com/torvalds/linux/blob/v6.12/fs/ext4/file.c#L299

XFS and friends via iomap — iomap_write_iter(), fs/iomap/buffered-io.c:
- function: https://github.com/torvalds/linux/blob/v6.12/fs/iomap/buffered-io.c#L910
- same fault-in and == bytes test: https://github.com/torvalds/linux/blob/v6.12/fs/iomap/buffered-io.c#L940-L953
- copy_folio_from_iter_atomic, then chunk /= 2 and goto retry: https://github.com/torvalds/linux/blob/v6.12/fs/iomap/buffered-io.c#L970 and https://github.com/torvalds/linux/blob/v6.12/fs/iomap/buffered-io.c#L995-L1007

btrfs — fs/btrfs/file.c:
- "Fault pages before locking them in prepare_pages to avoid recursive lock": https://github.com/torvalds/linux/blob/v6.12/fs/btrfs/file.c#L1251-L1258
- "if we have trouble faulting in the pages, fall back to one page at a time" → nrptrs = 1: https://github.com/torvalds/linux/blob/v6.12/fs/btrfs/file.c#L1354-L1359

Return semantics that make ZFS stricter than the kernel — fault_in_iov_iter_readable() returns the number of bytes not faulted in:
- https://github.com/torvalds/linux/blob/v6.12/lib/iov_iter.c#L77-L90 ("Returns the number of bytes not faulted in")
- ZFS treats any non-zero return as EFAULT: module/os/linux/zfs/zfs_uio.c:305, with the name mapped in include/os/linux/spl/sys/uio.h:45

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
