### PR TITLE
ZTS: divide by zero in ZTS though very rare

### DIFF
--- a/tests/zfs-tests/tests/functional/compression/compress_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/compression/compress_004_pos.ksh
@@ -47,11 +47,16 @@ function create_free_testing #<file size> <file>
 	typeset -i start=0
 	typeset -i len=0
 	typeset -i dist=0
+	typeset -i maxlen=0
 
 	for start in 0 $((RANDOM % fsz))
 	do
 		(( dist = fsz - start ))
-		for len in $((1 + RANDOM % (dist - 1))) $dist \
+		# Leave at least one byte of the hole, and never divide by
+		# zero when the random start lands on the last byte (dist == 1).
+		(( maxlen = dist - 1 ))
+		(( maxlen < 1 )) && (( maxlen = 1 ))
+		for len in $((1 + RANDOM % maxlen)) $dist \
 		    $((start + dist)); do
 			log_must randfree_file -l $fsz -s $start -n $len $file
 			[[ -e $file ]] && \

--- a/tests/zfs-tests/tests/functional/zstream/zstream_raw_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/zstream/zstream_raw_001_pos.ksh
@@ -106,8 +106,13 @@ function exercise_volume
 		log_must randwritecomp $f 100
 	done
 	log_must rm $(find $TESTDIR -type f | sort -R | head)
-	(( len = RANDOM % maxsz ))
-	(( start = RANDOM % len ))
+	#
+	# Keep len in [2, maxsz-1] and start in [0, len-2] so the ranges
+	# below never divide by zero and the punched range [start,
+	# start+num) always lies inside the file.
+	#
+	(( len = 2 + RANDOM % (maxsz - 2) ))
+	(( start = RANDOM % (len - 1) ))
 	(( num = 1 + RANDOM % (len - start - 1) ))
 	log_must randfree_file -l $len -s $start -n $num $TESTDIR/free-$RANDOM
 	log_must umount $TESTDIR


### PR DESCRIPTION
### Motivation and Context
While working on #19076 , ZTS ubuntu 26 failed with divide by zero errors:
```shell
~/qemu-ubuntu26/vm2/current/log:
 70731  09:23:52.84 SUCCESS: randfree_file -l 7 -s 0 -n 7 /var/tmp/testdir/singleblkfile.1806328
 70732  09:23:52.84 SUCCESS: rm -f /var/tmp/testdir/singleblkfile.1806328
 70733: 09:23:52.84 /usr/share/zfs/zfs-tests/tests/functional/compression/compress_004_pos.ksh[101]: create_free_testing: line 54: 1 + RANDOM % (dist - 1): divide by zero
 70734  09:23:52.86 SUCCESS: randfree_file -l 20480 -s 0 -n 13585 /var/tmp/testdir/multiblkfile.1806328
 70735  09:23:52.86 SUCCESS: rm -f /var/tmp/testdir/multiblkfile.1806328
 .....
 129332  11:37:47.24 SUCCESS: randwritecomp /var/tmp/testdir/file-14710 100
 129333  11:37:47.26 SUCCESS: rm /var/tmp/testdir/file-17118 /var/tmp/testdir/file-8374 /var/tmp/testdir/file-14976 /var/tmp/testdir/file-12196 /var/tmp/testdir/file-22553 /var/tmp/testdir/file-7022 /var/tmp/testdir/file-12624 /var/tmp/testdir/file-60 /var/tmp/testdir/file-14710 /var/tmp/testdir/file-24722
 129334: 11:37:47.26 /usr/share/zfs/zfs-tests/tests/functional/zstream/zstream_raw_001_pos.ksh[144]: exercise_volume: line 111:  num = 1 + RANDOM % (len - start - 1) : divide by zero
 129335  11:37:47.26 NOTE: Initial send
 129336  11:37:47.32 SUCCESS: zfs snapshot testpool/zvol@snapshot
```

### Description
Change how random picking to ensure no divide by zero, and also keep same sematics.

### How Has This Been Tested?
Local dev box.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [X] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
