### PR TITLE
zfs_ctldir: make .zfs/snapshot/<name> btime the snapshot creation time

### DIFF
--- a/include/os/linux/zfs/sys/zpl.h
+++ b/include/os/linux/zfs/sys/zpl.h
@@ -86,6 +86,8 @@ extern const struct inode_operations zpl_ops_root;
 extern const struct file_operations zpl_fops_snapdir;
 extern const struct inode_operations zpl_ops_snapdir;
 
+extern const struct inode_operations zpl_ops_snapdirs;
+
 extern const struct file_operations zpl_fops_shares;
 extern const struct inode_operations zpl_ops_shares;
 

--- a/module/os/linux/zfs/zfs_ctldir.c
+++ b/module/os/linux/zfs/zfs_ctldir.c
@@ -536,6 +536,8 @@ zfsctl_inode_alloc(zfsvfs_t *zfsvfs, uint64_t id,
 	zp->z_pflags = 0;
 	zp->z_mode = 0;
 	zp->z_sync_cnt = 0;
+	zp->z_btime.tv_sec = creation;
+	zp->z_btime.tv_nsec = 0;
 	ip->i_generation = 0;
 	ip->i_ino = id;
 	ip->i_mode = (S_IFDIR | S_IRWXUGO);
@@ -865,7 +867,7 @@ zfsctl_snapdir_lookup(struct inode *dip, const char *name, struct inode **ipp,
 	}
 
 	*ipp = zfsctl_inode_lookup(zfsvfs, ZFSCTL_INO_SNAPDIRS - id,
-	    &simple_dir_operations, &simple_dir_inode_operations);
+	    &simple_dir_operations, &zpl_ops_snapdirs);
 	if (*ipp == NULL)
 		error = SET_ERROR(ENOENT);
 

--- a/module/os/linux/zfs/zfs_vnops_os.c
+++ b/module/os/linux/zfs/zfs_vnops_os.c
@@ -1775,14 +1775,31 @@ zfs_getattr_fast(zidmap_t *idmap, u32 request_mask, struct inode *ip,
 
 	mutex_exit(&zp->z_lock);
 
+#ifdef STATX_BTIME
+	if (request_mask & STATX_BTIME) {
+		sp->btime = zp->z_btime;
+		sp->result_mask |= STATX_BTIME;
+	}
+#endif
+
 	/*
 	 * Required to prevent NFS client from detecting different inode
 	 * numbers of snapshot root dentry before and after snapshot mount.
+	 * Likewise report the snapshot creation time as the birth time,
+	 * matching the unmounted '.zfs/snapshot/<name>' directory.
 	 */
 	if (zfsvfs->z_issnap) {
-		if (ip->i_sb->s_root->d_inode == ip)
+		if (ip->i_sb->s_root->d_inode == ip) {
 			sp->ino = ZFSCTL_INO_SNAPDIRS -
 			    dmu_objset_id(zfsvfs->z_os);
+#ifdef STATX_BTIME
+			if (request_mask & STATX_BTIME) {
+				sp->btime.tv_sec = dsl_get_creation(
+				    dmu_objset_ds(zfsvfs->z_os));
+				sp->btime.tv_nsec = 0;
+			}
+#endif
+		}
 	}
 
 	zfs_exit(zfsvfs, FTAG);

--- a/module/os/linux/zfs/zpl_ctldir.c
+++ b/module/os/linux/zfs/zpl_ctldir.c
@@ -788,6 +788,38 @@ const struct inode_operations zpl_ops_snapdir = {
 	.mkdir		= zpl_snapdir_mkdir,
 };
 
+/*
+ * Get unmounted '.zfs/snapshot/<name>' directory attributes.
+ */
+ZPL_IDMAP_IOP_DEFINE(int, zpl_snapdirs_getattr, 4,
+    const struct path *, path, struct kstat *, stat, u32, request_mask,
+    unsigned int, query_flags)
+{
+	(void) request_mask, (void) query_flags;
+	struct inode *ip = path->dentry->d_inode;
+	znode_t *zp __maybe_unused = ITOZ(ip);
+
+	zpl_generic_fillattr(idmap, request_mask, ip, stat);
+
+#ifdef STATX_BTIME
+	if ((request_mask & STATX_BTIME) && zp->z_btime.tv_sec != 0) {
+		stat->btime = zp->z_btime;
+		stat->result_mask |= STATX_BTIME;
+	}
+#endif
+
+	return (0);
+}
+
+/*
+ * The '.zfs/snapshot/<name>' directory inode operations, used until the
+ * snapshot is mounted over it.
+ */
+const struct inode_operations zpl_ops_snapdirs = {
+	.lookup		= simple_lookup,
+	.getattr	= zpl_snapdirs_getattr,
+};
+
 static struct dentry *
 zpl_shares_lookup(struct inode *dip, struct dentry *dentry,
     unsigned int flags)

--- a/module/os/linux/zfs/zpl_ctldir.c
+++ b/module/os/linux/zfs/zpl_ctldir.c
@@ -88,7 +88,7 @@ ZPL_IDMAP_IOP_DEFINE(int, zpl_root_getattr, 4,
     const struct path *, path, struct kstat *, stat, u32, request_mask,
     unsigned int, query_flags)
 {
-	(void) request_mask, (void) query_flags;
+	(void) query_flags;
 	struct inode *ip = path->dentry->d_inode;
 	zpl_generic_fillattr(idmap, request_mask, ip, stat);
 	stat->atime = current_time(ip);
@@ -731,7 +731,7 @@ ZPL_IDMAP_IOP_DEFINE(int, zpl_snapdir_getattr, 4,
     const struct path *, path, struct kstat *, stat, u32, request_mask,
     unsigned int, query_flags)
 {
-	(void) request_mask, (void) query_flags;
+	(void) query_flags;
 	struct inode *ip = path->dentry->d_inode;
 	zfsvfs_t *zfsvfs = ITOZSB(ip);
 	int error;
@@ -795,7 +795,7 @@ ZPL_IDMAP_IOP_DEFINE(int, zpl_snapdirs_getattr, 4,
     const struct path *, path, struct kstat *, stat, u32, request_mask,
     unsigned int, query_flags)
 {
-	(void) request_mask, (void) query_flags;
+	(void) query_flags;
 	struct inode *ip = path->dentry->d_inode;
 	znode_t *zp __maybe_unused = ITOZ(ip);
 
@@ -886,7 +886,7 @@ ZPL_IDMAP_IOP_DEFINE(int, zpl_shares_getattr, 4,
     const struct path *, path, struct kstat *, stat, u32, request_mask,
     unsigned int, query_flags)
 {
-	(void) request_mask, (void) query_flags;
+	(void) query_flags;
 	struct inode *ip = path->dentry->d_inode;
 	zfsvfs_t *zfsvfs = ITOZSB(ip);
 	znode_t *dzp;

--- a/module/os/linux/zfs/zpl_inode.c
+++ b/module/os/linux/zfs/zpl_inode.c
@@ -427,13 +427,6 @@ ZPL_IDMAP_IOP_DEFINE(int, zpl_getattr, 4,
 
 	error = -zfs_getattr_fast(idmap, request_mask, ip, stat);
 
-#ifdef STATX_BTIME
-	if (request_mask & STATX_BTIME) {
-		stat->btime = zp->z_btime;
-		stat->result_mask |= STATX_BTIME;
-	}
-#endif
-
 #ifdef STATX_CHANGE_COOKIE
 	if (request_mask & STATX_CHANGE_COOKIE) {
 		/*

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -234,7 +234,7 @@ tests = ['snapdir_admin_create_destroy', 'snapdir_admin_rename_destroy',
     'snapdir_stat_no_mount', 'snapdir_mount_bind', 'snapdir_mount_move',
     'snapdir_mount_expire_bind', 'snapdir_mount_expire_move',
     'snapdir_mount_multiple', 'snapdir_mount_fd_hold', 'snapdir_mount_foreign',
-    'snapdir_mount_destroy_defer']
+    'snapdir_mount_destroy_defer', 'snapdir_stat_btime']
 tags = ['functional', 'snapdir']
 
 [tests/functional/syncfs:Linux]

--- a/tests/zfs-tests/tests/Makefile.am
+++ b/tests/zfs-tests/tests/Makefile.am
@@ -2287,6 +2287,7 @@ nobase_dist_datadir_zfs_tests_tests_SCRIPTS += \
 	functional/snapdir/snapdir_mount_no_setuid.ksh \
 	functional/snapdir/snapdir_mount_parallel.ksh \
 	functional/snapdir/snapdir_mount_unmount.ksh \
+	functional/snapdir/snapdir_stat_btime.ksh \
 	functional/snapdir/snapdir_stat_no_mount.ksh \
 	functional/snapshot/cleanup.ksh \
 	functional/snapshot/clone_001_pos.ksh \

--- a/tests/zfs-tests/tests/functional/snapdir/snapdir_stat_btime.ksh
+++ b/tests/zfs-tests/tests/functional/snapdir/snapdir_stat_btime.ksh
@@ -1,0 +1,88 @@
+#!/bin/ksh -p
+# SPDX-License-Identifier: CDDL-1.0
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# https://opensource.org/license/CDDL-1.0.
+#
+
+#
+# Copyright (c) 2026 by iXsystems, Inc.
+#
+
+. $STF_SUITE/tests/functional/snapdir/snapdir.kshlib
+. $STF_SUITE/tests/functional/snapdir/snapdir.cfg
+
+verify_runnable "both"
+
+log_assert "Verify .zfs/snapshot/<name> reports the snapshot creation time as" \
+    "its birth time whether or not the snapshot is mounted"
+
+if ! is_linux ; then
+	log_unsupported "This test uses the Linux-only statx helper"
+fi
+
+function cleanup
+{
+	destroy_pool $TESTPOOL
+}
+
+log_onexit cleanup
+
+# The statx helper opens with O_PATH and never automounts, so it can observe
+# the unmounted placeholder.  It exits 2 if STATX_BTIME is not in stx_mask.
+function check_btime # <path> <expected seconds> <description>
+{
+	typeset out btime
+	out=$(statx btime $1 2>&1) || log_fail "$3: statx btime failed: $out"
+	btime=${out#btime: }
+	log_note "$3: btime $btime (snapshot creation $2)"
+	[[ ${btime%.*} -eq $2 && ${btime#*.} -eq 0 ]] ||
+	    log_fail "$3: btime $btime != snapshot creation $2"
+}
+
+# Create a pool and a filesystem
+create_pool $TESTPOOL $DISKS
+log_must zfs create -o snapdir=visible -o mountpoint=$TESTDIR/fs \
+    $TESTPOOL/$TESTFS
+
+# The creation property has one-second granularity; make sure the snapshot's
+# differs from the filesystem root's crtime, which is what the mounted root
+# used to report, so that the mounted-state check below is discriminating.
+sleep 2
+log_must zfs snapshot $TESTPOOL/$TESTFS@snap
+
+typeset snap=$TESTPOOL/$TESTFS@snap
+typeset snapdir=$TESTDIR/fs/$SNAPROOT/snap
+typeset -i creation=$(get_prop creation $snap)
+typeset fs_btime
+fs_btime=$(statx btime $TESTDIR/fs) ||
+    log_fail "statx btime $TESTDIR/fs failed: $fs_btime"
+fs_btime=${fs_btime#btime: }
+log_must test ${fs_btime%.*} -lt $creation
+
+# 1. Unmounted placeholder: reports the snapshot creation time, and
+#    statx itself must not have mounted the snapshot.
+log_must test -z "$(get_mount_paths $snap)"
+check_btime $snapdir $creation "unmounted"
+log_must test -z "$(get_mount_paths $snap)"
+typeset ino=$(statx ino $snapdir)
+
+# 2. Mounted root: trigger the automount, same birth time, same inode
+#    number (zfs_getattr_fast() remaps both for the snapshot root).
+log_must ls -l $snapdir
+log_must test "$(get_mount_paths $snap)" == "$snapdir"
+check_btime $snapdir $creation "mounted"
+log_must test "$(statx ino $snapdir)" == "$ino"
+
+# 3. After an explicit unmount the placeholder is back.
+log_must umount $snapdir
+log_must test -z "$(get_mount_paths $snap)"
+check_btime $snapdir $creation "unmounted again"
+
+log_pass "Snapshot dir birth time is the snapshot creation time in both states."


### PR DESCRIPTION
### Motivation and Context
`.zfs/snapshot/<name>` reports a different birth time depending on whether the snapshot is automounted. Before the automount it is a placeholder inode with the kernel's `simple_dir_inode_operations`, which has no `getattr`, so `statx(2)` returns no `stx_btime` at all (`a`/`m`/`c`time are the snapshot creation time since a21ca18d4d29). Once mounted it is the snapshot's root directory and reports that directory's `crtime`, i.e. the dataset creation time. So a consumer that wants "when was this snapshot taken" from a plain `statx(2)` gets nothing or the dataset creation time, and the answer changes when the snapshot gets mounted. Reporting the snapshot creation time as `stx_btime` in both states gives one consistent value for the path; birth time is the natural field for it and the one least likely to affect existing consumers.

### Description
The unmounted entry gets its own `inode_operations` table, `zpl_ops_snapdirs`, so it has a `getattr` at all. It reports the creation time that `zfsctl_inode_alloc()` already looked up for a/m/ctime, now also kept in `z_btime`. For the mounted case, `zfs_getattr_fast()` already fakes the inode number of a snapshot root so NFS sees the same fileid before and after the automount; the birth time is now faked in the same place, from `dsl_get_creation()` of the mounted dataset. To make that stick, the `STATX_BTIME` copy in `zpl_getattr()` had to move down into `zfs_getattr_fast()`, otherwise it would overwrite the override on the way out.

### How Has This Been Tested?
**Before the patch:**
```bash
# zfs get -H -o value creation tank/ds@snap1
Wed Sep  9  8:28 2026
# P=/mnt/tank/ds/.zfs/snapshot/snap1

# before mounting (stat does not trigger the automount): no birth time
# stat -c 'birth=%w' $P
birth=-

# after mounting (ls into the directory triggers the automount):
# the root directory's crtime, i.e. the dataset creation time
# ls $P >/dev/null; stat -c 'birth=%w' $P
birth=2026-09-09 08:28:57.959575818 -0700
```
**After the patch:**
```bash
# before mounting: the snapshot creation time
# stat -c 'birth=%w' $P
birth=2026-09-09 08:28:58.000000000 -0700

# after mounting: same
# ls $P >/dev/null; stat -c 'birth=%w' $P
birth=2026-09-09 08:28:58.000000000 -0700
```
- Also verified that `.zfs`, `.zfs/snapshot` and files inside the snapshot are unaffected, and that the value holds across rename, rollback, promote, send/recv and expiry unmount, including over NFSv4 and SMB.

- **ZTS:** snapdir_stat_btime fails on an unpatched module at the first check and passes with the change; the snapdir, snapshot, crtime, stat and ctime groups pass. Also compiled against 6.1 headers.

### Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
