### PR TITLE
zdb.8: document the -Z flag

### DIFF
--- a/man/man8/zdb.8
+++ b/man/man8/zdb.8
@@ -15,7 +15,7 @@
 .\" Copyright (c) 2017 Lawrence Livermore National Security, LLC.
 .\" Copyright (c) 2017 Intel Corporation.
 .\"
-.Dd August 12, 2025
+.Dd September 10, 2026
 .Dt ZDB 8
 .Os
 .
@@ -24,7 +24,7 @@
 .Nd display ZFS storage pool debugging and consistency information
 .Sh SYNOPSIS
 .Nm
-.Op Fl AbcdDFGhikLMNPsTvXYy
+.Op Fl AbcdDFGhikLMNPsTvXYyZ
 .Op Fl e Oo Fl V Oc Oo Fl p Ar path Oc Ns …
 .Op Fl I Ar inflight-I/O-ops
 .Oo Fl o Ar var Ns = Ns Ar value Oc Ns …
@@ -572,6 +572,9 @@ Scans through the livelist and metaslabs, checking for duplicate entries
 and compares the two, checking for potential double frees.
 If it encounters issues, warnings will be printed, but the command will not
 necessarily fail.
+.It Fl Z , -zstd-headers
+Read each ZSTD-compressed block and display its ZSTD header: the compressed
+size, the zstd library version as well as the compression level used.
 .El
 .Pp
 Specifying a display option more than once enables verbosity for only that


### PR DESCRIPTION
### Motivation and Context
`zdb -Z` (`--zstd-headers`) was added with zstd support in 10b3c7f5e but is missing from the zdb.8 manual page.

### Description
Add `Z` to the SYNOPSIS and an entry for `-Z, --zstd-headers` to the option list.

### How Has This Been Tested?
man zdb.8 renders correctly

### Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
