### PR TITLE
Dbnofill dirty accounting

### DIFF
--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -3166,6 +3166,16 @@ dmu_buf_write_embedded(dmu_buf_t *dbuf, void *data,
 
 	dl->dr_override_state = DR_OVERRIDDEN;
 	BP_SET_LOGICAL_BIRTH(&dl->dr_overridden_by, dr->dr_txg);
+
+	/*
+	 * dmu_buf_will_not_fill() leaves the dbuf DB_NOFILL, which
+	 * dbuf_dirty() does not account for, so charge the dirty
+	 * record here.  This keeps a receive of embedded records
+	 * throttled against the syncing TXG.  An embedded write fills
+	 * a whole block, so charge one.
+	 */
+	dr->dr_accounted = db->db.db_size;
+	dmu_objset_willuse_space(db->db_objset, dr->dr_accounted, tx);
 }
 
 void


### PR DESCRIPTION
### Motivation and Context

`dbuf_dirty()` skips the dirty accounting for a DB_NOFILL dbuf. Three
callers leave a dbuf in that state, so none of their dirty records raise
`dp_dirty_total`, nothing throttles them, and the ARC cannot evict what
they pin.

`dmu_brt_clone()` is handled separately. These are the other two.

### Description

Two commits, one per caller.

`dmu_buf_write_embedded()` reaches DB_NOFILL through
`dmu_buf_will_not_fill()`. A receive of a stream of embedded records
runs unthrottled ahead of the syncing TXG. An embedded write fills a
whole block, so charge one.

`dmu_prealloc()` has the same gap. A preallocation writes whole blocks,
so charge one per record and hand the total over once. Only ztest calls
this today.

### How Has This Been Tested?

Throughput, median of 5 interleaved baseline/patched rounds, one VM at
a time so nothing else competes for the disk:

| | before | after |
|---|---|---|
| sequential write, 2 GB | 2470 ms | 2489 ms |
| cross-file clone, 2 GB | 322 ms | 326 ms |
| send -e, recv, 40k embedded records | 861 ms | 801 ms |

The receive path is the one these commits touch, and it does not
regress.

ztest passes, which is what exercises `dmu_prealloc()`, its only caller.

I have no reproducer that shows the embedded path overrunning the ARC on
its own. A receive of 300,002 embedded records against a 64 MiB ARC
peaks at 116%, and the same receive carrying 2 embedded records peaks at
118%, so that overshoot is dnode and bonus buffers from creating 300,000
files rather than the embedded writes. The accounting gap is visible in
the code either way, and these commits close it for consistency with
`dmu_brt_clone()`.

### Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [X] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain