### PR TITLE
spl: Honour forced Linux slab cache selection

### DIFF
--- a/man/man4/spl.4
+++ b/man/man4/spl.4
@@ -46,14 +46,15 @@ object sized larger than this limit.
 .It Sy spl_kmem_cache_slab_limit Ns = Ns Sy 16384 Pq uint
 For small objects the Linux slab allocator should be used to make the most
 efficient use of the memory.
-However, large objects are not supported by
-the Linux slab and therefore the SPL implementation is preferred.
+For large objects, the SPL implementation is preferred.
 This value is used to determine the cutoff between a small and large object.
+The cutoff applies to automatic cache selection.
+An explicit request for a Linux slab or SPL cache overrides it.
 .Pp
-Objects of size
+When cache selection is automatic, objects of size
 .Sy spl_kmem_cache_slab_limit
-or smaller will be allocated using the Linux slab allocator,
-large objects use the SPL allocator.
+or smaller are allocated using the Linux slab allocator,
+and larger objects use the SPL allocator.
 A cutoff of 16K was determined to be optimal for architectures using 4K pages.
 .
 .It Sy spl_kmem_alloc_warn Ns = Ns Sy 32768 Pq uint

--- a/module/os/linux/spl/spl-kmem-cache.c
+++ b/module/os/linux/spl/spl-kmem-cache.c
@@ -778,9 +778,6 @@ spl_kmem_cache_create(const char *name, size_t size, size_t align,
 	} else {
 		unsigned long slabflags = 0;
 
-		if (size > spl_kmem_cache_slab_limit)
-			goto out;
-
 		if (skc->skc_flags & KMC_RECLAIMABLE)
 			slabflags |= SLAB_RECLAIM_ACCOUNT;
 


### PR DESCRIPTION
`spl_kmem_cache_create()` can reject an explicitly requested Linux slab cache when its object size exceeds the automatic-selection cutoff. This violates the `KMC_SLAB` contract and can leave the znode cache unavailable.

Remove the second cutoff check from the Linux-slab branch. Automatic selection still applies the cutoff before choosing a backend, while explicit requests reach the requested allocator. Linux allocator failure handling and alignment validation remain intact. Clarify this distinction in `spl(4)`.

This preserves the automatic-selection change from [PR #15757](https://github.com/openzfs/zfs/pull/15757); it does not restore the old fixed size cap or change the default cutoff.
