### PR TITLE
ZTS: do not leave a suspended pool behind in the mmp tests

### DIFF
--- a/tests/zfs-tests/tests/functional/mmp/mmp_hostid.ksh
+++ b/tests/zfs-tests/tests/functional/mmp/mmp_hostid.ksh
@@ -36,7 +36,8 @@ verify_runnable "both"
 
 function cleanup
 {
-	datasetexists $MMP_POOL && destroy_pool $MMP_POOL
+	mmp_clear_suspended $MMP_POOL
+	poolexists $MMP_POOL && destroy_pool $MMP_POOL
 	log_must rm $MMP_DIR/file.{0,1,2,3,4,5}
 	log_must rmdir $MMP_DIR
 	log_must mmp_clear_hostid

--- a/tests/zfs-tests/tests/functional/mmp/mmp_on_off.ksh
+++ b/tests/zfs-tests/tests/functional/mmp/mmp_on_off.ksh
@@ -40,7 +40,8 @@ verify_runnable "both"
 
 function cleanup
 {
-	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+	mmp_clear_suspended $TESTPOOL
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
 	log_must set_tunable64 TXG_TIMEOUT $TXG_TIMEOUT_DEFAULT
 	log_must set_tunable64 MULTIHOST_INTERVAL $MMP_INTERVAL_DEFAULT
 	log_must rm -f $PREV_UBER $CURR_UBER

--- a/tests/zfs-tests/tests/functional/mmp/mmp_on_thread.ksh
+++ b/tests/zfs-tests/tests/functional/mmp/mmp_on_thread.ksh
@@ -35,7 +35,8 @@ verify_runnable "both"
 
 function cleanup
 {
-	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+	mmp_clear_suspended $TESTPOOL
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
 	log_must set_tunable64 TXG_TIMEOUT $TXG_TIMEOUT_DEFAULT
 	log_must rm -f $PREV_UBER $CURR_UBER
 	log_must mmp_clear_hostid

--- a/tests/zfs-tests/tests/functional/mmp/mmp_on_uberblocks.ksh
+++ b/tests/zfs-tests/tests/functional/mmp/mmp_on_uberblocks.ksh
@@ -38,7 +38,8 @@ TARGET=$((($NDISKS * $DURATION * 1000) / $MMP_INTERVAL))
 
 function cleanup
 {
-	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+	mmp_clear_suspended $TESTPOOL
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
 	log_must mmp_clear_hostid
 }
 
@@ -50,8 +51,25 @@ log_must mmp_set_hostid $HOSTID1
 log_must zpool create -f $TESTPOOL $DISKS
 log_must zpool set multihost=on $TESTPOOL
 
-clear_mmp_history
-MMP_WRITES=$(count_mmp_writes $TESTPOOL $DURATION)
+#
+# A machine that stops running for longer than the MMP failure window
+# has its pool suspended, and the writes it did not make in the
+# meantime say nothing about the interval this test measures.  Resume
+# the pool and take the sample again rather than report the stall.
+#
+typeset -i attempt
+for (( attempt = 1; attempt <= 3; attempt++ )); do
+	clear_mmp_history
+	MMP_WRITES=$(count_mmp_writes $TESTPOOL $DURATION)
+
+	[[ $(zpool list -H -o health $TESTPOOL) != "SUSPENDED" ]] && break
+
+	log_note "Pool suspended while counting writes, sample $attempt dropped"
+	mmp_clear_suspended $TESTPOOL
+	MMP_WRITES=""
+done
+
+[[ -z $MMP_WRITES ]] && log_fail "Pool suspended on every attempt"
 
 log_note "Uberblock changed $MMP_WRITES times"
 log_must within_percent $MMP_WRITES $TARGET 80

--- a/tests/zfs-tests/tests/functional/mmp/mmp_on_zdb.ksh
+++ b/tests/zfs-tests/tests/functional/mmp/mmp_on_zdb.ksh
@@ -38,7 +38,8 @@
 
 function cleanup
 {
-	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+	mmp_clear_suspended $TESTPOOL
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
 	for DISK in $DISKS; do
 		zpool labelclear -f $DEV_RDSKDIR/$DISK
 	done

--- a/tests/zfs-tests/tests/functional/mmp/mmp_reset_interval.ksh
+++ b/tests/zfs-tests/tests/functional/mmp/mmp_reset_interval.ksh
@@ -40,7 +40,7 @@ verify_runnable "both"
 function cleanup
 {
 	mmp_clear_suspended $TESTPOOL
-	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
 	log_must set_tunable64 MULTIHOST_INTERVAL $MMP_INTERVAL_DEFAULT
 	log_must set_tunable64 MULTIHOST_FAIL_INTERVALS \
 	    $MMP_FAIL_INTERVALS_DEFAULT

--- a/tests/zfs-tests/tests/functional/mmp/mmp_write_distribution.ksh
+++ b/tests/zfs-tests/tests/functional/mmp/mmp_write_distribution.ksh
@@ -33,7 +33,8 @@ verify_runnable "both"
 
 function cleanup
 {
-	datasetexists $MMP_POOL && destroy_pool $MMP_POOL
+	mmp_clear_suspended $MMP_POOL
+	poolexists $MMP_POOL && destroy_pool $MMP_POOL
 	log_must rm $MMP_DIR/file.{0..7}
 	log_must rm $MMP_HISTORY_TMP
 	log_must rmdir $MMP_DIR

--- a/tests/zfs-tests/tests/functional/mmp/mmp_write_uberblocks.ksh
+++ b/tests/zfs-tests/tests/functional/mmp/mmp_write_uberblocks.ksh
@@ -34,7 +34,8 @@ verify_runnable "both"
 function cleanup
 {
 	zinject -c all
-	datasetexists $TESTPOOL && destroy_pool $TESTPOOL
+	mmp_clear_suspended $TESTPOOL
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
 	log_must mmp_clear_hostid
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Seen in CI:
https://github.com/openzfs/zfs/actions/runs/33875183904/job/101031215276?pr=19046

### Description
<!--- Describe your changes in detail -->
The mmp tests destroy their pool from cleanup through

    datasetexists $TESTPOOL && destroy_pool $TESTPOOL

and datasetexists() asks zfs, which cannot open a pool whose I/O is suspended:

    # zfs get name msus
    cannot open 'msus': pool I/O is currently suspended

MMP suspends the pool by itself once its writes have not succeeded for long enough, which is exactly the state a failing mmp test tends to leave behind, so the guard says the pool is gone, cleanup destroys nothing, and the pool stays imported.  Every mmp test that runs after it then fails on its own zpool create:

    /dev/loop0 is part of active pool 'testpool'

In CI one mmp_on_uberblocks failure took mmp_on_off, mmp_reset_interval and mmp_write_uberblocks with it this way.

Ask zpool instead of zfs, and clear the suspension first with the mmp_clear_suspended() helper that 8373e97e4 ("ZTS: resume a suspended pool in mmp_reset_interval cleanup") added for this, so that the destroy has a pool it can work with.

mmp_on_uberblocks also fails on its own when the machine stalls: it counts the uberblock writes of ten seconds and requires them within 20% of the expected rate, and a machine that stops running for longer than the MMP failure window makes neither the writes nor a meaningful sample.  The CI run above lost 37 seconds inside that window:

    WARNING: MMP writes to pool 'testpool' have not succeeded in over
    37139 ms; suspending pool

and the kstat it dumped shows the same gap, fifteen writes in the first four seconds and then nothing for thirty-nine.  Take the sample again when the pool was suspended while it was being taken, up to three times, rather than report the stall as a wrong interval.  A genuine slowdown leaves the pool online and still fails.


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Verified in a VM: a pool suspended by holding its dm device shows "cannot open" from zfs and lists fine from zpool, which is the mechanism above, and the mmp group passes with the change.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [X] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
