### PR TITLE
dmu: account dirty data for cloned blocks

### DIFF
--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -2885,6 +2885,7 @@ dmu_brt_clone(objset_t *os, uint64_t object, uint64_t offset, uint64_t length,
 	dbuf_dirty_record_t *dr;
 	const blkptr_t *bp;
 	int error = 0, i, numbufs;
+	uint64_t accounted = 0, pinned_charge = 0;
 
 	spa = os->os_spa;
 
@@ -2941,6 +2942,41 @@ dmu_brt_clone(objset_t *os, uint64_t object, uint64_t offset, uint64_t length,
 		dl->dr_brtwrite = B_TRUE;
 		dl->dr_override_state = DR_OVERRIDDEN;
 
+		/*
+		 * The charge decides when the dirty throttle trips, and
+		 * neither obvious value works.  What a clone really pins
+		 * is the dbuf and its dirty record, a few hundred bytes,
+		 * which never reaches zfs_dirty_data_max and so bounds
+		 * nothing.  db_size, what dmu_write_direct() charges for
+		 * the other DB_NOFILL producer, throttles 11x to 347x too
+		 * early because no data buffer is held at all.
+		 *
+		 * Scale the real cost by how much larger the dirty limit
+		 * is than the ARC target, so the throttle trips just as
+		 * the pinned dbufs would fill the ARC.  The two limits are
+		 * independent, one derived from memory and one from the
+		 * ARC target, and it is the ARC that this overruns.
+		 *
+		 * dr_accounted has to be per record, because dbuf_undirty()
+		 * subtracts it again one record at a time.  The pool-wide
+		 * total does not: sum it here and hand it over once below.
+		 * dmu_objset_willuse_space() takes dd_lock and dp_lock, and
+		 * paying that per block is what made an earlier version of
+		 * this 30x slower on a file reflinked onto itself, where
+		 * every block shares one BRT entry and the baseline cost
+		 * per block is only a refcount bump.
+		 */
+		if (pinned_charge == 0) {
+			uint64_t pin = sizeof (dmu_buf_impl_t) +
+			    sizeof (dbuf_dirty_record_t);
+			uint64_t arcmax = arc_target_bytes();
+			pinned_charge = (arcmax == 0) ? pin :
+			    MAX(pin, (pin * zfs_dirty_data_max) / arcmax);
+			pinned_charge = MIN(pinned_charge, db->db.db_size);
+		}
+		dr->dr_accounted = pinned_charge;
+		accounted += dr->dr_accounted;
+
 		mutex_exit(&db->db_mtx);
 
 		/*
@@ -2953,6 +2989,9 @@ dmu_brt_clone(objset_t *os, uint64_t object, uint64_t offset, uint64_t length,
 		}
 	}
 out:
+	if (accounted != 0)
+		dmu_objset_willuse_space(os, accounted, tx);
+
 	dmu_buf_rele_array(dbp, numbufs, FTAG);
 
 	return (error);


### PR DESCRIPTION
### Motivation and Context

A clone can push the ARC well past `zfs_arc_max`, and hold a further
large amount of memory that the ARC never sees.

`dbuf_dirty()` skips the dirty accounting for a DB_NOFILL dbuf, and
`dmu_buf_will_clone_or_dio()` leaves a cloned dbuf DB_NOFILL, so a clone
contributes nothing to `dp_dirty_total` and nothing throttles it. A
clone dirties dbufs far faster than it moves data, and those dbufs stay
pinned until the TXG syncs, so the ARC cannot evict them.

The same missing throttle lets `brt_entry_cache` grow without bound.
Every cloned block holds a 168 byte entry in `bv_pending_tree` until the
TXG syncs, and with nothing to slow the clone down the whole thing lands
in one TXG. That memory is not ARC, and no ARC tunable limits it.

Closes #17424.

### Description

Charge each dirty record in `dmu_brt_clone()`.

Neither obvious value for the charge works. The real per-record cost is
around 530 bytes, too small to trip the throttle before the pinned dbufs
fill the ARC. `db_size` overcharges by two orders of magnitude, since no
data buffer is held at all, and the throttle then trips almost at once.
So scale the real cost by how much larger the dirty limit is than the
ARC target. The throttle then trips at the point the pinned dbufs would
have filled the ARC.

`dr_accounted` is set per record because `dbuf_undirty()` subtracts it
one record at a time. The pool-wide total is summed and handed to
`dmu_objset_willuse_space()` once, since that call takes `dd_lock` and
then `dp_lock`, and paying it per block is expensive on a file reflinked
onto itself where every block shares one BRT entry.

### How Has This Been Tested?

Debian 13, kernel 6.12.96, in QEMU.

ARC behaviour with `zfs_arc_max` at 128 MiB under a back-to-back clone
workload, sampled over 12 passes:

| | before | after |
|---|---|---|
| passes over the limit | 12 of 12 | 0 to 6 |
| trend | climbs 140 to 163 MiB | oscillates, no climb |
| peak | 127% | 110 to 115% |
| evict_skip | 75,531,675 | 0 to 36,475 |

The peak percentages undersell it. Before, the ARC climbs on every pass
and does not come back. After, it moves up and down around the limit.

`brt_entry_cache` peak, cloning distinct blocks at a 4K recordsize:

| clone | blocks | before | after |
|---|---|---|---|
| 2 GB | 524,288 | 524,304 entries, 84 MB | 13 MB |
| 4 GB | 1,048,576 | 1,048,728 entries, 168 MB | 8 to 39 MB |

Before, the peak is the block count exactly, and doubling the clone
doubles the memory. After it stops tracking the clone size.

Throughput, median of 5 interleaved baseline/patched rounds, one VM at a
time so nothing else competes for the disk:

| | before | after |
|---|---|---|
| sequential write, 2 GB | 2246 ms | 2207 ms |
| cross-file clone, 2 GB | 271 ms | 266 ms |
| send -e, recv, 40k embedded records | 827 ms | 840 ms |

fstests: 776 tests across raidz1, stripe3, mirror, single-vdev
ashift=12 and single-vdev ashift=9. No new failures on any topology.
generic/297 went from failing on all five to passing on all five.

ZTS: 2072 pass, 17 fail, 19 skip, 98.3%, in 6h12m. All 53 tests in the
bclone and block_cloning groups pass. Every one of the 17 failures also
occurs without this patch: 13 fail identically on unpatched master (6 of
those are the casenorm tests fixed by #19028), and the remaining 4 pass
when run individually with this patch applied, so their failures come
from running inside a six-hour suite rather than from this change.

ztest passes.

### Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
