### PR TITLE
Fix self-deadlock when cloning a range within the same file

### DIFF
--- a/module/zfs/zfs_vnops.c
+++ b/module/zfs/zfs_vnops.c
@@ -2083,7 +2083,23 @@ zfs_clone_range(znode_t *inzp, uint64_t *inoffp, znode_t *outzp,
 	/*
 	 * Maintain predictable lock order.
 	 */
-	if (inzp < outzp || (inzp == outzp && inoff < outoff)) {
+	if (inzp == outzp) {
+		/*
+		 * Within one file, one writer lock spans both
+		 * ranges.  Two locks on the same znode can deadlock
+		 * this thread against itself: a write that grows the
+		 * file's block size grows its lock to cover the
+		 * whole file (see zfs_rlock.c), which then conflicts
+		 * with the other.  The source block pointers are
+		 * read before the lock is reduced, so the source
+		 * stays covered.
+		 */
+		uint64_t lo = MIN(inoff, outoff);
+		uint64_t hi = MAX(inoff + len, outoff + len);
+		outlr = zfs_rangelock_enter(&outzp->z_rangelock, lo,
+		    hi - lo, RL_WRITER);
+		inlr = NULL;
+	} else if (inzp < outzp) {
 		inlr = zfs_rangelock_enter(&inzp->z_rangelock, inoff, len,
 		    RL_READER);
 		outlr = zfs_rangelock_enter(&outzp->z_rangelock, outoff, len,
@@ -2099,7 +2115,8 @@ zfs_clone_range(znode_t *inzp, uint64_t *inoffp, znode_t *outzp,
 	    outlr, B_FALSE, &done);
 
 	zfs_rangelock_exit(outlr);
-	zfs_rangelock_exit(inlr);
+	if (inlr != NULL)
+		zfs_rangelock_exit(inlr);
 
 	if (done > 0) {
 		/*


### PR DESCRIPTION
### Motivation and Context

`copy_file_range()` within a single file can self-deadlock the calling
thread forever.

`zfs_clone_range()` takes an RL_READER lock on the source range and an
RL_WRITER lock on the destination range. When source and destination are
the same file, both are on one znode's rangelock. If the destination
write has to grow the file's block size, `zfs_rangelock_enter()` grows
the writer lock to cover the whole file (see zfs_rlock.c), which then
conflicts with the source reader the same thread already holds.

The thread waits in `zfs_rangelock_enter_impl()` in D state. SIGKILL
does not clear it and only a reboot frees it.

The blocksize guard a few lines further down assumes the grow happened:

```c
if (inblksz != outzp->z_blksz && (outzp->z_size > outzp->z_blksz ||
    outlr->lr_length != UINT64_MAX))
```

`lr_length == UINT64_MAX` is the whole-file grow, so reaching that check
for a same-file clone means surviving the deadlock first.

### Description

For a same-file clone, take a single writer lock spanning both ranges
instead of a separate reader and writer. The source block pointers are
read before `zfs_clone_range_locked()` reduces the lock, so the source
stays covered, and one lock cannot conflict with itself. Clones between
different files are unchanged.

`zfs_dedupe_range()` locks the same way and is left alone. It is safe
only because both ranges are checked to lie within the file before the
locks are taken, so `end_size` in `zfs_rangelock_cb()` is just `z_size`
and no lock can grow to cover the whole file. Nothing enforces that
invariant, so it is recorded in a comment next to the locks. A later
change that lets dedupe extend the file would bring the deadlock back.

### How Has This Been Tested?

The deadlock reproduces on unpatched master. fstests generic/564 wedges
an `xfs_io` permanently, both at aa26ca67b1 and at 33ae06bb61, the
commit this one sits on:

```
cmdline: xfs_io -i -F -f -c copy_range -f 0 -d 4k -l 4k <testdir>/$$.xfs_io
[<0>] cv_wait_common
[<0>] zfs_rangelock_enter_impl
[<0>] zfs_clone_range
[<0>] zpl_clone_file_range_impl
[<0>] zpl_copy_file_range
[<0>] vfs_copy_file_range
```

Worth knowing why this has stayed quiet: the call that hangs is the
`_require_xfs_io_command "copy_range" "-f"` probe, not the test body.
The probe copies `[0,4k)` to `[4k,8k)` in one file, which extends it and
grows the block size. The ranges do not overlap, so the EINVAL check
does not fire. check(1) reports no failure and leaves an unkillable task
behind, and the 900 second test timeout cannot clear a D state task
either.

With the commit applied, generic/564 passes and leaves no blocked task.
Same VM, same pool, only the module swapped between arms:

| test | master | master + this commit |
|---|---|---|
| generic/564 | times out, `xfs_io` unkillable | pass |
| generic/297 | pass | pass |
| generic/298 | pass | pass |
| generic/013 | raidz/mirror deadlock | pass |

Throughput, five interleaved baseline and patched rounds. Both modules
came from one tree and differ only by this commit, baseline 793B0F90
and patched 00D20B99:

| | before | after |
|---|---|---|
| same-file clone, 16 clones of 32 MiB, file never grows | 143 ms | 145 ms |
| cross-file clone, 512 MiB | 105 ms | 104 ms |

The same-file clone that this commit changes the locking of cannot be
timed against master, because the case that grows the block size is the
one that deadlocks. So the row above clones inside a file that stays the
same size, which both modules survive, and it shows no cost.

### Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [X] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain