### PR TITLE
ZTS: tighten the device_access tests

### DIFF
--- a/tests/zfs-tests/tests/functional/device_access/device_access.kshlib
+++ b/tests/zfs-tests/tests/functional/device_access/device_access.kshlib
@@ -34,13 +34,13 @@ function restore_perms { #path
 	if [[ -z ${_saved_perms[$path]} ]] ; then
 		log_fail "restore_perms($path): must call save_perms first"
 	fi
-	chmod ${_saved_perms[$path]} "$path"
+	log_must chmod ${_saved_perms[$path]} "$path"
 }
 
 function check_vdevs { #pool, vdevs...
 	typeset pool="$1"
 	typeset want=$(echo "${@:2}" | xargs -n 1 | sort | xargs)
-	typeset have=$(zpool list -HvLP -o name | grep /dev | sort | xargs)
+	typeset have=$(zpool list -HvLP -o name "$pool" | grep /dev | sort | xargs)
 	log_must test "$want" == "$have"
 }
 

--- a/tests/zfs-tests/tests/functional/device_access/device_access_import.ksh
+++ b/tests/zfs-tests/tests/functional/device_access/device_access_import.ksh
@@ -40,7 +40,8 @@ log_assert 'device permissions are properly checked for zpool import'
 log_must chmod 666 $DEV1 $DEV2
 log_must zpool create $TESTPOOL $DEV1 $DEV2
 check_vdevs $TESTPOOL $DEV1 $DEV2
-cp /etc/zfs/zpool.cache $tmpcache
+log_must cp /etc/zfs/zpool.cache $tmpcache
+log_must test -s $tmpcache
 log_must zpool export $TESTPOOL
 
 # remove perms from devices, check pool can be imported. this is relying on the

--- a/tests/zfs-tests/tests/functional/device_access/setup.ksh
+++ b/tests/zfs-tests/tests/functional/device_access/setup.ksh
@@ -20,4 +20,7 @@
 
 verify_runnable "global"
 
+[[ -b $DEV1 && -b $DEV2 && -b $DEV3 ]] || \
+	log_unsupported "$DISKS must be real block devices"
+
 log_pass


### PR DESCRIPTION
As discussed in #19050, three robustness fixes for the new `device_access` test group (4f8b5d3d2). Harmless on the standard CI VM, but they produce false results in other environments:

- Wrap the cachefile copy in `log_must` and require it to be non-empty, so the negative import tests cannot pass vacuously on a system without `/etc/zfs/zpool.cache`.
- Make `check_vdevs()` list only the pool it is passed instead of every `/dev`-backed pool on the host (misfires on root-on-ZFS hosts).
- Skip the group with `log_unsupported` when `$DISKS` are not real block devices (file vdev runs), instead of failing.
- Wrap the `restore_perms()` chmod in `log_must`.

Fixes #19050
