### PR TITLE
ZTS: fill the ARC before l2arc_multidev_scaling_pos measures it

### DIFF
--- a/tests/zfs-tests/tests/functional/l2arc/l2arc_multidev_scaling_pos.ksh
+++ b/tests/zfs-tests/tests/functional/l2arc/l2arc_multidev_scaling_pos.ksh
@@ -24,13 +24,21 @@
 #
 # STRATEGY:
 #	1. Configure L2ARC write rate to 4MB/s per device.
-#	2. Disable DWPD rate limiting and depth cap to test pure parallel throughput.
-#	3. Create pool with single 3072MB cache device.
-#	4. Generate continuous writes, wait for L2ARC activity, measure over 12s.
-#	5. Verify single-device throughput ~48MB (4MB/s × 12s).
-#	6. Recreate pool with dual 3072MB cache devices.
-#	7. Generate continuous writes, wait for L2ARC activity, measure over 12s.
-#	8. Verify dual-device throughput ~96MB (2×4MB/s × 12s).
+#	2. Disable DWPD rate limiting and depth cap to test pure parallel
+#	   throughput.
+#	3. Create a pool without cache devices and fill the ARC, so that the
+#	   eviction lists hold a stable pool of evictable buffers.
+#	4. Add a single cache device and measure the writes over 8s.
+#	5. Detach it and repeat with two cache devices.
+#	6. Verify that each phase reached its rate limit, and that two devices
+#	   wrote substantially more than one.
+#
+# NOTES:
+#	The ARC is filled before the cache devices are added, and nothing
+#	writes to the pool while the window is measured.  A writer running
+#	alongside makes the result depend on how fast it can feed the ARC
+#	rather than on l2arc_write_max, and on a loaded machine the feed
+#	threads then run out of eligible buffers.
 #
 
 verify_runnable "global"
@@ -64,8 +72,9 @@ save_tunable ARC_MAX
 # per phase stay below the global marker reset threshold
 # (smallest_capacity/8) to avoid throughput disruption from marker resets.
 typeset cache_sz=3072
-typeset fill_mb=2500   # 2.5GB initial data
-typeset test_time=12   # Measurement window: 4MB/s × 12s = ~48MB per device
+typeset arc_max_mb=400
+typeset fill_mb=$arc_max_mb
+typeset test_time=8    # Measurement window: 4MB/s × 8s = ~32MB per device
 
 # Disable DWPD and depth cap to test pure parallel throughput
 log_must set_tunable32 L2ARC_DWPD_LIMIT 0
@@ -76,86 +85,90 @@ log_must set_tunable32 L2ARC_WRITE_MAX $((4 * 1024 * 1024))
 log_must set_tunable32 L2ARC_NOPREFETCH 0
 
 # Configure arc_max so L2ARC >= arc_c_max * 2 threshold for persistent markers
-log_must set_tunable64 ARC_MAX $((400 * 1024 * 1024))
+log_must set_tunable64 ARC_MAX $((arc_max_mb * 1024 * 1024))
 log_must set_tunable64 ARC_MIN $((200 * 1024 * 1024))
 
-# Single device test
-log_must truncate -s 4G $VDEV
-log_must truncate -s ${cache_sz}M $VDEV_CACHE
-log_must zpool create -f $TESTPOOL $VDEV cache $VDEV_CACHE
+#
+# Attach the cache devices named in $@ and leave the bytes L2ARC wrote
+# over the measurement window in $measured.  Every phase gets devices of
+# its own, so that none of them is ever seen with an L2ARC header on it
+# and rebuilt instead of filled.
+#
+function measure_writes
+{
+	typeset devs="$*"
+	typeset dev
 
-# Generate data in background
-dd if=/dev/urandom of=/$TESTPOOL/file1 bs=1M count=$fill_mb &
-typeset dd_pid=$!
+	for dev in $devs; do
+		log_must truncate -s ${cache_sz}M $dev
+	done
+	log_must zpool add -f $TESTPOOL cache $devs
 
-# Wait for L2ARC to start writing
-typeset l2_size=0
-for i in {1..30}; do
-	l2_size=$(kstat arcstats.l2_size)
-	[[ $l2_size -gt 0 ]] && break
-	sleep 1
-done
-if [[ $l2_size -eq 0 ]]; then
-	kill $dd_pid 2>/dev/null
-	log_fail "L2ARC did not start writing (single device)"
-fi
+	# Wait for L2ARC to start writing
+	typeset l2_size=0
+	for i in {1..30}; do
+		l2_size=$(kstat arcstats.l2_size)
+		[[ $l2_size -gt 0 ]] && break
+		sleep 1
+	done
+	if [[ $l2_size -eq 0 ]]; then
+		log_fail "L2ARC did not start writing ($devs)"
+	fi
 
-# Measure single-device write throughput
-typeset start=$(kstat arcstats.l2_write_bytes)
-log_must sleep $test_time
-typeset end=$(kstat arcstats.l2_write_bytes)
-kill $dd_pid 2>/dev/null
-wait $dd_pid 2>/dev/null
-typeset single_writes=$((end - start))
+	typeset start=$(kstat arcstats.l2_write_bytes)
+	log_must sleep $test_time
+	typeset end=$(kstat arcstats.l2_write_bytes)
 
-# expected = 4MB/s * 1 device * 12s = 48MB
+	#
+	# Detaching the cache devices drops the L2ARC headers of everything
+	# they hold, so the very same buffers are candidates again for the
+	# next phase and the ARC does not have to be refilled.
+	#
+	log_must zpool remove $TESTPOOL $devs
+	log_must rm -f $devs
+
+	measured=$((end - start))
+}
+
+typeset measured=0
+
+log_must truncate -s 5G $VDEV
+log_must zpool create -f $TESTPOOL $VDEV
+
+# Fill the ARC so the eviction lists have stable evictable buffers.
+log_must file_write -o create -f /$TESTPOOL/file -b 1048576 -c $fill_mb -d R
+log_must zpool sync $TESTPOOL
+
+measure_writes $VDIR/e
+typeset single_writes=$measured
 typeset single_expected=$((4 * 1024 * 1024 * test_time))
-log_note "Single-device writes: $((single_writes / 1024 / 1024))MB (expected ~$((single_expected / 1024 / 1024))MB)"
+log_note "Single-device writes: $((single_writes / 1024 / 1024))MB" \
+    "(expected ~$((single_expected / 1024 / 1024))MB)"
 
-# Dual device test
-destroy_pool $TESTPOOL
-log_must truncate -s ${cache_sz}M $VDEV_CACHE
-log_must truncate -s ${cache_sz}M $VDEV_CACHE2
-
-log_must zpool create -f $TESTPOOL $VDEV cache $VDEV_CACHE $VDEV_CACHE2
-
-# Generate data in background
-dd if=/dev/urandom of=/$TESTPOOL/file2 bs=1M count=$fill_mb &
-dd_pid=$!
-
-# Wait for L2ARC to start writing
-l2_size=0
-for i in {1..30}; do
-	l2_size=$(kstat arcstats.l2_size)
-	[[ $l2_size -gt 0 ]] && break
-	sleep 1
-done
-if [[ $l2_size -eq 0 ]]; then
-	kill $dd_pid 2>/dev/null
-	log_fail "L2ARC did not start writing (dual device)"
-fi
-
-# Measure parallel write throughput (2 feed threads active)
-start=$(kstat arcstats.l2_write_bytes)
-log_must sleep $test_time
-end=$(kstat arcstats.l2_write_bytes)
-kill $dd_pid 2>/dev/null
-wait $dd_pid 2>/dev/null
-typeset dual_writes=$((end - start))
-
-# expected = 4MB/s * 2 devices * 12s = 96MB
+measure_writes $VDIR/f $VDIR/g
+typeset dual_writes=$measured
 typeset dual_expected=$((4 * 1024 * 1024 * 2 * test_time))
-log_note "Dual-device writes: $((dual_writes / 1024 / 1024))MB (expected ~$((dual_expected / 1024 / 1024))MB)"
+log_note "Dual-device writes: $((dual_writes / 1024 / 1024))MB" \
+    "(expected ~$((dual_expected / 1024 / 1024))MB)"
 
-# Verify writes are within expected range (80-150%)
+# Verify each phase reached at least 80% of its rate limit, and that the
+# second device did add to the throughput rather than just share it.
 typeset single_min=$((single_expected * 80 / 100))
 typeset dual_min=$((dual_expected * 80 / 100))
+typeset scale_min=$((single_writes * 150 / 100))
 
 if [[ $single_writes -lt $single_min ]]; then
-	log_fail "Single-device writes $((single_writes / 1024 / 1024))MB below minimum $((single_min / 1024 / 1024))MB"
+	log_fail "Single-device writes $((single_writes / 1024 / 1024))MB" \
+	    "below minimum $((single_min / 1024 / 1024))MB"
 fi
 if [[ $dual_writes -lt $dual_min ]]; then
-	log_fail "Dual-device writes $((dual_writes / 1024 / 1024))MB below minimum $((dual_min / 1024 / 1024))MB"
+	log_fail "Dual-device writes $((dual_writes / 1024 / 1024))MB" \
+	    "below minimum $((dual_min / 1024 / 1024))MB"
+fi
+if [[ $dual_writes -lt $scale_min ]]; then
+	log_fail "Dual-device writes $((dual_writes / 1024 / 1024))MB" \
+	    "did not scale over the single device" \
+	    "($((single_writes / 1024 / 1024))MB)"
 fi
 
 destroy_pool $TESTPOOL


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Seen in CI:
- https://github.com/openzfs/zfs/actions/runs/32990706781/job/98247493581 
- https://github.com/openzfs/zfs/actions/runs/33239960250/job/99067518845 
- https://github.com/openzfs/zfs/actions/runs/33616167155/job/100202460041 
- https://github.com/openzfs/zfs/actions/runs/33771751763/job/100703543860 
- https://github.com/openzfs/zfs/actions/runs/34043328718/job/101514327109

, and speedup test a little (see numbers below)

### Description
<!--- Describe your changes in detail -->
The test sets l2arc_write_max to 4MB/s, starts a background dd and then requires that L2ARC wrote at least 80% of 4MB/s per device over a fixed window.  What that window measures, though, is not the rate limit but how fast the dd manages to feed the ARC: a feed thread writes what it finds on the eviction lists and goes back to sleep, so with a writer that cannot keep ahead of it the phase falls short of the bound through no fault of the code under test.

In CI on Linux it fails both ways, on unrelated branches:

    NOTE: Single-device writes: 19MB (expected ~48MB)
    Single-device writes 19MB below minimum 38MB

    NOTE: Dual-device writes: 26MB (expected ~96MB)
    Dual-device writes 26MB below minimum 76MB

while passing runs on the same days report 72MB and 158MB for those very phases, which is 150% of what the assertion calls "expected": the feed thread shortens its interval when it wrote less than it asked for (l2arc_feed_thread()), so the throughput is not pinned to write_max in that direction either.

Measured in a Linux VM with the original 12s window: with the source unthrottled the single-device phase writes 73MB, and with the source held to 16MB/s it writes 52MB, i.e. what the window records tracks the writer, not l2arc_write_max.  At the 38MB the test demanded, the writer had to sustain some 12MB/s for the whole window - not a given on a loaded CI runner.

Fill the ARC before attaching the cache devices and leave the pool idle while the window runs, the way l2arc_multidev_throughput_pos was fixed in 4655bdd8a ("ZTS: Fix L2ARC test reliability").  Both phases then run against the same filled ARC on one pool: removing the cache devices of a phase drops the L2ARC headers of everything they hold, so the buffers are candidates again and only the first phase has to fill.  Each phase gets cache devices of its own, so none is ever re-added carrying an L2ARC header and rebuilt instead of filled.

Also assert what the test is named after: two devices have to write substantially more than one.  The "80-150%" comment claimed an upper bound the test never checked, and which the runs above exceed.

The window is 8s and the fill is 400MB, which is arc_max here, so the test is also faster than it was: 22-25s against 29s before, measured over 14 runs.  All of them passed - 8 on 16 vCPUs (46-52MB single, 92MB dual) and 6 restricted to 2 vCPUs as the CI runners are (46-52MB and 92-98MB), against minimums of 25MB and 51MB.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [X] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
