### PR TITLE
zfs: spa_sync_upgrades() should only take lock when needed

### DIFF
--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -27,6 +27,7 @@
  * Copyright (c) 2023 Hewlett Packard Enterprise Development LP.
  * Copyright (c) 2023-2026, Klara, Inc.
  * Copyright (c) 2026, TrueNAS.
+ * Copyright 2026 Edgecast Cloud LLC.
  */
 
 /*
@@ -10867,32 +10868,49 @@ spa_sync_upgrades(spa_t *spa, dmu_tx_t *tx)
 	if (spa_sync_pass(spa) != 1)
 		return;
 
-	dsl_pool_t *dp = spa->spa_dsl_pool;
-	rrw_enter(&dp->dp_config_rwlock, RW_WRITER, FTAG);
+	uint64_t oldver = spa->spa_ubsync.ub_version;
+	uint64_t newver = spa->spa_uberblock.ub_version;
 
-	if (spa->spa_ubsync.ub_version < SPA_VERSION_ORIGIN &&
-	    spa->spa_uberblock.ub_version >= SPA_VERSION_ORIGIN) {
-		dsl_pool_create_origin(dp, tx);
+	/*
+	 * These upgrades change DSL namespace, so they need the
+	 * writer lock.
+	 */
+	boolean_t need_origin = oldver < SPA_VERSION_ORIGIN &&
+	    newver >= SPA_VERSION_ORIGIN;
+	boolean_t need_clones = oldver < SPA_VERSION_NEXT_CLONES &&
+	    newver >= SPA_VERSION_NEXT_CLONES;
+	boolean_t need_dir_clones = oldver < SPA_VERSION_DIR_CLONES &&
+	    newver >= SPA_VERSION_DIR_CLONES;
 
-		/* Keeping the origin open increases spa_minref */
-		spa->spa_minref += 3;
+	if (need_origin || need_clones || need_dir_clones) {
+		dsl_pool_t *dp = spa->spa_dsl_pool;
+
+		rrw_enter(&dp->dp_config_rwlock, RW_WRITER, FTAG);
+
+		if (need_origin) {
+			dsl_pool_create_origin(dp, tx);
+
+			/* Keeping the origin open increases spa_minref */
+			spa->spa_minref += 3;
+		}
+
+		if (need_clones) {
+			dsl_pool_upgrade_clones(dp, tx);
+		}
+
+		if (need_dir_clones) {
+			dsl_pool_upgrade_dir_clones(dp, tx);
+
+			/* Keeping the freedir open increases spa_minref */
+			spa->spa_minref += 3;
+		}
+
+		rrw_exit(&dp->dp_config_rwlock, FTAG);
 	}
 
-	if (spa->spa_ubsync.ub_version < SPA_VERSION_NEXT_CLONES &&
-	    spa->spa_uberblock.ub_version >= SPA_VERSION_NEXT_CLONES) {
-		dsl_pool_upgrade_clones(dp, tx);
-	}
+	/* Remaining upgrades do not need dp_config_rwlock */
 
-	if (spa->spa_ubsync.ub_version < SPA_VERSION_DIR_CLONES &&
-	    spa->spa_uberblock.ub_version >= SPA_VERSION_DIR_CLONES) {
-		dsl_pool_upgrade_dir_clones(dp, tx);
-
-		/* Keeping the freedir open increases spa_minref */
-		spa->spa_minref += 3;
-	}
-
-	if (spa->spa_ubsync.ub_version < SPA_VERSION_FEATURES &&
-	    spa->spa_uberblock.ub_version >= SPA_VERSION_FEATURES) {
+	if (oldver < SPA_VERSION_FEATURES && newver >= SPA_VERSION_FEATURES) {
 		spa_feature_create_zap_objects(spa, tx);
 	}
 
@@ -10902,7 +10920,7 @@ spa_sync_upgrades(spa_t *spa, dmu_tx_t *tx)
 	 * Old pools that have this feature enabled must be upgraded to have
 	 * this feature active
 	 */
-	if (spa->spa_uberblock.ub_version >= SPA_VERSION_FEATURES) {
+	if (newver >= SPA_VERSION_FEATURES) {
 		boolean_t lz4_en = spa_feature_is_enabled(spa,
 		    SPA_FEATURE_LZ4_COMPRESS);
 		boolean_t lz4_ac = spa_feature_is_active(spa,
@@ -10924,8 +10942,6 @@ spa_sync_upgrades(spa_t *spa, dmu_tx_t *tx)
 		    sizeof (spa->spa_cksum_salt.zcs_bytes),
 		    spa->spa_cksum_salt.zcs_bytes, tx));
 	}
-
-	rrw_exit(&dp->dp_config_rwlock, FTAG);
 }
 
 static void


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

"zfs get -Hp ..." command got into waiting for memory allocation while holding READER lock as dmu_objset_hold holds dp_config_rwlock READ via dsl_pool_hold.

pageout was freeing memory by pushing some pages to swap zvol, but got waiting for txg_wait_synced() and the memory was not freed.

txg_sync thread: spa_sync -> spa_sync_upgrades ->
rrw_enter(&dp->dp_config_rwlock, RW_WRITER) blocked.

This scenario did lead to investigation if spa_sync_upgrades() is actually correct about requiring writer lock and it turns out that we only do need write lock for three cases, where upgrade does change DSL name space.

In other cases, and to check uberblock versions, we do not need to set this lock.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Failure to acquire dp_config_rwlock WRITER lock while READ lock holder is waiting for other resources.

<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

Only set lock when needed.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
ZTS is still running.

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
