### PR TITLE
L2ARC: do not feed a device while its rebuild is pending

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -10250,6 +10250,11 @@ l2arc_feed_thread(void *arg)
 		if (!spa_config_tryenter(spa, SCL_L2ARC, dev, RW_READER))
 			continue;
 
+		if (dev->l2ad_rebuild || dev->l2ad_trim_all) {
+			spa_config_exit(spa, SCL_L2ARC, dev);
+			continue;
+		}
+
 		/*
 		 * Avoid contributing to memory pressure.
 		 */


### PR DESCRIPTION
### Motivation and Context

A cache vdev reports 16.0E free once `vs_alloc` passes `vs_space`. Supersedes
#18926, which bounded what the rebuild restores and did not fix it. The cause
is a feed thread writing to a device whose rebuild has not run yet, a check
lost in b525525b4 (#18093).

### Description

`l2arc_add_vdev()` marks the device `l2ad_rebuild` and starts its feed thread,
but the rebuild itself runs later from the spa async thread and nothing stops
the feed thread from writing in between. It writes at `l2ad_start` as if the
device were empty, while the rebuild then restores the on-disk contents.

`l2ad_buflist` is ordered by when each header was written, which is also
device-offset order as long as only the feed thread adds to it. The rebuild
appends restored headers at the tail, behind anything a racing feed already
put at the head, so the list ends up out of order. That breaks the assumption
`l2arc_evict()` makes when it walks from the tail and stops at the first
header outside the range it is clearing: it now exits early, headers the hand
is about to overwrite are never destroyed, and each rewrite charges the space
again. `vs_alloc` passes `vs_space` and the unclamped subtraction in zpool(8)
wraps.

`l2arc_dev_invalid()` skipped a device with `l2ad_rebuild` or `l2ad_trim_all`
set until b525525b4 made the feed threads per-device; neither flag has had a
reader since. Check them in `l2arc_feed_thread()` after taking `SCL_L2ARC`,
which also orders the check against `vdev_reopen()` setting the flag.
`l2ad_trim_all` is restored on the same reasoning but is untested.

### How Has This Been Tested?

Reproducer: 256 MiB file-backed cache vdev with
`l2arc_rebuild_blocks_min_l2size=0`, wrap the write hand twice, `zpool remove`
and `zpool add` the cache vdev, write, export, import, keep writing. It fails
on the first post-import write cycle in roughly half of attempts.

### Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).