### PR TITLE
dmu: remove dmu_prealloc()

### DIFF
--- a/cmd/ztest.c
+++ b/cmd/ztest.c
@@ -424,7 +424,6 @@ ztest_func_t ztest_zil_commit;
 ztest_func_t ztest_zil_remount;
 ztest_func_t ztest_dmu_read_write_zcopy;
 ztest_func_t ztest_dmu_objset_create_destroy;
-ztest_func_t ztest_dmu_prealloc;
 ztest_func_t ztest_fzap;
 ztest_func_t ztest_dmu_snapshot_create_destroy;
 ztest_func_t ztest_dsl_prop_get_set;
@@ -483,9 +482,6 @@ static ztest_info_t ztest_info[] = {
 	ZTI_INIT(ztest_dmu_objset_create_destroy, 1, &zopt_often),
 	ZTI_INIT(ztest_dsl_prop_get_set, 1, &zopt_often),
 	ZTI_INIT(ztest_spa_prop_get_set, 1, &zopt_sometimes),
-#if 0
-	ZTI_INIT(ztest_dmu_prealloc, 1, &zopt_sometimes),
-#endif
 	ZTI_INIT(ztest_fzap, 1, &zopt_sometimes),
 	ZTI_INIT(ztest_dmu_snapshot_create_destroy, 1, &zopt_sometimes),
 	ZTI_INIT(ztest_spa_create_destroy, 1, &zopt_sometimes),
@@ -3017,37 +3013,6 @@ ztest_setattr(ztest_ds_t *zd, uint64_t object)
 	ztest_lr_free(lr, sizeof (*lr), NULL);
 
 	return (error);
-}
-
-static void
-ztest_prealloc(ztest_ds_t *zd, uint64_t object, uint64_t offset, uint64_t size)
-{
-	objset_t *os = zd->zd_os;
-	dmu_tx_t *tx;
-	uint64_t txg;
-	rl_t *rl;
-
-	txg_wait_synced(dmu_objset_pool(os), 0);
-
-	ztest_object_lock(zd, object, ZTRL_READER);
-	rl = ztest_range_lock(zd, object, offset, size, ZTRL_WRITER);
-
-	tx = dmu_tx_create(os);
-
-	dmu_tx_hold_write(tx, object, offset, size);
-
-	txg = ztest_tx_assign(tx, DMU_TX_WAIT, FTAG);
-
-	if (txg != 0) {
-		dmu_prealloc(os, object, offset, size, tx);
-		dmu_tx_commit(tx);
-		txg_wait_synced(dmu_objset_pool(os), txg);
-	} else {
-		(void) dmu_free_long_range(os, object, offset, size);
-	}
-
-	ztest_range_unlock(rl);
-	ztest_object_unlock(zd, object);
 }
 
 static void
@@ -5804,48 +5769,6 @@ ztest_dmu_write_parallel(ztest_ds_t *zd, uint64_t id)
 	while (ztest_random(10) != 0)
 		ztest_io(zd, od->od_object, offset);
 
-	umem_free(od, sizeof (ztest_od_t));
-}
-
-void
-ztest_dmu_prealloc(ztest_ds_t *zd, uint64_t id)
-{
-	ztest_od_t *od;
-	uint64_t offset = (1ULL << (ztest_random(4) + SPA_MAXBLOCKSHIFT)) +
-	    (ztest_random(ZTEST_RANGE_LOCKS) << SPA_MAXBLOCKSHIFT);
-	uint64_t count = ztest_random(20) + 1;
-	uint64_t blocksize = ztest_random_blocksize();
-	void *data;
-
-	od = umem_alloc(sizeof (ztest_od_t), UMEM_NOFAIL);
-
-	ztest_od_init(od, id, FTAG, 0, DMU_OT_UINT64_OTHER, blocksize, 0, 0);
-
-	if (ztest_object_init(zd, od, sizeof (ztest_od_t),
-	    !ztest_random(2)) != 0) {
-		umem_free(od, sizeof (ztest_od_t));
-		return;
-	}
-
-	if (ztest_truncate(zd, od->od_object, offset, count * blocksize) != 0) {
-		umem_free(od, sizeof (ztest_od_t));
-		return;
-	}
-
-	ztest_prealloc(zd, od->od_object, offset, count * blocksize);
-
-	data = umem_zalloc(blocksize, UMEM_NOFAIL);
-
-	while (ztest_random(count) != 0) {
-		uint64_t randoff = offset + (ztest_random(count) * blocksize);
-		if (ztest_write(zd, od->od_object, randoff, blocksize,
-		    data) != 0)
-			break;
-		while (ztest_random(4) != 0)
-			ztest_io(zd, od->od_object, randoff);
-	}
-
-	umem_free(data, blocksize);
 	umem_free(od, sizeof (ztest_od_t));
 }
 

--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -918,8 +918,6 @@ void dmu_write(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
     const void *buf, dmu_tx_t *tx, dmu_flags_t flags);
 int dmu_write_by_dnode(dnode_t *dn, uint64_t offset, uint64_t size,
     const void *buf, dmu_tx_t *tx, dmu_flags_t flags);
-void dmu_prealloc(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
-    dmu_tx_t *tx);
 #ifdef _KERNEL
 int dmu_read_uio(objset_t *os, uint64_t object, zfs_uio_t *uio, uint64_t size,
     dmu_flags_t flags);

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -1534,27 +1534,6 @@ dmu_write_by_dnode(dnode_t *dn, uint64_t offset, uint64_t size,
 }
 
 void
-dmu_prealloc(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
-    dmu_tx_t *tx)
-{
-	dmu_buf_t **dbp;
-	int numbufs, i;
-
-	if (size == 0)
-		return;
-
-	VERIFY0(dmu_buf_hold_array(os, object, offset, size,
-	    FALSE, FTAG, &numbufs, &dbp, DMU_READ_PREFETCH));
-
-	for (i = 0; i < numbufs; i++) {
-		dmu_buf_t *db = dbp[i];
-
-		dmu_buf_will_not_fill(db, tx);
-	}
-	dmu_buf_rele_array(dbp, numbufs, FTAG);
-}
-
-void
 dmu_write_embedded(objset_t *os, uint64_t object, uint64_t offset,
     void *data, uint8_t etype, uint8_t comp, int uncompressed_size,
     int compressed_size, int byteorder, dmu_tx_t *tx)
@@ -3170,7 +3149,6 @@ EXPORT_SYMBOL(dmu_write_by_dnode);
 EXPORT_SYMBOL(dmu_write_uio);
 EXPORT_SYMBOL(dmu_write_uio_dbuf);
 EXPORT_SYMBOL(dmu_write_uio_dnode);
-EXPORT_SYMBOL(dmu_prealloc);
 EXPORT_SYMBOL(dmu_object_info);
 EXPORT_SYMBOL(dmu_object_info_from_dnode);
 EXPORT_SYMBOL(dmu_object_info_from_db);


### PR DESCRIPTION
ztest is the only caller, and its ZTI_INIT entry has sat behind #if 0 since the 2010 import from OpenSolaris build 141, so nothing exercises it. No kernel or libzpool code calls it either.

Remove the function and its export, plus the ztest code that existed only for it: ztest_dmu_prealloc(), the ztest_prealloc() helper it called, and the disabled ZTI_INIT entry.

As requested by pr19071

Types of Changes
[X] Bug fix (non-breaking change which fixes an issue)

Checklist
[X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
[ ] I have updated the documentation accordingly.
[X] I have read the [contributing document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
[ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
[X] I have run the ZFS Test Suite with this change applied.
[X] All commit messages are properly formatted and contain