### PR TITLE
Unforced readonly

### DIFF
--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -274,6 +274,7 @@ extern boolean_t zfs_force_some_double_word_sm_entries;
 extern unsigned long zfs_reconstruct_indirect_damage_fraction;
 extern uint64_t raidz_expand_max_reflow_bytes;
 extern uint_t raidz_expand_pause_point;
+extern int spa_simulate_writable_mounts;
 extern boolean_t ddt_prune_artificial_age;
 extern boolean_t ddt_dump_prune_histogram;
 
@@ -8515,6 +8516,199 @@ ztest_import_impl(void)
 	fnvlist_free(cfg);
 }
 
+/* keep in sync with spa_make_readonly_blocked() calls in spa.c */
+#define	ZTEST_READONLY_BLOCKED_CALLS	4
+
+static int
+ztest_readonly_try_convert(spa_t *spa)
+{
+	nvlist_t *props;
+	int error;
+
+	props = fnvlist_alloc();
+	fnvlist_add_uint64(props, zpool_prop_to_name(ZPOOL_PROP_READONLY), 1);
+	error = spa_prop_set(spa, props);
+	fnvlist_free(props);
+	return (error);
+}
+
+static void
+ztest_readonly_verify_rw(spa_t *spa, ztest_ds_t *zd, uint64_t object,
+    uint64_t *buf, uint64_t size, uint64_t gen)
+{
+	uint64_t *check;
+
+	VERIFY(spa_writeable(spa));
+	VERIFY(spa_mode(spa) & SPA_MODE_WRITE);
+	VERIFY0P(spa->spa_export_thread);
+	VERIFY(!spa->spa_is_exporting);
+	VERIFY(spa->spa_sync_on);
+	VERIFY3U(spa->spa_final_txg, ==, UINT64_MAX);
+
+	VERIFY0(ztest_dataset_open(0));
+	for (size_t i = 0; i < size / sizeof (*buf); i++)
+		buf[i] = (0x5a5a000000000000ULL | i) + gen;
+	VERIFY0(ztest_write(zd, object, 0, size, buf));
+	VERIFY0(zil_commit(zd->zd_zilog, object));
+	txg_wait_synced(spa_get_dsl(spa), 0);
+
+	/*
+	 * The dmu_read() call will most likely hit the ARC, but we're
+	 * just checking that the pool at least allowed the write.
+	 */
+	check = umem_alloc(size, UMEM_NOFAIL);
+	memset(check, 0, size);
+	VERIFY0(dmu_read(zd->zd_os, object, 0, size, check,
+	    DMU_READ_NO_PREFETCH));
+	VERIFY0(memcmp(buf, check, size));
+	umem_free(check, size);
+
+	ztest_dataset_close(0);
+}
+
+/*
+ * Convert an imported pool from read/write to readonly, confirm that
+ * a write-mode objset own fails and that a readonly own can still read,
+ * then export, import, and check that the data is still intact.
+ */
+static void
+ztest_readonly(void)
+{
+	ztest_ds_t *zd = &ztest_ds[0];
+	spa_t *spa;
+	ztest_od_t od;
+	objset_t *os;
+	char name[ZFS_MAX_DATASET_NAME_LEN];
+	const uint64_t size = 8192;
+	uint64_t *buf, *check;
+	uint64_t object;
+	int error;
+
+	/* not supported during RAIDZ expansion */
+	if (ztest_opts.zo_raid_do_expand)
+		return;
+
+	if (ztest_opts.zo_verbose >= 3)
+		(void) printf("testing spa_make_readonly()...\n");
+
+	buf = umem_alloc(size, UMEM_NOFAIL);
+	check = umem_alloc(size, UMEM_NOFAIL);
+
+	raidz_scratch_verify();
+	kernel_init(SPA_MODE_READ | SPA_MODE_WRITE);
+	VERIFY0(spa_open(ztest_opts.zo_pool, &spa, FTAG));
+	VERIFY0(ztest_dataset_open(0));
+	ztest_spa = spa;
+	VERIFY(spa_writeable(spa));
+
+	ztest_od_init(&od, 0, FTAG, 0, DMU_OT_UINT64_OTHER, size, 0, 0);
+	VERIFY0(ztest_object_init(zd, &od, sizeof (od), B_TRUE));
+	object = od.od_object;
+
+	for (size_t i = 0; i < size / sizeof (*buf); i++)
+		buf[i] = 0x5a5a000000000000ULL | i;
+	VERIFY0(ztest_write(zd, object, 0, size, buf));
+	VERIFY0(zil_commit(zd->zd_zilog, object));
+	txg_wait_synced(spa_get_dsl(spa), 0);
+	ztest_dataset_close(0);
+
+	for (int call = 0; call < ZTEST_READONLY_BLOCKED_CALLS; call++) {
+		if (ztest_opts.zo_verbose >= 3) {
+			(void) printf("spa_make_readonly() blocked "
+			    "call site %d...\n", call);
+		}
+
+		spa_simulate_writable_mounts = call + 1;
+		error = ztest_readonly_try_convert(spa);
+		VERIFY3S(error, ==, EBUSY);
+
+		if (spa_simulate_writable_mounts != 0) {
+			/*
+			 * Failed before the simulated mount check at this
+			 * site (e.g. MOS writer).  Still require R/W
+			 * rollback; clear the leftover countdown.
+			 */
+			if (ztest_opts.zo_verbose >= 3) {
+				(void) printf("spa_make_readonly() busy "
+				    "before site %d (left=%d)\n", call,
+				    spa_simulate_writable_mounts);
+			}
+			spa_simulate_writable_mounts = 0;
+		}
+
+		ztest_readonly_verify_rw(spa, zd, object, buf, size, call);
+	}
+
+	/* now verify we can successfully convert the pool to RO mode */
+	spa_simulate_writable_mounts = 0;
+	error = ztest_readonly_try_convert(spa);
+	if (error == EBUSY) {
+		if (ztest_opts.zo_verbose >= 3) {
+			(void) printf("spa_make_readonly() busy, "
+			    "skipping\n");
+		}
+		spa_close(spa, FTAG);
+		VERIFY0(spa_export(ztest_opts.zo_pool, NULL, B_FALSE,
+		    B_FALSE));
+		kernel_fini();
+		umem_free(buf, size);
+		umem_free(check, size);
+		return;
+	}
+	VERIFY0(error);
+	VERIFY(!spa_writeable(spa));
+	VERIFY3U(spa_mode(spa), ==, SPA_MODE_READ);
+
+	ztest_dataset_name(name, ztest_opts.zo_pool, 0);
+	VERIFY3S(ztest_dmu_objset_own(name, DMU_OST_OTHER, B_FALSE, B_TRUE,
+	    FTAG, &os), ==, EROFS);
+
+	VERIFY0(ztest_dmu_objset_own(name, DMU_OST_OTHER, B_TRUE, B_TRUE,
+	    FTAG, &os));
+	memset(check, 0, size);
+	VERIFY0(dmu_read(os, object, 0, size, check, DMU_READ_NO_PREFETCH));
+	VERIFY0(memcmp(buf, check, size));
+	dmu_objset_disown(os, B_TRUE, FTAG);
+
+	spa_close(spa, FTAG);
+
+	ztest_walk_pool_directory("pools before export");
+	int count = 0;
+	while (count < 10 && (error = spa_export(ztest_opts.zo_pool, NULL,
+	    B_FALSE, B_FALSE)) == EBUSY) {
+		if (ztest_opts.zo_verbose >= 3)
+			(void) printf("> spa_export EBUSY; pausing\n");
+		(void) poll(NULL, 0, 1000);
+		count++;
+	}
+	VERIFY0(error);
+	ztest_walk_pool_directory("pools after export");
+
+	kernel_fini();
+
+	raidz_scratch_verify();
+	kernel_init(SPA_MODE_READ | SPA_MODE_WRITE);
+	ztest_import_impl();
+	VERIFY0(spa_open(ztest_opts.zo_pool, &spa, FTAG));
+	ztest_spa = spa;
+	VERIFY(spa_writeable(spa));
+	VERIFY0(ztest_dataset_open(0));
+
+	VERIFY0(ztest_object_init(zd, &od, sizeof (od), B_FALSE));
+	VERIFY3U(od.od_object, ==, object);
+	memset(check, 0, size);
+	VERIFY0(dmu_read(zd->zd_os, object, 0, size, check,
+	    DMU_READ_NO_PREFETCH));
+	VERIFY0(memcmp(buf, check, size));
+
+	ztest_dataset_close(0);
+	spa_close(spa, FTAG);
+	kernel_fini();
+
+	umem_free(buf, size);
+	umem_free(check, size);
+}
+
 /*
  * Import a storage pool with the given name.
  */
@@ -8543,6 +8737,8 @@ ztest_import(ztest_shared_t *zs)
 	if (!ztest_opts.zo_mmp_test) {
 		ztest_run_zdb(zs->zs_guid);
 		ztest_freeze();
+		ztest_run_zdb(zs->zs_guid);
+		ztest_readonly();
 		ztest_run_zdb(zs->zs_guid);
 	}
 
@@ -9102,7 +9298,7 @@ make_random_pool_props(void)
 
 /*
  * Create a storage pool with the given name and initial vdev size.
- * Then test spa_freeze() functionality.
+ * Then test spa_freeze() and spa_make_readonly() functionality.
  */
 static void
 ztest_init(ztest_shared_t *zs)
@@ -9194,6 +9390,8 @@ ztest_init(ztest_shared_t *zs)
 	if (!ztest_opts.zo_mmp_test) {
 		ztest_run_zdb(zs->zs_guid);
 		ztest_freeze();
+		ztest_run_zdb(zs->zs_guid);
+		ztest_readonly();
 		ztest_run_zdb(zs->zs_guid);
 	}
 

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -779,6 +779,7 @@ extern int spa_checkpoint_discard(const char *pool);
 extern int spa_export(const char *pool, nvlist_t **oldconfig, boolean_t force,
     boolean_t hardforce);
 extern int spa_reset(const char *pool);
+extern int spa_make_readonly(spa_t *spa);
 extern void spa_async_request(spa_t *spa, int flag);
 extern void spa_async_unrequest(spa_t *spa, int flag);
 extern void spa_async_suspend(spa_t *spa);

--- a/include/sys/vdev_impl.h
+++ b/include/sys/vdev_impl.h
@@ -231,6 +231,7 @@ struct vdev {
 	vdev_stat_ex_t	vdev_stat_ex;	/* extended statistics		*/
 	boolean_t	vdev_expanding;	/* expand the vdev?		*/
 	boolean_t	vdev_reopening;	/* reopen in progress?		*/
+	spa_mode_t	vdev_open_mode;	/* spa_mode at last leaf open	*/
 	boolean_t	vdev_nonrot;	/* true if solid state		*/
 	int		vdev_load_error; /* error on last load		*/
 	int		vdev_open_error; /* error on last open		*/

--- a/include/sys/zil.h
+++ b/include/sys/zil.h
@@ -636,6 +636,7 @@ extern int 	zil_check_log_chain(struct dsl_pool *dp,
     struct dsl_dataset *ds, void *tx);
 extern void	zil_sync(zilog_t *zilog, dmu_tx_t *tx);
 extern void	zil_clean(zilog_t *zilog, uint64_t synced_txg);
+extern void	zil_reset_txg_info(zilog_t *zilog);
 
 extern int	zil_suspend(const char *osname, void **cookiep);
 extern void	zil_resume(void *cookie);

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -908,10 +908,22 @@ zpool_valid_proplist(libzfs_handle_t *hdl, const char *poolname,
 			}
 			break;
 		case ZPOOL_PROP_READONLY:
-			if (!flags.import) {
+			if (flags.create) {
 				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-				    "property '%s' can only be set at "
-				    "import time"), propname);
+				    "property '%s' cannot be set at "
+				    "creation time"), propname);
+				(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
+				goto error;
+			}
+			/*
+			 * If we're importing, we can set it 'on' or 'off'.
+			 * Once it's imported, only off->on is supported
+			 * for now.
+			 */
+			if (!flags.import && intval == 0) {
+				zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
+				    "property '%s' can only be set to "
+				    "'on'"), propname);
 				(void) zfs_error(hdl, EZFS_BADPROP, errbuf);
 				goto error;
 			}

--- a/module/os/linux/zfs/vdev_disk.c
+++ b/module/os/linux/zfs/vdev_disk.c
@@ -358,7 +358,9 @@ vdev_disk_open(vdev_t *v, uint64_t *psize, uint64_t *max_psize,
 					reread_part = B_TRUE;
 			}
 
-			vdev_blkdev_put(bdh, smode, zfs_vdev_holder);
+			vdev_blkdev_put(bdh,
+			    v->vdev_open_mode != SPA_MODE_UNINIT ?
+			    v->vdev_open_mode : smode, zfs_vdev_holder);
 		}
 
 		if (reread_part) {
@@ -548,9 +550,11 @@ vdev_disk_close(vdev_t *v)
 
 	rw_enter(&vd->vd_lock, RW_WRITER);
 
-	if (vd->vd_bdh != NULL)
-		vdev_blkdev_put(vd->vd_bdh, spa_mode(v->vdev_spa),
-		    zfs_vdev_holder);
+	if (vd->vd_bdh != NULL) {
+		spa_mode_t put_mode = v->vdev_open_mode != SPA_MODE_UNINIT ?
+		    v->vdev_open_mode : spa_mode(v->vdev_spa);
+		vdev_blkdev_put(vd->vd_bdh, put_mode, zfs_vdev_holder);
+	}
 
 	v->vdev_tsd = NULL;
 

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -776,6 +776,8 @@ dmu_objset_own_impl(dsl_dataset_t *ds, dmu_objset_type_t type,
 		return (SET_ERROR(EINVAL));
 	} else if (!readonly && dsl_dataset_is_snapshot(ds)) {
 		return (SET_ERROR(EROFS));
+	} else if (!readonly && !spa_writeable(dmu_objset_spa(*osp))) {
+		return (SET_ERROR(EROFS));
 	} else if (!readonly && decrypt &&
 	    dsl_dir_incompatible_encryption_version(ds->ds_dir)) {
 		return (SET_ERROR(EROFS));

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -89,6 +89,9 @@
 #include <sys/callb.h>
 #include <sys/zone.h>
 #include <sys/vmsystm.h>
+#include <sys/zfs_vfsops.h>
+#include <sys/zfs_ioctl_impl.h>
+#include <sys/zvol_impl.h>
 #endif	/* _KERNEL */
 
 #include "zfs_crrd.h"
@@ -121,6 +124,15 @@
  * should be retried.
  */
 int zfs_ccw_retry_interval = 300;
+
+#ifndef	_KERNEL
+/*
+ * This global is used in ztest to allow the ztest_readonly() function
+ * to verify each site that spa_make_readonly_blocked() is called. There
+ * are currently 4. If this changes, update the #define in ztest.c
+ */
+int spa_simulate_writable_mounts = 0;
+#endif
 
 typedef enum zti_modes {
 	ZTI_MODE_FIXED,			/* value is # of threads (min 1) */
@@ -890,6 +902,16 @@ spa_prop_validate(spa_t *spa, nvlist_t *props)
 			}
 			break;
 
+		case ZPOOL_PROP_READONLY:
+			error = nvpair_value_uint64(elem, &intval);
+			if (!error && intval > 1)
+				error = SET_ERROR(EINVAL);
+
+			/* only rw->ro allowed for now */
+			if (!error && intval == 0 && !spa_writeable(spa))
+				error = SET_ERROR(EROFS);
+			break;
+
 		case ZPOOL_PROP_CACHEFILE:
 			if ((error = nvpair_value_string(elem, &strval)) != 0)
 				break;
@@ -981,6 +1003,7 @@ spa_prop_set(spa_t *spa, nvlist_t *nvp)
 	int error;
 	nvpair_t *elem = NULL;
 	boolean_t need_sync = B_FALSE;
+	boolean_t make_readonly = B_FALSE;
 
 	if ((error = spa_prop_validate(spa, nvp)) != 0)
 		return (error);
@@ -988,9 +1011,17 @@ spa_prop_set(spa_t *spa, nvlist_t *nvp)
 	while ((elem = nvlist_next_nvpair(nvp, elem)) != NULL) {
 		zpool_prop_t prop = zpool_name_to_prop(nvpair_name(elem));
 
+		if (prop == ZPOOL_PROP_READONLY) {
+			uint64_t intval;
+
+			VERIFY0(nvpair_value_uint64(elem, &intval));
+			if (intval)
+				make_readonly = B_TRUE;
+			continue;
+		}
+
 		if (prop == ZPOOL_PROP_CACHEFILE ||
-		    prop == ZPOOL_PROP_ALTROOT ||
-		    prop == ZPOOL_PROP_READONLY)
+		    prop == ZPOOL_PROP_ALTROOT)
 			continue;
 
 		if (prop == ZPOOL_PROP_INVAL &&
@@ -1033,11 +1064,16 @@ spa_prop_set(spa_t *spa, nvlist_t *nvp)
 	}
 
 	if (need_sync) {
-		return (dsl_sync_task(spa->spa_name, NULL, spa_sync_props,
-		    nvp, 6, ZFS_SPACE_CHECK_RESERVED));
+		error = dsl_sync_task(spa->spa_name, NULL, spa_sync_props,
+		    nvp, 6, ZFS_SPACE_CHECK_RESERVED);
+		if (error)
+			return (error);
 	}
 
-	return (0);
+	if (make_readonly)
+		error = spa_make_readonly(spa);
+
+	return (error);
 }
 
 /*
@@ -2303,6 +2339,39 @@ spa_should_sync_time_logger_on_unload(spa_t *spa)
 
 
 /*
+ * Stop all write activity for the pool.
+ */
+static void
+spa_quiesce_writes(spa_t *spa)
+{
+	if (spa->spa_root_vdev != NULL) {
+		vdev_initialize_stop_all(spa->spa_root_vdev,
+		    VDEV_INITIALIZE_ACTIVE);
+		vdev_trim_stop_all(spa->spa_root_vdev, VDEV_TRIM_ACTIVE);
+		vdev_autotrim_stop_all(spa);
+		vdev_rebuild_stop_all(spa);
+		l2arc_spa_rebuild_stop(spa);
+	}
+
+	if (spa->spa_final_txg == UINT64_MAX) {
+		spa_config_enter(spa, SCL_ALL, FTAG, RW_WRITER);
+		spa->spa_final_txg = spa_last_synced_txg(spa) +
+		    TXG_DEFER_SIZE + 1;
+		spa_config_exit(spa, SCL_ALL, FTAG);
+	}
+
+	if (spa->spa_sync_on) {
+		txg_sync_stop(spa->spa_dsl_pool);
+		spa->spa_sync_on = B_FALSE;
+	}
+
+	if (spa->spa_mmp.mmp_thread)
+		mmp_thread_stop(spa);
+
+	spa_destroy_aux_threads(spa);
+}
+
+/*
  * Opposite of spa_load().
  */
 static void
@@ -2319,8 +2388,9 @@ spa_unload(spa_t *spa)
 
 	/*
 	 * If we have set the spa_final_txg, we have already performed the
-	 * tasks below in spa_export_common(). We should not redo it here since
-	 * we delay the final TXGs beyond what spa_final_txg is set at.
+	 * tasks below in spa_export_common() / spa_quiesce_writes(). We
+	 * should not redo them here since we delay the final TXGs beyond
+	 * what spa_final_txg is set at.
 	 */
 	if (spa->spa_final_txg == UINT64_MAX) {
 		if (spa_should_sync_time_logger_on_unload(spa))
@@ -2341,39 +2411,15 @@ spa_unload(spa_t *spa)
 		 * Stop async tasks.
 		 */
 		spa_async_suspend(spa);
-
-		if (spa->spa_root_vdev) {
-			vdev_t *root_vdev = spa->spa_root_vdev;
-			vdev_initialize_stop_all(root_vdev,
-			    VDEV_INITIALIZE_ACTIVE);
-			vdev_trim_stop_all(root_vdev, VDEV_TRIM_ACTIVE);
-			vdev_autotrim_stop_all(spa);
-			vdev_rebuild_stop_all(spa);
-			l2arc_spa_rebuild_stop(spa);
-		}
-
-		spa_config_enter(spa, SCL_ALL, FTAG, RW_WRITER);
-		spa->spa_final_txg = spa_last_synced_txg(spa) +
-		    TXG_DEFER_SIZE + 1;
-		spa_config_exit(spa, SCL_ALL, FTAG);
 	}
 
-	/*
-	 * Stop syncing.
-	 */
-	if (spa->spa_sync_on) {
-		txg_sync_stop(spa->spa_dsl_pool);
-		spa->spa_sync_on = B_FALSE;
-	}
+	spa_quiesce_writes(spa);
 
 	/*
 	 * This ensures that there is no async metaslab prefetching
 	 * while we attempt to unload the spa.
 	 */
 	taskq_wait(spa->spa_metaslab_taskq);
-
-	if (spa->spa_mmp.mmp_thread)
-		mmp_thread_stop(spa);
 
 	/*
 	 * Wait for any outstanding async I/O to complete.
@@ -2967,6 +3013,39 @@ spa_reset_logs(spa_t *spa)
 		txg_wait_synced(spa->spa_dsl_pool, 0);
 	}
 	return (error);
+}
+
+typedef struct spa_zil_cookie {
+	list_node_t	szc_node;
+	void		*szc_cookie;
+} spa_zil_cookie_t;
+
+/* used by spa_make_readonly() to flush the zils */
+static int
+spa_zil_suspend_cb(const char *osname, void *arg)
+{
+	list_t *cookies = arg;
+	void *cookie = NULL;
+	int error = zil_suspend(osname, &cookie);
+
+	if (cookie != NULL) {
+		spa_zil_cookie_t *szc = kmem_alloc(sizeof (*szc), KM_SLEEP);
+		szc->szc_cookie = cookie;
+		list_insert_tail(cookies, szc);
+	}
+
+	return (error);
+}
+
+static void
+spa_zil_resume_all(list_t *cookies)
+{
+	spa_zil_cookie_t *szc;
+
+	while ((szc = list_remove_head(cookies)) != NULL) {
+		zil_resume(szc->szc_cookie);
+		kmem_free(szc, sizeof (*szc));
+	}
 }
 
 static void
@@ -7958,7 +8037,7 @@ spa_export_common(const char *pool, int new_state, nvlist_t **oldconfig,
 		}
 
 		/*
-		 * We're about to export or destroy this pool. Make sure
+		 * We're about to export or destroy the pool. Make sure
 		 * we stop all initialization and trim activity here before
 		 * we set the spa_final_txg. This will ensure that all
 		 * dirty data resulting from the initialization is
@@ -7972,8 +8051,8 @@ spa_export_common(const char *pool, int new_state, nvlist_t **oldconfig,
 
 		/*
 		 * We want this to be reflected on every label,
-		 * so mark them all dirty.  spa_unload() will do the
-		 * final sync that pushes these changes out.
+		 * so mark them all dirty.  spa_quiesce_writes() will
+		 * sync these changes out.
 		 */
 		if (new_state != POOL_STATE_UNINITIALIZED && !hardforce) {
 			spa_config_enter(spa, SCL_ALL, FTAG, RW_WRITER);
@@ -7998,12 +8077,8 @@ spa_export_common(const char *pool, int new_state, nvlist_t **oldconfig,
 		if (spa_should_flush_logs_on_unload(spa))
 			spa_unload_log_sm_flush_all(spa);
 
-		if (new_state != POOL_STATE_UNINITIALIZED && !hardforce) {
-			spa_config_enter(spa, SCL_ALL, FTAG, RW_WRITER);
-			spa->spa_final_txg = spa_last_synced_txg(spa) +
-			    TXG_DEFER_SIZE + 1;
-			spa_config_exit(spa, SCL_ALL, FTAG);
-		}
+		if (new_state != POOL_STATE_UNINITIALIZED && !hardforce)
+			spa_quiesce_writes(spa);
 	}
 
 export_spa:
@@ -8093,6 +8168,213 @@ spa_reset(const char *pool)
 {
 	return (spa_export_common(pool, POOL_STATE_UNINITIALIZED, NULL,
 	    B_FALSE, B_FALSE));
+}
+
+/*
+ * Fail if a filesystem is mounted writable, or a zvol is open writable.
+ * Unmounted datasets and closed zvols are ignored.
+ */
+#ifdef	_KERNEL
+static int
+spa_mounted_writable_cb(const char *osname, void *arg)
+{
+	(void) arg;
+	zfsvfs_t *zfsvfs;
+	zvol_state_t *zv;
+
+	/* it's a filesystem */
+	if (getzfsvfs(osname, &zfsvfs) == 0) {
+		if (!zfs_is_readonly(zfsvfs)) {
+			zfs_vfs_rele(zfsvfs);
+			return (SET_ERROR(EBUSY));
+		}
+		zfs_vfs_rele(zfsvfs);
+		return (0);
+	}
+
+	/* it's a zvol */
+	zv = zvol_find_by_name_hash(osname, zvol_name_hash(osname), RW_NONE);
+	if (zv == NULL)
+		return (0);
+
+	if (zv->zv_open_count > 0 && !(zv->zv_flags & ZVOL_RDONLY)) {
+		mutex_exit(&zv->zv_state_lock);
+		return (SET_ERROR(EBUSY));
+	}
+
+	mutex_exit(&zv->zv_state_lock);
+	return (0);
+}
+#endif	/* _KERNEL */
+
+/*
+ * Check if we're blocked from converting a pool from rw to ro.
+ *
+ * Unless skip_mounts is set, also fail if any filesystem is mounted
+ * writable or a zvol is open writable. (We only skip_mounts if
+ * we're holding the namespace lock.)
+ */
+static boolean_t
+spa_make_readonly_blocked(spa_t *spa, boolean_t skip_mounts)
+{
+	if (spa_suspended(spa))
+		return (B_TRUE);
+
+	if (spa->spa_vdev_removal != NULL ||
+	    spa->spa_removing_phys.sr_state == DSS_SCANNING)
+		return (B_TRUE);
+
+	if (spa->spa_condensing_indirect != NULL ||
+	    spa->spa_condensing_indirect_phys.scip_next_mapping_object != 0)
+		return (B_TRUE);
+
+	if (spa_checkpoint_discard_thread_check(spa, NULL))
+		return (B_TRUE);
+
+	if (spa->spa_raidz_expand != NULL)
+		return (B_TRUE);
+
+#ifdef	_KERNEL
+	if (!skip_mounts && dmu_objset_find(spa_name(spa),
+	    spa_mounted_writable_cb, NULL, DS_FIND_CHILDREN) != 0)
+		return (B_TRUE);
+#else
+	(void) skip_mounts;
+	if (spa_simulate_writable_mounts > 0 &&
+	    --spa_simulate_writable_mounts == 0)
+		return (B_TRUE);
+#endif
+
+	return (B_FALSE);
+}
+
+/*
+ * Make a pool RO from a RW state. From the CLI, this is done by executing
+ * `zpool set readonly=on`. In this proof-of-concept, all we do is check
+ * that all filesystems are readonly (`zfs mount -o remount,ro`) first,
+ * and that zvols are not being written to. A real implementation of this
+ * would extend the code to call the necessary kernel functions to make
+ * the datasets RO after draining all write activity. That's beyond the
+ * scope of this PoC.
+ */
+int
+spa_make_readonly(spa_t *spa)
+{
+	boolean_t activate_slog = B_FALSE;
+	boolean_t cookies_created = B_FALSE;
+	list_t zil_cookies;
+	int error = 0;
+
+	/* nothing to do? */
+	if (!spa_writeable(spa))
+		return (0);
+
+	/* failfast: validate spa state */
+	if (spa_make_readonly_blocked(spa, B_FALSE))
+		return (SET_ERROR(EBUSY));
+
+	/* pretend we're exporting the pool */
+	spa_namespace_enter(FTAG);
+	if (spa->spa_is_exporting) {
+		spa_namespace_exit(FTAG);
+		return (SET_ERROR(ZFS_ERR_EXPORT_IN_PROGRESS));
+	}
+
+	/* validate spa state again, inside the namespace lock this time */
+	if (spa_make_readonly_blocked(spa, B_TRUE)) {
+		spa_namespace_exit(FTAG);
+		return (SET_ERROR(EBUSY));
+	}
+	spa->spa_is_exporting = B_TRUE;
+	spa->spa_export_thread = curthread;
+	spa_namespace_exit(FTAG);
+
+	spa_async_suspend(spa);
+
+	/* check that we're still in a good state */
+	if (spa_make_readonly_blocked(spa, B_FALSE)) {
+		error = SET_ERROR(EBUSY);
+		goto out;
+	}
+
+	list_create(&zil_cookies, sizeof (spa_zil_cookie_t),
+	    offsetof(spa_zil_cookie_t, szc_node));
+	cookies_created = B_TRUE;
+
+	spa_config_enter(spa, SCL_ALLOC | SCL_ZIO, FTAG, RW_WRITER);
+	activate_slog = spa_passivate_log(spa);
+	spa_config_exit(spa, SCL_ALLOC | SCL_ZIO, FTAG);
+
+	/*
+	 * Commit, sync, and destroy every dataset ZIL.  Keep them
+	 * suspended so a concurrent fsync cannot allocate a new chain.
+	 */
+	if ((error = dmu_objset_find(spa_name(spa), spa_zil_suspend_cb,
+	    &zil_cookies, DS_FIND_CHILDREN)) == 0) {
+		txg_wait_synced(spa->spa_dsl_pool, 0);
+		/* after syncing, we should still be good to go */
+		if (spa_make_readonly_blocked(spa, B_FALSE))
+			error = SET_ERROR(EBUSY);
+	}
+
+	if (error == 0) {
+		/*
+		 * Here's where we write the EXPORTED state to the labels
+		 * so that another pool can import RO as well. Note that
+		 * there's nothing in this PoC that stops someone from
+		 * importing the pool RW, which would cause this pool to
+		 * eventually panic. A more robust implementation is needed
+		 * (probably leveraging off of mmp?) to support that.
+		 */
+		spa_config_enter(spa, SCL_ALL, FTAG, RW_WRITER);
+		spa->spa_state = POOL_STATE_EXPORTED;
+		vdev_config_dirty(spa->spa_root_vdev);
+		spa_config_exit(spa, SCL_ALL, FTAG);
+
+		if (spa_should_sync_time_logger_on_unload(spa))
+			spa_unload_sync_time_logger(spa);
+		if (spa_should_flush_logs_on_unload(spa))
+			spa_unload_log_sm_flush_all(spa);
+
+		for (spa_zil_cookie_t *szc = list_head(&zil_cookies); szc;
+		    szc = list_next(&zil_cookies, szc))
+			zil_reset_txg_info(dmu_objset_zil(szc->szc_cookie));
+
+		spa_quiesce_writes(spa);
+
+		/* tag the spa active (internal only) so we can keep reading */
+		spa_config_enter(spa, SCL_ALL, FTAG, RW_WRITER);
+		spa->spa_state = POOL_STATE_ACTIVE;
+		spa_config_exit(spa, SCL_ALL, FTAG);
+
+		spa_config_enter(spa, SCL_STATE_ALL, FTAG, RW_WRITER);
+		spa->spa_mode = SPA_MODE_READ;
+		vdev_reopen(spa->spa_root_vdev);
+		spa_config_exit(spa, SCL_STATE_ALL, FTAG);
+	} else if (activate_slog) {
+		spa_config_enter(spa, SCL_ALLOC | SCL_ZIO, FTAG, RW_WRITER);
+		spa_activate_log(spa);
+		spa_config_exit(spa, SCL_ALLOC | SCL_ZIO, FTAG);
+	}
+
+	if (cookies_created) {
+		spa_zil_resume_all(&zil_cookies);
+		list_destroy(&zil_cookies);
+	}
+
+out:
+	if (error != 0)
+		spa_async_resume(spa);
+
+	spa_evicting_os_wait(spa);
+
+	spa_namespace_enter(FTAG);
+	spa->spa_is_exporting = B_FALSE;
+	spa->spa_export_thread = NULL;
+	spa_namespace_broadcast();
+	spa_namespace_exit(FTAG);
+
+	return (error);
 }
 
 /*
@@ -12200,6 +12482,7 @@ EXPORT_SYMBOL(spa_tryimport);
 EXPORT_SYMBOL(spa_destroy);
 EXPORT_SYMBOL(spa_export);
 EXPORT_SYMBOL(spa_reset);
+EXPORT_SYMBOL(spa_make_readonly);
 EXPORT_SYMBOL(spa_async_request);
 EXPORT_SYMBOL(spa_async_suspend);
 EXPORT_SYMBOL(spa_async_resume);

--- a/module/zfs/spa_log_spacemap.c
+++ b/module/zfs/spa_log_spacemap.c
@@ -418,10 +418,15 @@ void
 spa_log_summary_decrement_mscount(spa_t *spa, uint64_t txg, boolean_t dirty)
 {
 	/*
-	 * We don't track summary data for read-only pools and this function
-	 * can be called from metaslab_fini(). In that case return immediately.
+	 * Pools imported readonly never populate spa_log_summary
+	 * (spa_ld_log_sm_data() skips them). metaslab_fini() still
+	 * calls here, so an empty summary is a no-op.
+	 *
+	 * A pool converted RW -> RO with spa_make_readonly() still has
+	 * a live summary. We must decrement it so spa_unload_log_sm_metadata()
+	 * can VERIFY0(lse_mscount) after vdev_free().
 	 */
-	if (!spa_writeable(spa))
+	if (!spa_writeable(spa) && list_is_empty(&spa->spa_log_summary))
 		return;
 
 	log_summary_entry_t *target = NULL;

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -2224,6 +2224,9 @@ vdev_open(vdev_t *vd, cred_t *cred)
 	error = vd->vdev_ops->vdev_op_open(vd, &osize, &max_osize,
 	    &logical_ashift, &physical_ashift, cred);
 
+	if (error == 0 && vd->vdev_ops->vdev_op_leaf)
+		vd->vdev_open_mode = spa_mode(spa);
+
 	/* Keep the device in removed state if unplugged */
 	if (error == ENOENT && vd->vdev_removed) {
 		vdev_set_state(vd, B_TRUE, VDEV_STATE_REMOVED,
@@ -2903,7 +2906,7 @@ void
 vdev_close(vdev_t *vd)
 {
 	vdev_t *pvd = vd->vdev_parent;
-	spa_t *spa __maybe_unused = vd->vdev_spa;
+	spa_t *spa = vd->vdev_spa;
 
 	ASSERT(vd != NULL);
 	ASSERT(vd->vdev_open_thread == curthread ||
@@ -2916,7 +2919,19 @@ vdev_close(vdev_t *vd)
 	if (pvd != NULL && pvd->vdev_reopening)
 		vd->vdev_reopening = (pvd->vdev_reopening && !vd->vdev_offline);
 
+	/*
+	 * If we're going from RW to RO, then do a real close so the next
+	 * open uses the new flags.
+	 */
+	if (vd->vdev_ops->vdev_op_leaf &&
+	    vd->vdev_open_mode != SPA_MODE_UNINIT &&
+	    vd->vdev_open_mode != spa_mode(spa))
+		vd->vdev_reopening = B_FALSE;
+
+	boolean_t skipped = vd->vdev_reopening;
 	vd->vdev_ops->vdev_op_close(vd);
+	if (!skipped && vd->vdev_ops->vdev_op_leaf)
+		vd->vdev_open_mode = SPA_MODE_UNINIT;
 
 	/*
 	 * We record the previous state before we close it, so that if we are

--- a/module/zfs/zil.c
+++ b/module/zfs/zil.c
@@ -4399,6 +4399,21 @@ zil_open(objset_t *os, zil_get_data_t *get_data, zil_sums_t *zil_sums)
 }
 
 /*
+ * Reset txg watermarks after making the pool readonly.
+ */
+void
+zil_reset_txg_info(zilog_t *zilog)
+{
+	ASSERT(list_is_empty(&zilog->zl_lwb_list));
+	ASSERT(!zilog_is_dirty(zilog));
+	ASSERT(zilog->zl_suspend != 0);
+	ASSERT(!zilog->zl_suspending);
+
+	zilog->zl_dirty_max_txg = 0;
+	zilog->zl_lwb_max_issued_txg = 0;
+}
+
+/*
  * Close an intent log.
  */
 void

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -583,7 +583,11 @@ tests = ['zpool_set_001_pos', 'zpool_set_002_neg', 'zpool_set_003_neg',
     'zpool_set_ashift', 'zpool_set_features', 'zpool_set_inherit',
     'vdev_set_001_pos', 'user_property_001_pos', 'user_property_002_neg',
     'zpool_set_clear_userprop','vdev_set_scheduler', 'vdev_set_allocating',
-    'vdev_set_path']
+    'vdev_set_path',
+    'zpool_set_readonly_001_pos', 'zpool_set_readonly_002_pos',
+    'zpool_set_readonly_003_pos', 'zpool_set_readonly_004_pos',
+    'zpool_set_readonly_001_neg', 'zpool_set_readonly_002_neg',
+    'zpool_set_readonly_003_neg', 'zpool_set_readonly_004_neg']
 tags = ['functional', 'cli_root', 'zpool_set']
 
 [tests/functional/cli_root/zpool_split]

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -1384,6 +1384,14 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/cli_root/zpool_set/user_property_002_neg.ksh \
 	functional/cli_root/zpool_set/zpool_set_features.ksh \
 	functional/cli_root/zpool_set/zpool_set_clear_userprop.ksh \
+	functional/cli_root/zpool_set/zpool_set_readonly_001_pos.ksh \
+	functional/cli_root/zpool_set/zpool_set_readonly_002_pos.ksh \
+	functional/cli_root/zpool_set/zpool_set_readonly_003_pos.ksh \
+	functional/cli_root/zpool_set/zpool_set_readonly_004_pos.ksh \
+	functional/cli_root/zpool_set/zpool_set_readonly_001_neg.ksh \
+	functional/cli_root/zpool_set/zpool_set_readonly_002_neg.ksh \
+	functional/cli_root/zpool_set/zpool_set_readonly_003_neg.ksh \
+	functional/cli_root/zpool_set/zpool_set_readonly_004_neg.ksh \
 	functional/cli_root/zpool_split/cleanup.ksh \
 	functional/cli_root/zpool_split/setup.ksh \
 	functional/cli_root/zpool_split/zpool_split_cliargs.ksh \

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_set/zpool_set_readonly_001_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_set/zpool_set_readonly_001_neg.ksh
@@ -1,0 +1,50 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+#
+# zpool set readonly=on fails while a filesystem is mounted writable
+#
+# STRATEGY:
+# 1. Create a pool with a filesystem mounted read-write
+# 2. Verify zpool set readonly=on fails
+# 3. Verify the pool remains writable
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	destroy_pool $TESTPOOL1
+	rm -f $FILEVDEV
+}
+
+log_assert "zpool set readonly=on fails while a filesystem is mounted writable"
+log_onexit cleanup
+
+FILEVDEV="$TEST_BASE_DIR/zpool_set_readonly_001_neg.$$.dat"
+TESTFILE="readonly-neg-file"
+
+log_must truncate -s $MINVDEVSIZE $FILEVDEV
+log_must zpool create -O canmount=off $TESTPOOL1 $FILEVDEV
+log_must zfs create $TESTPOOL1/$TESTFS
+MNTPFS="$(get_prop mountpoint $TESTPOOL1/$TESTFS)"
+
+log_mustnot zpool set readonly=on $TESTPOOL1
+log_must test "$(get_pool_prop readonly $TESTPOOL1)" == "off"
+log_must touch $MNTPFS/$TESTFILE
+
+log_pass "zpool set readonly=on fails while a filesystem is mounted writable"

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_set/zpool_set_readonly_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_set/zpool_set_readonly_001_pos.ksh
@@ -1,0 +1,65 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+#
+# zpool set readonly=on can convert a pool from RW to RO
+#
+# STRATEGY:
+# 1. Create a pool and filesystem, write a test file
+# 2. Remount the filesystem readonly
+# 3. Set readonly=on on the pool
+# 4. Verify the pool is readonly and data is still readable
+# 5. Verify writes and remount,rw fail
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	datasetexists $TESTPOOL1/$TESTFS && \
+	    log_must zfs unmount -f $TESTPOOL1/$TESTFS
+	destroy_pool $TESTPOOL1
+	rm -f $FILEVDEV
+}
+
+log_assert "zpool set readonly=on can convert a pool from RW to RO"
+log_onexit cleanup
+
+FILEVDEV="$TEST_BASE_DIR/zpool_set_readonly_001.$$.dat"
+TESTFILE="readonly-test-file"
+CONTENT="zpool_set_readonly_001"
+
+log_must truncate -s $MINVDEVSIZE $FILEVDEV
+log_must zpool create -O canmount=off $TESTPOOL1 $FILEVDEV
+log_must zfs create $TESTPOOL1/$TESTFS
+MNTPFS="$(get_prop mountpoint $TESTPOOL1/$TESTFS)"
+
+log_must eval "echo $CONTENT > $MNTPFS/$TESTFILE"
+log_must zfs mount -o remount,ro $TESTPOOL1/$TESTFS
+
+log_must zpool set readonly=on $TESTPOOL1
+log_must test "$(get_pool_prop readonly $TESTPOOL1)" == "on"
+
+log_must test "$(cat $MNTPFS/$TESTFILE)" == "$CONTENT"
+log_mustnot touch $MNTPFS/$TESTFILE.new
+log_mustnot zfs create $TESTPOOL1/${TESTFS}_new
+
+# note: remount,rw does not return a failure, but readonly should stay 'on'
+log_must zfs mount -o remount,rw $TESTPOOL1/$TESTFS
+log_must test "$(get_pool_prop readonly $TESTPOOL1)" == "on"
+
+log_pass "zpool set readonly=on can convert a pool from RW to RO"

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_set/zpool_set_readonly_002_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_set/zpool_set_readonly_002_neg.ksh
@@ -1,0 +1,59 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+#
+# zpool set/create reject unsupported readonly property values
+#
+# STRATEGY:
+# 1. Verify zpool create -o readonly=on fails
+# 2. Verify zpool set readonly=off fails on a writable pool
+# 3. Convert a pool to readonly and verify readonly=off still fails
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	datasetexists $TESTPOOL1/$TESTFS && \
+	    ismounted $TESTPOOL1/$TESTFS && \
+	    log_must zfs unmount -f $TESTPOOL1/$TESTFS
+	destroy_pool $TESTPOOL1
+	rm -f $FILEVDEV $FILEVDEV2
+}
+
+log_assert "zpool set/create reject unsupported readonly property values"
+log_onexit cleanup
+
+FILEVDEV="$TEST_BASE_DIR/zpool_set_readonly_002_neg.$$.dat"
+FILEVDEV2="$TEST_BASE_DIR/zpool_set_readonly_002_neg_2.$$.dat"
+
+log_must truncate -s $MINVDEVSIZE $FILEVDEV2
+log_mustnot zpool create -o readonly=on $TESTPOOL1 $FILEVDEV2
+log_mustnot poolexists $TESTPOOL1
+
+log_must truncate -s $MINVDEVSIZE $FILEVDEV
+log_must zpool create -O canmount=off $TESTPOOL1 $FILEVDEV
+log_mustnot zpool set readonly=off $TESTPOOL1
+log_must test "$(get_pool_prop readonly $TESTPOOL1)" == "off"
+
+log_must zfs create $TESTPOOL1/$TESTFS
+log_must zfs mount -o remount,ro $TESTPOOL1/$TESTFS
+log_must zpool set readonly=on $TESTPOOL1
+log_mustnot zpool set readonly=off $TESTPOOL1
+log_must test "$(get_pool_prop readonly $TESTPOOL1)" == "on"
+
+log_pass "zpool set/create reject unsupported readonly property values"

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_set/zpool_set_readonly_002_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_set/zpool_set_readonly_002_pos.ksh
@@ -1,0 +1,65 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+#
+# readonly set by zpool set does not persist across export/import
+#
+# STRATEGY:
+# 1. Create a pool, write data, remount readonly, and convert the pool
+# 2. Export and import the pool without -o readonly=on
+# 3. Verify the pool is writable and the data is intact
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	datasetexists $TESTPOOL1/$TESTFS && \
+	    ismounted $TESTPOOL1/$TESTFS && \
+	    log_must zfs unmount -f $TESTPOOL1/$TESTFS
+	destroy_pool $TESTPOOL1
+	rm -f $FILEVDEV
+}
+
+log_assert "readonly set by zpool set does not persist across export/import"
+log_onexit cleanup
+
+FILEVDEV="$TEST_BASE_DIR/zpool_set_readonly_002.$$.dat"
+TESTFILE="readonly-persist-file"
+CONTENT="zpool_set_readonly_002"
+
+log_must truncate -s $MINVDEVSIZE $FILEVDEV
+log_must zpool create -O canmount=off $TESTPOOL1 $FILEVDEV
+log_must zfs create $TESTPOOL1/$TESTFS
+MNTPFS="$(get_prop mountpoint $TESTPOOL1/$TESTFS)"
+
+log_must eval "echo $CONTENT > $MNTPFS/$TESTFILE"
+log_must zfs mount -o remount,ro $TESTPOOL1/$TESTFS
+log_must zpool set readonly=on $TESTPOOL1
+log_must test "$(get_pool_prop readonly $TESTPOOL1)" == "on"
+
+log_must zfs unmount $TESTPOOL1/$TESTFS
+log_must zpool export $TESTPOOL1
+log_must zpool import -d $TEST_BASE_DIR $TESTPOOL1
+
+log_must test "$(get_pool_prop readonly $TESTPOOL1)" == "off"
+MNTPFS="$(get_prop mountpoint $TESTPOOL1/$TESTFS)"
+log_must ismounted $TESTPOOL1/$TESTFS
+log_must test "$(cat $MNTPFS/$TESTFILE)" == "$CONTENT"
+log_must eval "echo rewritten > $MNTPFS/$TESTFILE"
+
+log_pass "readonly set by zpool set does not persist across export/import"

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_set/zpool_set_readonly_003_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_set/zpool_set_readonly_003_neg.ksh
@@ -1,0 +1,64 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+#
+# zpool set readonly=on fails while a zvol is open writable
+#
+# STRATEGY:
+# 1. Create a pool with a filesystem and a zvol
+# 2. Remount the filesystem readonly and open the zvol writable
+# 3. Verify zpool set readonly=on fails
+# 4. Close the zvol and verify the conversion then succeeds
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	exec 9<&-
+	exec 9>&-
+	datasetexists $TESTPOOL1/$TESTFS && \
+	    ismounted $TESTPOOL1/$TESTFS && \
+	    log_must zfs unmount -f $TESTPOOL1/$TESTFS
+	destroy_pool $TESTPOOL1
+	rm -f $FILEVDEV
+}
+
+log_assert "zpool set readonly=on fails while a zvol is open writable"
+log_onexit cleanup
+
+FILEVDEV="$TEST_BASE_DIR/zpool_set_readonly_003_neg.$$.dat"
+VOL=$TESTPOOL1/$TESTVOL
+ZDEV=$ZVOL_DEVDIR/$VOL
+
+log_must truncate -s $MINVDEVSIZE $FILEVDEV
+log_must zpool create -O canmount=off $TESTPOOL1 $FILEVDEV
+log_must zfs create $TESTPOOL1/$TESTFS
+log_must zfs create -V 10m $VOL
+block_device_wait $ZDEV
+
+log_must zfs mount -o remount,ro $TESTPOOL1/$TESTFS
+exec 9<> "$ZDEV"
+log_mustnot zpool set readonly=on $TESTPOOL1
+log_must test "$(get_pool_prop readonly $TESTPOOL1)" == "off"
+
+exec 9<&-
+exec 9>&-
+log_must zpool set readonly=on $TESTPOOL1
+log_must test "$(get_pool_prop readonly $TESTPOOL1)" == "on"
+
+log_pass "zpool set readonly=on fails while a zvol is open writable"

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_set/zpool_set_readonly_003_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_set/zpool_set_readonly_003_pos.ksh
@@ -1,0 +1,58 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+#
+# zpool set readonly=on succeeds with unmounted datasets and closed zvols
+#
+# STRATEGY:
+# 1. Create a pool with a mounted filesystem, an unmounted filesystem, and
+#    a closed zvol
+# 2. Remount the mounted filesystem readonly
+# 3. Verify zpool set readonly=on succeeds
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	datasetexists $TESTPOOL1/$TESTFS && \
+	    ismounted $TESTPOOL1/$TESTFS && \
+	    log_must zfs unmount -f $TESTPOOL1/$TESTFS
+	destroy_pool $TESTPOOL1
+	rm -f $FILEVDEV
+}
+
+log_assert "zpool set readonly=on succeeds with unmounted datasets and closed zvols"
+log_onexit cleanup
+
+FILEVDEV="$TEST_BASE_DIR/zpool_set_readonly_003.$$.dat"
+UNMOUNTED=$TESTPOOL1/${TESTFS}_unmounted
+VOL=$TESTPOOL1/$TESTVOL
+
+log_must truncate -s $MINVDEVSIZE $FILEVDEV
+log_must zpool create -O canmount=off $TESTPOOL1 $FILEVDEV
+log_must zfs create $TESTPOOL1/$TESTFS
+log_must zfs create $UNMOUNTED
+log_must zfs unmount $UNMOUNTED
+log_must zfs create -V 10m $VOL
+block_device_wait $ZVOL_DEVDIR/$VOL
+
+log_must zfs mount -o remount,ro $TESTPOOL1/$TESTFS
+log_must zpool set readonly=on $TESTPOOL1
+log_must test "$(get_pool_prop readonly $TESTPOOL1)" == "on"
+
+log_pass "zpool set readonly=on succeeds with unmounted datasets and closed zvols"

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_set/zpool_set_readonly_004_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_set/zpool_set_readonly_004_neg.ksh
@@ -1,0 +1,59 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+#
+# Pool and dataset modifying commands fail after readonly conversion
+#
+# STRATEGY:
+# 1. Convert a pool to readonly
+# 2. Verify zpool and zfs modifying commands fail
+# 3. Verify remount,rw fails
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	datasetexists $TESTPOOL1/$TESTFS && \
+	    ismounted $TESTPOOL1/$TESTFS && \
+	    log_must zfs unmount -f $TESTPOOL1/$TESTFS
+	destroy_pool $TESTPOOL1
+	rm -f $FILEVDEV $FILEVDEV2
+}
+
+log_assert "Pool and dataset modifying commands fail after readonly conversion"
+log_onexit cleanup
+
+FILEVDEV="$TEST_BASE_DIR/zpool_set_readonly_004_neg.$$.dat"
+FILEVDEV2="$TEST_BASE_DIR/zpool_set_readonly_004_neg_2.$$.dat"
+
+log_must truncate -s $MINVDEVSIZE $FILEVDEV
+log_must truncate -s $MINVDEVSIZE $FILEVDEV2
+log_must zpool create -O canmount=off $TESTPOOL1 $FILEVDEV
+log_must zfs create $TESTPOOL1/$TESTFS
+log_must zfs mount -o remount,ro $TESTPOOL1/$TESTFS
+log_must zpool set readonly=on $TESTPOOL1
+
+log_mustnot zpool add $TESTPOOL1 $FILEVDEV2
+log_mustnot zpool clear $TESTPOOL1
+log_mustnot zpool scrub $TESTPOOL1
+log_mustnot zpool reguid $TESTPOOL1
+log_mustnot zfs create $TESTPOOL1/${TESTFS}_new
+log_mustnot zfs set compression=on $TESTPOOL1/$TESTFS
+log_must test "$(get_pool_prop readonly $TESTPOOL1)" == "on"
+
+log_pass "Pool and dataset modifying commands fail after readonly conversion"

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_set/zpool_set_readonly_004_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_set/zpool_set_readonly_004_pos.ksh
@@ -1,0 +1,57 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+#
+# Synced data remains readable after converting a pool to readonly
+#
+# STRATEGY:
+# 1. Create a pool with sync=always and write a file
+# 2. Remount readonly and convert the pool
+# 3. Verify the synced data is still readable
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	datasetexists $TESTPOOL1/$TESTFS && \
+	    ismounted $TESTPOOL1/$TESTFS && \
+	    log_must zfs unmount -f $TESTPOOL1/$TESTFS
+	destroy_pool $TESTPOOL1
+	rm -f $FILEVDEV
+}
+
+log_assert "Synced data remains readable after converting a pool to readonly"
+log_onexit cleanup
+
+FILEVDEV="$TEST_BASE_DIR/zpool_set_readonly_004.$$.dat"
+TESTFILE="readonly-sync-file"
+CONTENT="zpool_set_readonly_004"
+
+log_must truncate -s $MINVDEVSIZE $FILEVDEV
+log_must zpool create -O canmount=off $TESTPOOL1 $FILEVDEV
+log_must zfs create -o sync=always $TESTPOOL1/$TESTFS
+MNTPFS="$(get_prop mountpoint $TESTPOOL1/$TESTFS)"
+
+log_must eval "echo $CONTENT > $MNTPFS/$TESTFILE"
+log_must zfs mount -o remount,ro $TESTPOOL1/$TESTFS
+log_must zpool set readonly=on $TESTPOOL1
+
+log_must test "$(get_pool_prop readonly $TESTPOOL1)" == "on"
+log_must test "$(cat $MNTPFS/$TESTFILE)" == "$CONTENT"
+
+log_pass "Synced data remains readable after converting a pool to readonly"


### PR DESCRIPTION
This is an "unforced readonly" proof of concept.

It requires all datasets to be temporarily converted to r/o mounts, using `zfs mount -o remount,ro {dataset}` for each dataset. Note that making this change WILL NOT modify the dataset property on disk. It will still import the next time as "readonly=off". However, the command `zfs get readonly {dataset}` will show that readonly is "on" but the SOURCE is "temporary".

Once that's done, the command `zpool set readonly=on {pool}` will shut down the sync engine, mark the pool as "exported" but keep it loaded in memory so that read requests will continue to work.

The reason for marking the pool as exported is so that it can be imported readonly on another system without having to force it.

Do not import the pool read/write on another system at the same time that it's imported readonly on the first system, as that will cause the first system to eventually panic.

There are a number of follow-on features that will make this a product rather than a proof of concept:
- Adding code to check the labels to see if the pool was imported r/w elsewhere, and immediately unload it
- Adding the ability to automatically convert r/w mounts to r/o without having to manually do that
- Adding corresponding FreeBSD changes that were made to `module/os/linux/zfs/vdev_disk.c`
- Allow users to convert back to a r/w pool
- Handle checking datasets in parallel (not needed for wasabi's configs)

There are probably some others that I'm not thinking of now, but I believe that this PR is a MVP for wasabi's needs