### PR TITLE
build: Add gitrev as a dependency to specific targets that require it

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -67,9 +67,11 @@ GITREV = include/zfs_gitrev.h
 CLEANFILES += $(GITREV)
 PHONY += gitrev
 gitrev:
+	cd "$(abs_top_builddir)"; \
 	$(AM_V_GEN)$(top_srcdir)/scripts/make_gitrev.sh $(GITREV)
 
-all: gitrev
+GITREV_TARGETS := $(shell $(GREP) -rl --include="*.[ch]" $(notdir $(GITREV)) "$(abs_srcdir)"/* | sed "s|$(abs_srcdir)/||" )
+$(GITREV_TARGETS): gitrev
 
 PHONY += install-data-hook $(INSTALL_DATA_HOOKS)
 install-data-hook: $(INSTALL_DATA_HOOKS)

--- a/contrib/debian/rules.in
+++ b/contrib/debian/rules.in
@@ -102,7 +102,7 @@ override_dh_auto_install:
 		'$(CURDIR)/$(NAME)-$(DEB_VERSION_UPSTREAM)/configure.ac' | sed '/ZFS_AC_PACKAGE/d' > '$(CURDIR)/debian/tmp/usr/src/$(NAME)-$(DEB_VERSION_UPSTREAM)/configure.ac'
 	@# Set "SUBDIRS = module include" for CONFIG_KERNEL and remove SUBDIRS for all other configs.
 	@# Do not regenerate zfs_gitrev.h during dkms build
-	sed '1,/CONFIG_KERNEL/s/SUBDIRS.*=.*//g;s/SUBDIRS.*=.*/SUBDIRS = module include/g;/make_gitrev.sh/d' \
+	sed '1,/CONFIG_KERNEL/s/SUBDIRS.*=.*//g;s/SUBDIRS.*=.*/SUBDIRS = module include/g;s/\([^\t]*make_gitrev.sh\)/: \1/' \
 		'$(CURDIR)/$(NAME)-$(DEB_VERSION_UPSTREAM)/Makefile.am' > '$(CURDIR)/debian/tmp/usr/src/$(NAME)-$(DEB_VERSION_UPSTREAM)/Makefile.am'
 	@# Sanity test
 	grep -q 'SUBDIRS = module include' '$(CURDIR)/debian/tmp/usr/src/$(NAME)-$(DEB_VERSION_UPSTREAM)/Makefile.am'

--- a/module/Makefile.in
+++ b/module/Makefile.in
@@ -3,13 +3,13 @@ include Kbuild
 INSTALL_MOD_DIR ?= extra
 INSTALL_MOD_PATH ?= $(DESTDIR)
 
-all: modules
+all: modules gitrev
 distclean maintainer-clean: clean
 install: modules_install data_install
 uninstall: modules_uninstall data_uninstall
 check:
 
-.PHONY: all distclean maintainer-clean install uninstall check distdir \
+.PHONY: all distclean maintainer-clean install uninstall check distdir gitrev \
 	modules modules-Linux modules-FreeBSD modules-unknown \
 	clean clean-Linux clean-FreeBSD \
 	modules_install modules_install-Linux modules_install-FreeBSD \
@@ -50,6 +50,9 @@ FMAKEFLAGS += MAKEOBJDIR=@abs_builddir@
 endif
 
 FMAKE = env -u MAKEFLAGS make $(FMAKEFLAGS)
+
+gitrev:
+	$(MAKE) -C "@abs_top_builddir@" gitrev
 
 modules-Linux:
 	mkdir -p $(sort $(dir $(spl-objs) $(spl-)))


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
`make zdb` on a clean build dir is broken.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->
The gitrev target was added as a dependency of the "all" target in e6c093dd94 as previous to that it was a dependency of all built sources, including the dist target for which it is unnecessary. This the meant that the gitrev target would only be triggered when running the "all" target. All subtargets that have an indirect dependency would not trigger the gitrev target. Practically this means that building directly certain binary targets, like zdb, would fail like so:

```
$ make zdb
  CC       module/zfs/libzpool_la-abd.lo
... snip ...
  CC       module/zfs/libzpool_la-uberblock.lo
/home/user/zfs.git/module/zfs/spa_history.c:32:10: fatal error: zfs_gitrev.h: No such file or directory
   32 | #include "zfs_gitrev.h"
      |          ^~~~~~~~~~~~~~
compilation terminated.
make: *** [Makefile:11422: module/zfs/libzpool_la-spa_history.lo] Error 1
make: *** Waiting for unfinished jobs....
```

Fix the build system to allow building directly binary targets by finding .c or .h souce files that include zfs_gitrev.h and adding a rule to have them depend on the gitrev target. This way gitrev will precisely be built for targets that indirectly require it.

### How Has This Been Tested?
Without this change `make zdb` on a clean build it broken, with this change it succeeds.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
