### PR TITLE
ztest: sleep while waiting for the fishing thread to seed; fix %016lx seed printing

### DIFF
--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -1095,7 +1095,12 @@ fishing:
 	result = thread_create_named(name, stk, stksize,
 	    ztest_fishing_thread, ftargp, len, pp, state, pri);
 	while (atomic_load_64(&ztest_prng_state->zs_jumps) == jumps) {
-		/* let this thread initialize its seed */
+		/*
+		 * Let this thread initialize its seed. Sleep briefly so
+		 * the fishing thread is not starved on a single-CPU or
+		 * heavily loaded system.
+		 */
+		usleep(1000);
 	}
 
 	return (result);

--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -1006,11 +1006,12 @@ fishing:
 			    sizeof (ztest_prng_state->zs_primary_seed));
 		}
 		if (ztest_opts.zo_verbose >= 1) {
-			printf("primary_prng_seed=%016lx%016lx%016lx%016lx\n",
-			    ztest_prng_state->zs_primary_seed[0],
-			    ztest_prng_state->zs_primary_seed[1],
-			    ztest_prng_state->zs_primary_seed[2],
-			    ztest_prng_state->zs_primary_seed[3]);
+			printf("primary_prng_seed="
+			    "%016llx%016llx%016llx%016llx\n",
+			    (u_longlong_t)ztest_prng_state->zs_primary_seed[0],
+			    (u_longlong_t)ztest_prng_state->zs_primary_seed[1],
+			    (u_longlong_t)ztest_prng_state->zs_primary_seed[2],
+			    (u_longlong_t)ztest_prng_state->zs_primary_seed[3]);
 		}
 	}
 	if (atomic_load_64(&seeded) == 0) {
@@ -1022,8 +1023,10 @@ fishing:
 			xoshiro256plusplus_jump(seed);
 		atomic_inc_64(&seeded);
 		if (ztest_opts.zo_verbose >= 5) {
-			printf("thread prng_seed=%016lx%016lx%016lx%016lx\n",
-			    seed[0], seed[1], seed[2], seed[3]);
+			printf("thread prng_seed="
+			    "%016llx%016llx%016llx%016llx\n",
+			    (u_longlong_t)seed[0], (u_longlong_t)seed[1],
+			    (u_longlong_t)seed[2], (u_longlong_t)seed[3]);
 		}
 	}
 	r = xoshiro256plusplus_next(seed);


### PR DESCRIPTION
As discussed in #19048, two robustness fixes for the ztest fishing mode (b46561aa7):

1. `ztest_thread_create()` busy-waits on `zs_jumps` with an empty loop body until the newly created fishing thread jumps the shared PRNG state. On a single-CPU system, or when the machine is heavily loaded, the spinning parent can starve the very thread it is waiting for. Sleep briefly in the wait loop so the fishing thread gets a chance to run. (Taking the "a little sleep should be the simplest way to yield" suggestion from @ihoro.)

2. `printf("%016lx", uint64_t)` is undefined on ILP32 where `uint64_t` promotes to `unsigned long long`. Cast to `u_longlong_t` and use `%016llx`, as is done elsewhere in this file.

Fixes #19048
