### PR TITLE
zdb: do not adopt an unreferenced spa when the pool fails to open

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -10674,12 +10674,18 @@ main(int argc, char **argv)
 				/*
 				 * If we're missing the log device then
 				 * try opening the pool after clearing the
-				 * log state.
+				 * log state.  Keep the global spa NULL
+				 * meanwhile: the failed open left it that
+				 * way, we hold no reference on what the
+				 * lookup returns, and zdb_exit() would
+				 * spa_close() it on the way out.
 				 */
+				spa_t *found;
+
 				spa_namespace_enter(FTAG);
-				if ((spa = spa_lookup(target)) != NULL &&
-				    spa->spa_log_state == SPA_LOG_MISSING) {
-					spa->spa_log_state = SPA_LOG_CLEAR;
+				if ((found = spa_lookup(target)) != NULL &&
+				    found->spa_log_state == SPA_LOG_MISSING) {
+					found->spa_log_state = SPA_LOG_CLEAR;
 					error = 0;
 				}
 				spa_namespace_exit(FTAG);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Small cleanup, seen in CI:
https://github.com/openzfs/zfs/actions/runs/33803391217/job/100808053318?pr=19043 https://github.com/openzfs/zfs/actions/runs/33875183904/job/101031216073?pr=19046

### Description
<!--- Describe your changes in detail -->
When spa_open_rewind() fails, zdb looks the pool up in the namespace to see whether it only failed for a missing log device, and it does so into the global spa:

    if ((spa = spa_lookup(target)) != NULL &&
        spa->spa_log_state == SPA_LOG_MISSING) {

spa_lookup() takes no reference, and the open that just failed had already set spa to NULL.  So whenever the pool is in the namespace but fails to open for any other reason, zdb goes on to fatal(), and zdb_exit() then spa_close()s a pool it holds no reference on:

    zdb: can't open 'testpool': Device not configured
    ASSERT at module/zfs/spa_misc.c:1004:spa_close()
    zfs_refcount_count(&spa->spa_refcount) > spa->spa_minref || ...

The pool is in the namespace whenever the cachefile names it, so a zdb run against a pool that is momentarily not openable, which is what ZTS vdev_zaps_004_pos hit right after a zpool attach, aborts with a backtrace instead of reporting the error.

Keep the lookup in a local variable.  The global stays NULL, as the failed open left it, and the retry sets it if it succeeds.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Verified with a cachefile that names a pool whose vdev path is gone: before this change zdb -C on it aborts with the assertion above, after it reports "can't open" and exits with 1.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [X] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
