### PR TITLE
dsl_deadlist_space_range: use correct tree when summing up space

### DIFF
--- a/module/zfs/dsl_deadlist.c
+++ b/module/zfs/dsl_deadlist.c
@@ -30,7 +30,7 @@
  * dp_config_rwlock held with RW_WRITER.
  *
  * The accessors (dsl_deadlist_space() and dsl_deadlist_space_range()) can
- * be called concurrently, from open context, with the dl_config_rwlock held
+ * be called concurrently, from open context, with the dp_config_rwlock held
  * with RW_READER.
  *
  * Therefore, we only need to provide locking between dsl_deadlist_insert() and
@@ -783,7 +783,7 @@ dsl_deadlist_space_range(dsl_deadlist_t *dl, uint64_t mintxg, uint64_t maxtxg,
 		dlce = avl_nearest(&dl->dl_cache, where, AVL_AFTER);
 
 	for (; dlce && dlce->dlce_mintxg < maxtxg;
-	    dlce = AVL_NEXT(&dl->dl_tree, dlce)) {
+	    dlce = AVL_NEXT(&dl->dl_cache, dlce)) {
 		*usedp += dlce->dlce_bytes;
 		*compp += dlce->dlce_comp;
 		*uncompp += dlce->dlce_uncomp;


### PR DESCRIPTION
This was found via code inspection: space_range uses dl_cache for determining the starting point, and then uses dl_tree for the loop. This works accidentally only because the tree and cache structs have the same fields (specifically, node and mintxg) at the same offsets.

### Motivation and Context
Code correctness issue.

### Description
One-liner to fix the avl tree being used; there's a danger of UB if dl_tree isn't set up.

### How Has This Been Tested?
I ran ztest.

### Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [X] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [X] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
