### PR TITLE
FreeBSD: use sys/abi_compat.h for time32_t

### DIFF
--- a/include/os/freebsd/spl/sys/types32.h
+++ b/include/os/freebsd/spl/sys/types32.h
@@ -30,9 +30,10 @@
 #ifndef _SPL_TYPES32_H
 #define	_SPL_TYPES32_H
 
+#include <sys/abi_compat.h>
+
 typedef uint32_t	caddr32_t;
 typedef int32_t	daddr32_t;
-typedef int32_t	time32_t;
 typedef uint32_t	size32_t;
 
 #endif  /* _SPL_TYPES32_H */

--- a/lib/libspl/include/sys/types32.h
+++ b/lib/libspl/include/sys/types32.h
@@ -53,7 +53,12 @@ typedef	uint32_t	dev32_t;
 typedef	int32_t		pid32_t;
 typedef	uint32_t	size32_t;
 typedef	int32_t		ssize32_t;
+#ifdef __FreeBSD__
+#include <sys/abi_compat.h>
+#endif
+#ifndef __HAVE_TIME32_T
 typedef	int32_t		time32_t;
+#endif
 typedef	int32_t		clock32_t;
 
 typedef struct timespec32 {


### PR DESCRIPTION
### Motivation and Context
Building the kernel modules on FreeBSD 14.5-RELEASE fails with the following message:

```
/usr/src/sys/sys/abi_types.h:30:19: error: redefinition of typedef 'time32_t' is a C11 feature [-Werror,-Wtypedef-redefinition]
/home/zfs/zfs/include/os/freebsd/spl/sys/types32.h:35:17: note: previous definition is here
```

FreeBSD 14.5 gained `sys/abi_types.h`, which typedefs `time32_t` and is included by `sys/event.h` in the kernel. The SPL `types32.h` typedefs it too so stable/14 builds modules with `-std=gnu99`, where clang rejects the identical redefinition under `-Werror`; 15.x and CURRENT build with `-std=gnu17` and are unaffected.

The issue appeared after introducing #19058, which upgraded the CI runner to 14.5.

### Description
Apply the change of Konstantin Belousov made to FreeBSD's vendor copy of OpenZFS in freebsd/freebsd-src@87632ddf67b (D55135): include `sys/abi_compat.h` and drop the SPL typedef.

### How Has This Been Tested?
Compiled avl.c, blake3.c, arc.c and spl_procfs_list.c with the CI kmod against headers that include `abi_types.h`: fails under `-std=gnu99` before the change and passes after the commit.

### Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
