### PR TITLE
CI: update the FreeBSD CI runner to 14.5-STABLE

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -75,7 +75,7 @@ Auto-selected:
 
 - Linux: almalinux 8/9/10, centos-stream 9/10, debian 11/12/13,
   fedora 43/44, ubuntu 22/24/26
-- FreeBSD: 14.4-RELEASE/STABLE, 15.1-RELEASE/STABLE, 16.0-CURRENT
+- FreeBSD: 14.4-RELEASE, 14.5-STABLE, 15.1-RELEASE/STABLE, 16.0-CURRENT
 
 Available via `specific_os` or `ZTS_OS_OVERRIDE`:
 

--- a/.github/workflows/scripts/qemu-2-start.sh
+++ b/.github/workflows/scripts/qemu-2-start.sh
@@ -114,8 +114,8 @@ case "$OS" in
     URLxz="$FREEBSD_REL/$FreeBSD/amd64/Latest/FreeBSD-$FreeBSD-amd64-BASIC-CI-ufs.raw.xz"
     KSRC="$FREEBSD_REL/../amd64/$FreeBSD/src.txz"
     ;;
-  freebsd14-4s)
-    FreeBSD="14.4-STABLE"
+  freebsd14-5s)
+    FreeBSD="14.5-STABLE"
     OSNAME="FreeBSD $FreeBSD"
     OSv="freebsd14.0"
     URLxz="$FREEBSD_SNAP/$FreeBSD/amd64/Latest/FreeBSD-$FreeBSD-amd64-BASIC-CI-ufs.raw.xz"

--- a/.github/workflows/zfs-qemu.yml
+++ b/.github/workflows/zfs-qemu.yml
@@ -56,7 +56,7 @@ jobs:
             os_selection='["almalinux8", "almalinux9", "almalinux10", "centos-stream9", "centos-stream10", "debian11", "debian12", "debian13", "fedora43", "fedora44", "ubuntu22", "ubuntu24", "ubuntu26"]'
             ;;
           freebsd)
-            os_selection='["freebsd14-4r", "freebsd14-4s", "freebsd15-1r", "freebsd15-1s", "freebsd16-0c"]'
+            os_selection='["freebsd14-4r", "freebsd14-5s", "freebsd15-1r", "freebsd15-1s", "freebsd16-0c"]'
             ;;
           *)
             # default list
@@ -107,7 +107,7 @@ jobs:
         # misc:    archlinux, tumbleweed
         # FreeBSD variants of november 2025:
         # FreeBSD Release: freebsd14-4r, freebsd15-1r
-        # FreeBSD Stable:  freebsd14-4s, freebsd15-1s
+        # FreeBSD Stable:  freebsd14-5s, freebsd15-1s
         # FreeBSD Current: freebsd16-0c
         os: ${{ fromJson(needs.test-config.outputs.test_os) }}
     runs-on: ubuntu-24.04


### PR DESCRIPTION
### Motivation and Context

FreeBSD 14.5-RELEASE supersedes 14.4 as the supported release of the stable/14 branch. 

### Description
Update the CI images to 14.5-STABLE. The latest images are from 3rd September.

### How Has This Been Tested?

FreeBSD 14.5-STABLE CI images are available under [https://download.freebsd.org/]( https://download.freebsd.org/)

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
