### PR TITLE
vdev_id: add sas_expander topology

### DIFF
--- a/contrib/debian/not-installed
+++ b/contrib/debian/not-installed
@@ -5,6 +5,7 @@ etc/init.d
 etc/zfs/vdev_id.conf.alias.example
 etc/zfs/vdev_id.conf.multipath.example
 etc/zfs/vdev_id.conf.sas_direct.example
+etc/zfs/vdev_id.conf.sas_expander.example
 etc/zfs/vdev_id.conf.sas_switch.example
 etc/zfs/vdev_id.conf.scsi.example
 etc/zfs/zfs-functions

--- a/contrib/debian/openzfs-zfsutils.examples
+++ b/contrib/debian/openzfs-zfsutils.examples
@@ -1,5 +1,6 @@
 etc/zfs/vdev_id.conf.alias.example
 etc/zfs/vdev_id.conf.multipath.example
 etc/zfs/vdev_id.conf.sas_direct.example
+etc/zfs/vdev_id.conf.sas_expander.example
 etc/zfs/vdev_id.conf.sas_switch.example
 etc/zfs/vdev_id.conf.scsi.example

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -6,6 +6,7 @@ dist_sysconf_zfs_DATA = \
 	%D%/zfs/vdev_id.conf.alias.example \
 	%D%/zfs/vdev_id.conf.multipath.example \
 	%D%/zfs/vdev_id.conf.sas_direct.example \
+	%D%/zfs/vdev_id.conf.sas_expander.example \
 	%D%/zfs/vdev_id.conf.sas_switch.example \
 	%D%/zfs/vdev_id.conf.scsi.example
 

--- a/etc/zfs/vdev_id.conf.sas_expander.example
+++ b/etc/zfs/vdev_id.conf.sas_expander.example
@@ -1,0 +1,7 @@
+topology sas_expander
+
+#       EXPANDER ADDR      CHANNEL NAME
+channel 0x500304000000000f J1A
+channel 0x500304000000001f J1B
+channel 0x500304000000002f J2A
+channel 0x500304000000003f J2B

--- a/man/man5/vdev_id.conf.5
+++ b/man/man5/vdev_id.conf.5
@@ -109,12 +109,15 @@ then
 will examine the first running component disk of a dm-multipath
 device as provided by the driver command to determine the physical path.
 .
-.It Sy topology Sy sas_direct Ns | Ns Sy sas_switch Ns | Ns Sy scsi
+.It Sy topology Sy sas_direct Ns | Ns Sy sas_expander Ns | Ns Sy sas_switch Ns | Ns Sy scsi
 Identifies a physical topology that governs how physical paths are
 mapped to channels:
 .Bl -tag -compact -width "sas_direct and scsi"
 .It Sy sas_direct No and Sy scsi
 channels are uniquely identified by a PCI slot and HBA port number
+.It Sy sas_expander
+channels are uniquely identified by the SAS address of the rightmost expander
+in the device path
 .It Sy sas_switch
 channels are uniquely identified by a SAS switch port number
 .El
@@ -213,6 +216,20 @@ channel 1            A
 channel 2            B
 channel 3            C
 channel 4            D
+.Ed
+.Pp
+A SAS-expander topology.
+Note that the
+.Ar channel
+keyword takes only two arguments in this example:
+.Bd -literal -compact -offset Ds
+topology      sas_expander
+
+#       EXPANDER ADDR      CHANNEL NAME
+channel 0x500304000000000f J1A
+channel 0x500304000000001f J1B
+channel 0x500304000000002f J2A
+channel 0x500304000000003f J2B
 .Ed
 .Pp
 A multipath configuration.

--- a/man/man8/vdev_id.8
+++ b/man/man8/vdev_id.8
@@ -20,7 +20,7 @@
 .Nm
 .Fl d Ar dev
 .Fl c Ar config_file
-.Fl g Sy sas_direct Ns | Ns Sy sas_switch Ns | Ns Sy scsi
+.Fl g Sy sas_direct Ns | Ns Sy sas_expander Ns | Ns Sy sas_switch Ns | Ns Sy scsi
 .Fl m
 .Fl p Ar phys_per_port
 .
@@ -40,6 +40,7 @@ The drive aliases will be created as symbolic links in
 .Pp
 The currently supported topologies are
 .Sy sas_direct ,
+.Sy sas_expander ,
 .Sy sas_switch ,
 and
 .Sy scsi .
@@ -67,12 +68,15 @@ The device node to classify, like
 Specifies the path to an alternate configuration file.
 The default is
 .Pa /etc/zfs/vdev_id.conf .
-.It Fl g Sy sas_direct Ns | Ns Sy sas_switch Ns | Ns Sy scsi
+.It Fl g Sy sas_direct Ns | Ns Sy sas_expander Ns | Ns Sy sas_switch Ns | Ns Sy scsi
 Identifies a physical topology that governs how physical paths are
 mapped to channels:
 .Bl -tag -compact -width "sas_direct and scsi"
 .It Sy sas_direct No and Sy scsi
 channels are uniquely identified by a PCI slot and HBA port number
+.It Sy sas_expander
+channels are uniquely identified by the SAS address of the rightmost expander
+in the device path
 .It Sy sas_switch
 channels are uniquely identified by a SAS switch port number
 .El

--- a/udev/vdev_id
+++ b/udev/vdev_id
@@ -11,7 +11,8 @@
 # default numbering is unsatisfactory.  The drive aliases will be
 # created as symbolic links in /dev/disk/by-vdev.
 #
-# The currently supported topologies are sas_direct and sas_switch.
+# The currently supported topologies are sas_direct, sas_expander
+# and sas_switch.
 # A multipath mode is supported in which dm-mpath devices are
 # handled by examining the first-listed running component disk.  In
 # multipath mode the configuration file should contain a channel
@@ -54,6 +55,18 @@
 # slot 2          2
 # slot 3          1
 # slot 4          3
+
+# #
+# # Example vdev_id.conf - sas_expander
+# #
+#
+# topology sas_expander
+#
+# #       EXPANDER ADDR      CHANNEL NAME
+# channel 0x500304000000000f J1A
+# channel 0x500304000000001f J1B
+# channel 0x500304000000002f J2A
+# channel 0x500304000000003f J2B
 
 # #
 # # Example vdev_id.conf - sas_switch
@@ -130,7 +143,7 @@ usage() {
 	cat << EOF
 Usage: vdev_id [-h]
        vdev_id <-d device> [-c config_file] [-p phys_per_port]
-               [-g sas_direct|sas_switch|scsi] [-m]
+               [-g sas_direct|sas_expander|sas_switch|scsi] [-m]
 
   -c    specify name of an alternative config file [default=$CONFIG]
   -d    specify basename of device (i.e. sda)
@@ -162,6 +175,7 @@ map_channel() {
 	MAPPED_CHAN=
 	PCI_ID=$1
 	PORT=$2
+	EXPANDER=$3
 
 	case $TOPOLOGY in
 		"sas_switch")
@@ -173,6 +187,11 @@ map_channel() {
 		MAPPED_CHAN=$(awk -v pciID="$PCI_ID" -v port="$PORT" \
 			'$1 == "channel" && $2 == pciID && $3 == port \
 			{print $4}' $CONFIG)
+		;;
+		"sas_expander")
+		MAPPED_CHAN=$(awk -v expaddr="$EXPANDER" \
+			'$1 == "channel" && tolower($2) == tolower(expaddr) \
+			{print $3; exit}' $CONFIG)
 		;;
 	esac
 	printf "%s" "${MAPPED_CHAN}"
@@ -383,7 +402,7 @@ sas_handler() {
 
 	case $TOPOLOGY in
 		"sas_switch") j=$((i + 4)) ;;
-		"sas_direct") j=$((i + 1)) ;;
+		"sas_direct"|"sas_expander") j=$((i + 1)) ;;
 	esac
 
 	i=$((i + 1))
@@ -403,15 +422,27 @@ sas_handler() {
 	# attribute.
 	end_device_dir=$port_dir
 
+	expander_dev=
 	while [ $i -lt "$num_dirs" ] ; do
 		d=$(eval echo '$'{$i})
 		end_device_dir="$end_device_dir/$d"
-		if echo "$d" | grep -q '^end_device' ; then
+		case $d in
+		expander-*)
+			expander_dev="$d"
+			;;
+		end_device*)
 			end_device_dir="$end_device_dir/sas_device/$d"
 			break
-		fi
+			;;
+		esac
 		i=$((i + 1))
 	done
+
+	EXPANDER=
+	if [ -n "$expander_dev" ] ; then
+		EXPANDER=$(cat \
+			"/sys/class/sas_device/$expander_dev/sas_address" 2>/dev/null)
+	fi
 
 	# Add 'mix' slot type for environments where dm-multipath devices
 	# include end-devices connected via SAS expanders or direct connection
@@ -480,7 +511,7 @@ sas_handler() {
 	fi
 
 	if [ "$MULTIJBOD_MODE" = "yes" ] ; then
-		CHAN=$(map_channel "$PCI_ID" "$PORT")
+		CHAN=$(map_channel "$PCI_ID" "$PORT" "$EXPANDER")
 		SLOT=$(map_slot "$SLOT" "$CHAN")
 		JBOD=$(map_jbod "$DEV")
 
@@ -489,7 +520,7 @@ sas_handler() {
 		fi
 		echo "${CHAN}"-"${JBOD}"-"${SLOT}${LUN}${PART}"
 	else
-		CHAN=$(map_channel "$PCI_ID" "$PORT")
+		CHAN=$(map_channel "$PCI_ID" "$PORT" "$EXPANDER")
 		SLOT=$(map_slot "$SLOT" "$CHAN")
 
 		if [ -z "$CHAN" ] ; then
@@ -614,7 +645,7 @@ scsi_handler() {
 		return
 	fi
 
-	CHAN=$(map_channel "$PCI_ID" "$PORT")
+	CHAN=$(map_channel "$PCI_ID" "$PORT" "")
 	SLOT=$(map_slot "$SLOT" "$CHAN")
 
 	if [ -z "$CHAN" ] ; then
@@ -809,7 +840,7 @@ ID_VDEV=$(alias_handler)
 if [ -z "$ID_VDEV" ] ; then
 	BAY=${BAY:-bay}
 	case $TOPOLOGY in
-		sas_direct|sas_switch)
+		sas_direct|sas_switch|sas_expander)
 			ID_VDEV=$(sas_handler)
 			;;
 		scsi)


### PR DESCRIPTION
This adds a new topology, sas_expander, which assigns disks to channels based on the address of the rightmost expander in their path.

### Motivation and Context

Certain external JBODs present multiple internal expanders (front and backside bays, for example), which each have respective bay and phy 0, and so on.
This results in none of the current topologies/slot setting being able to sensibly map such a setup.
Disks will inevitably overlap, since the same port has multiple disks in bay or phy 0.

### Description
It enumerates the rightmost expander in the device path, and adds it as element to the channel mapping

### How Has This Been Tested?
Copied it onto one of my servers where the issue presents itself with the given example config, and it enumerates all 88 disks correctly.

### Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

Not sure if this is really a bugfix or new feature.
vdev_id was broken on this setup before. But it's also a new feature?

### Checklist
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
