### PR TITLE
ZTS: judge mmap_sync by a concurrent fsync, not by a fixed bound

### DIFF
--- a/tests/zfs-tests/cmd/mmap_sync.c
+++ b/tests/zfs-tests/cmd/mmap_sync.c
@@ -10,20 +10,150 @@
  * https://opensource.org/license/CDDL-1.0.
  */
 
+/*
+ * Dirty a mapped page, let the kernel pick it up for background writeback,
+ * msync() it, and fail if an msync() takes longer than the given bound.
+ * An msync() must not wait for the transaction group that a concurrent
+ * background writeback of the page went into (see zpl_writepages()).
+ *
+ * The bound is an absolute time, and an msync() ends with a ZIL commit,
+ * so an IO stall of the underlying device would exceed it just as well.
+ * To tell the two apart a second thread keeps fsync()ing a plain write to
+ * another file of the same dataset: that takes the same ZIL and the same
+ * disk, but has no page writeback to wait for.  An msync() over the bound
+ * is reported only if no fsync() that overlapped it was at least half as
+ * slow; otherwise the device was stalled and the case is noted and
+ * ignored.
+ */
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
-#include <sys/time.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <time.h>
+#include <pthread.h>
+
+#define	NSAMPLES	1024
+
+/*
+ * How long a dirtied page is left alone before it is msync()ed, on every
+ * other iteration.  The test sets dirty_writeback_centisecs and
+ * dirty_expire_centisecs to 1, so the kernel picks the page up for
+ * background writeback within some 10-20 ms; this makes sure that has
+ * happened by the time msync() looks at it.  The iterations in between
+ * msync() right away, so that it is msync() that writes the page out.
+ */
+#define	WRITEBACK_DELAY_US	50000
+
+/* Pause between the fsync()s that sample the device latency. */
+#define	FSYNC_INTERVAL_US	10000
+
+typedef struct sample {
+	struct timespec start;
+	struct timespec end;
+} sample_t;
+
+static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+static sample_t samples[NSAMPLES];
+static unsigned long nsamples;
+static struct timespec inflight;	/* start of the fsync in progress */
+static int inflight_valid;
+static int fsync_fd = -1;
+static volatile int stop;
+static int fsync_err;
+
+static double
+ms_since(const struct timespec *from, const struct timespec *to)
+{
+	return ((to->tv_sec - from->tv_sec) * 1000.0 +
+	    (to->tv_nsec - from->tv_nsec) / 1000000.0);
+}
+
+static int
+ts_before(const struct timespec *a, const struct timespec *b)
+{
+	return (a->tv_sec < b->tv_sec ||
+	    (a->tv_sec == b->tv_sec && a->tv_nsec < b->tv_nsec));
+}
+
+static void *
+fsync_loop(void *arg)
+{
+	(void) arg;
+	long long y = 0;
+
+	while (!stop) {
+		sample_t s;
+
+		clock_gettime(CLOCK_MONOTONIC, &s.start);
+		pthread_mutex_lock(&lock);
+		inflight = s.start;
+		inflight_valid = 1;
+		pthread_mutex_unlock(&lock);
+
+		if (pwrite(fsync_fd, &y, sizeof (y), 0) != sizeof (y) ||
+		    fsync(fsync_fd) != 0) {
+			fsync_err = 1;
+			perror("fsync");
+			stop = 1;
+			return (NULL);
+		}
+		y++;
+
+		clock_gettime(CLOCK_MONOTONIC, &s.end);
+		pthread_mutex_lock(&lock);
+		samples[nsamples++ % NSAMPLES] = s;
+		inflight_valid = 0;
+		pthread_mutex_unlock(&lock);
+		usleep(FSYNC_INTERVAL_US);
+	}
+	return (NULL);
+}
+
+/*
+ * The longest fsync() that overlapped [start, end], in ms.  An fsync()
+ * that started inside that window but has not finished yet is waited for,
+ * since it is the one that saw the same stall.
+ */
+static double
+slowest_overlapping_fsync(const struct timespec *start,
+    const struct timespec *end)
+{
+	double slowest = 0;
+
+	for (;;) {
+		pthread_mutex_lock(&lock);
+		if (!inflight_valid || !ts_before(&inflight, end) || stop) {
+			pthread_mutex_unlock(&lock);
+			break;
+		}
+		pthread_mutex_unlock(&lock);
+		usleep(1000);
+	}
+
+	pthread_mutex_lock(&lock);
+	unsigned long n = nsamples < NSAMPLES ? nsamples : NSAMPLES;
+	for (unsigned long i = 0; i < n; i++) {
+		sample_t *s = &samples[i];
+
+		if (ts_before(&s->end, start) || ts_before(end, &s->start))
+			continue;
+		double ms = ms_since(&s->start, &s->end);
+		if (ms > slowest)
+			slowest = ms;
+	}
+	pthread_mutex_unlock(&lock);
+	return (slowest);
+}
 
 static void
-cleanup(char *file)
+cleanup(char *file, char *fsync_file)
 {
 	(void) remove(file);
+	(void) remove(fsync_file);
 }
 
 int
@@ -61,13 +191,16 @@ main(int argc, char *argv[])
 	}
 
 	char filepath[512];
-	filepath[0] = '\0';
+	char fsyncpath[512];
 	char *file = &filepath[0];
+	char *fsync_file = &fsyncpath[0];
 
-	(void) snprintf(file, 512, "%s/msync_file", testdir);
+	(void) snprintf(file, sizeof (filepath), "%s/msync_file", testdir);
+	(void) snprintf(fsync_file, sizeof (fsyncpath), "%s/fsync_file",
+	    testdir);
 
 	const int LEN = 8;
-	cleanup(file);
+	cleanup(file, fsync_file);
 
 	int fd = open(file, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR |
 	    S_IRGRP | S_IROTH);
@@ -78,9 +211,19 @@ main(int argc, char *argv[])
 		return (1);
 	}
 
+	fsync_fd = open(fsync_file, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR |
+	    S_IRGRP | S_IROTH);
+
+	if (fsync_fd == -1) {
+		(void) fprintf(stderr, "%s: %s: ", argv[0], fsync_file);
+		perror("open");
+		cleanup(file, fsync_file);
+		return (1);
+	}
+
 	if (ftruncate(fd, LEN) != 0) {
 		perror("ftruncate");
-		cleanup(file);
+		cleanup(file, fsync_file);
 		return (1);
 	}
 
@@ -88,56 +231,77 @@ main(int argc, char *argv[])
 
 	if (ptr == MAP_FAILED) {
 		perror("mmap");
-		cleanup(file);
+		cleanup(file, fsync_file);
 		return (1);
 	}
 
-	struct timeval tstart;
-	gettimeofday(&tstart, NULL);
+	pthread_t tid;
+	if (pthread_create(&tid, NULL, fsync_loop, NULL) != 0) {
+		perror("pthread_create");
+		cleanup(file, fsync_file);
+		return (1);
+	}
+
+	struct timespec tstart;
+	clock_gettime(CLOCK_MONOTONIC, &tstart);
 
 	long long x = 0LL;
+	int ret = 0;
+	int stalls = 0;
 
-	for (;;) {
+	while (!stop) {
 		*((long long *)ptr) = x;
 		x++;
+		if (x % 2 == 0)
+			usleep(WRITEBACK_DELAY_US);
 
-		struct timeval t1, t2;
-		gettimeofday(&t1, NULL);
+		struct timespec t1, t2;
+		clock_gettime(CLOCK_MONOTONIC, &t1);
 		if (msync(ptr, LEN, MS_SYNC|MS_INVALIDATE) != 0) {
 			perror("msync");
-			cleanup(file);
-			return (1);
-		}
-
-		gettimeofday(&t2, NULL);
-
-		double elapsed = (t2.tv_sec - t1.tv_sec) * 1000.0;
-		elapsed += ((t2.tv_usec - t1.tv_usec) / 1000.0);
-		if (elapsed > max_msync_time_ms) {
-			fprintf(stderr, "slow msync: %f ms\n", elapsed);
-			if (munmap(ptr, LEN) != 0)
-				perror("munmap");
-			cleanup(file);
-			return (1);
-		}
-
-		double elapsed_start = (t2.tv_sec - tstart.tv_sec) * 1000.0;
-		elapsed_start += ((t2.tv_usec - tstart.tv_usec) / 1000.0);
-		if (elapsed_start > run_time_mins * 60 * 1000) {
+			ret = 1;
 			break;
 		}
+		clock_gettime(CLOCK_MONOTONIC, &t2);
+
+		double elapsed = ms_since(&t1, &t2);
+		if (elapsed > max_msync_time_ms) {
+			double fsync_ms = slowest_overlapping_fsync(&t1, &t2);
+
+			if (fsync_ms < elapsed / 2) {
+				fprintf(stderr, "slow msync: %f ms, while a "
+				    "concurrent fsync took at most %f ms\n",
+				    elapsed, fsync_ms);
+				ret = 1;
+				break;
+			}
+			fprintf(stderr, "slow msync: %f ms, ignored: a "
+			    "concurrent fsync took %f ms as well\n",
+			    elapsed, fsync_ms);
+			stalls++;
+		}
+
+		if (ms_since(&tstart, &t2) > run_time_mins * 60 * 1000.0)
+			break;
 	}
+
+	stop = 1;
+	(void) pthread_join(tid, NULL);
+	if (fsync_err)
+		ret = 1;
+	if (stalls > 0)
+		fprintf(stderr, "%d msync(s) ignored due to IO stalls\n",
+		    stalls);
 
 	if (munmap(ptr, LEN) != 0) {
 		perror("munmap");
-		cleanup(file);
-		return (1);
+		ret = 1;
 	}
 
-	if (close(fd) != 0) {
+	if (close(fd) != 0 || close(fsync_fd) != 0) {
 		perror("close");
 	}
 
-	cleanup(file);
-	return (0);
+	cleanup(file, fsync_file);
+	return (ret);
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Seen in CI:
- https://github.com/openzfs/zfs/actions/runs/33803391217/job/100808052912?pr=19043 
- https://github.com/openzfs/zfs/actions/runs/33850494608/job/100952017236?pr=19045

### Description
<!--- Describe your changes in detail -->
mmap_sync fails whenever one msync() takes longer than two seconds, and in CI it does, on machines that are merely loaded:

    slow msync: 2318.177000 ms
    slow msync: 4043.686000 ms

The bound was raised once already, in c4d1a19b3 ("ZTS: increase timeout of mmap_sync_001_pos"), and the ctime_001_pos failure fixed in 8486ea36f shows the same CI stalling a creat() for twelve seconds, so no fixed bound is going to hold there.

An msync() goes through zpl_fsync(): since a18c9edda ("Linux: sync: remove async/sync accounting") it writes the dirty pages out with zfs_putpage() and ends in zil_commit(), and it never waits for page writeback.  So what the bound really measures is the ZIL commit, which is the disk.  Sampling the kernel stacks of mmap_sync under an IO load in a VM confirms it: the time goes into zil_commit_impl() waiting for the lwb, with nothing txg-related on the msync() path.

Measure the disk alongside instead.  A second thread keeps fsync()ing a plain write to another file of the same dataset every 10 ms: that takes the same ZIL and the same device, but has no page writeback to wait for.  An msync() over the bound is reported only when no fsync() that overlapped it was at least half as slow; when one was, the device stalled, and the case is printed and ignored.  A regression that makes msync() wait for something fsync() does not is still caught, since the fsync() next to it stays fast.

The loop also did not test what the test describes.  Each iteration msync()ed right after dirtying the page, so the page was dirty for microseconds and the background writeback, which the test tunes the kernel to run every 10 ms, almost never saw it: a kprobe on zfs_putpage() counted 2916 calls from msync() against 5 from the writeback in 20 seconds.  Every other iteration now leaves the page alone for 50 ms first, so half of the msync()s find the page written back already and the other half write it out themselves; the counts became 1032 to 1032.
### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Verified in a VM with a dm-linear device over the pool that gets suspended for three seconds three times during the run: the old binary fails at the first stall, the new one reports all three as ignored and passes, and passes without the stalls as well.
### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [X] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
