### PR TITLE
rpm: Add support for building akmod packages (main branch)

### DIFF
--- a/config/rpm.am
+++ b/config/rpm.am
@@ -7,11 +7,11 @@
 # Build targets for RPM packages.
 ###############################################################################
 
-PHONY += srpm srpms srpm-kmod srpm-dkms srpm-utils
-PHONY += rpm rpms rpm-kmod rpm-dkms rpm-utils rpm-utils-initramfs
+PHONY += srpm srpms srpm-kmod srpm-dkms srpm-utils srpm-akmod
+PHONY += rpm rpms rpm-kmod rpm-dkms rpm-utils rpm-utils-initramfs rpm-akmod
 PHONY += srpm-common rpm-common rpm-local
 
-srpm-kmod srpm-dkms srpm-utils: dist
+srpm-kmod srpm-dkms srpm-utils srpm-akmod: dist
 
 srpm-kmod:
 	$(MAKE) $(AM_MAKEFLAGS) pkg="${PACKAGE}-kmod" \
@@ -24,6 +24,11 @@ srpm-dkms:
 srpm-utils:
 	$(MAKE) $(AM_MAKEFLAGS) pkg="${PACKAGE}" \
 		def='${SRPM_DEFINE_COMMON} ${SRPM_DEFINE_UTIL}' srpm-common
+
+srpm-akmod:
+	$(MAKE) $(AM_MAKEFLAGS) pkg="${PACKAGE}-kmod" \
+		def='${SRPM_DEFINE_COMMON} --define "_wrong_version_format_terminate_build 0" --define "_enable_akmod 1"' \
+		RPM_SPEC_DIR="rpm/generic" srpm-common
 
 srpm: srpm-kmod srpm-dkms srpm-utils
 srpms: srpm-kmod srpm-dkms srpm-utils
@@ -51,6 +56,11 @@ rpm-utils: srpm-utils
 rpm-utils-initramfs: srpm-utils
 	$(MAKE) $(AM_MAKEFLAGS) pkg="${PACKAGE}" \
 		def='${RPM_DEFINE_COMMON} ${RPM_DEFINE_UTIL} ${RPM_DEFINE_INITRAMFS}' rpm-common
+
+rpm-akmod: srpm-akmod
+	$(MAKE) $(AM_MAKEFLAGS) pkg="${PACKAGE}-kmod" \
+		def='${RPM_DEFINE_COMMON} --define "_wrong_version_format_terminate_build 0" --define "_enable_akmod 1"' \
+		RPM_SPEC_DIR="rpm/generic" rpm-common
 
 rpm: rpm-kmod rpm-dkms rpm-utils
 rpms: rpm-kmod rpm-dkms rpm-utils

--- a/config/zfs-build.m4
+++ b/config/zfs-build.m4
@@ -454,9 +454,9 @@ AC_DEFUN([ZFS_AC_RPM], [
 		AC_SUBST(MULTIARCH_LIBDIR)
 	])
 
-	dnl # Make RPM_DEFINE_KMOD additions conditional on CONFIG_KERNEL,
-	dnl # since the values will not be set otherwise. The spec files
-	dnl # provide defaults for them.
+	dnl # For akmod builds, we don't need to define kernel build parameters
+	dnl # since akmods handles this automatically. For regular kmod builds,
+	dnl # we need all the kernel build parameters.
 	dnl #
 	RPM_DEFINE_KMOD='--define "_wrong_version_format_terminate_build 0"'
 	AM_COND_IF([CONFIG_KERNEL], [

--- a/rpm/generic/zfs-kmod.spec.in
+++ b/rpm/generic/zfs-kmod.spec.in
@@ -1,3 +1,4 @@
+%define debug_package %{nil}
 %define module  @PACKAGE@
 
 %if !%{defined ksrc}
@@ -28,13 +29,15 @@
 %endif
 %endif
 
-#define repo    rpmfusion
+# Conditional akmod support - can be enabled via: rpmbuild --define "_enable_akmod 1"
+%{?_enable_akmod:%define repo rpmfusion}
+%{!?_enable_akmod:#define repo rpmfusion}
 #define repo    chaos
 
 # (un)define the next line to either build for the newest or all current kernels
-%define buildforkernels newest
+%{?_enable_akmod:%define buildforkernels akmod}
+%{!?_enable_akmod:%define buildforkernels newest}
 #define buildforkernels current
-#define buildforkernels akmod
 
 %bcond_with     debug
 %bcond_with     debuginfo
@@ -72,7 +75,8 @@ Conflicts:      %{module}-dkms
 # Building for a repository use the proper build-sysbuild package
 # to determine which kernel-devel packages should be installed.
 BuildRequires:  %{_bindir}/kmodtool
-%{!?kernels:BuildRequires: buildsys-build-%{repo}-kerneldevpkgs-%{?buildforkernels:%{buildforkernels}}%{!?buildforkernels:current}-%{_target_cpu}}
+# Skip buildsys-build for akmod builds as akmods handles kernel dependencies
+%{!?_enable_akmod:%{!?kernels:BuildRequires: buildsys-build-%{repo}-kerneldevpkgs-%{?buildforkernels:%{buildforkernels}}%{!?buildforkernels:current}-%{_target_cpu}}}
 
 %else
 
@@ -105,6 +109,16 @@ BuildRequires:  %{_bindir}/kmodtool
 %description
 This package contains the ZFS kernel modules.
 
+# akmod package requires -common subpackage
+%package common
+Summary: Common files for the ZFS kernel modules
+Requires: %{name} = %{version}-%{release}
+BuildArch: noarch
+
+%description common
+This package contains the common files (license, documentation, etc.) for the
+ZFS kernel modules.
+
 %prep
 # Error out if there was something wrong with kmodtool.
 %{?kmodtool_check}
@@ -128,6 +142,9 @@ bash %{SOURCE10}  --target %{_target_cpu} %{?repo:--repo %{?repo}} --kmodname %{
 %define _configure ../%{module}-%{version}/configure
 
 %setup -q -c -T -a 0
+
+# For common package
+cp %{module}-%{version}/{COPYRIGHT,LICENSE,NOTICE,README.md} .
 
 for kernel_version in %{?kernel_versions}; do
     %{__mkdir} _kmod_build_${kernel_version%%___*}
@@ -207,9 +224,15 @@ for kernel_version in %{?kernel_versions}; do
     cd ..
 done
 # find-debuginfo.sh only considers executables
+%if %{defined kernel_versions}
 chmod u+x ${RPM_BUILD_ROOT}%{kmodinstdir_prefix}/*/extra/*/*
+%endif
 %{?akmod_install}
 
 
 %clean
 rm -rf $RPM_BUILD_ROOT
+
+%files common
+%doc README.md
+%license COPYRIGHT LICENSE NOTICE

--- a/scripts/kmodtool
+++ b/scripts/kmodtool
@@ -332,43 +332,46 @@ EOF
 
 print_customrpmtemplate ()
 {
+	local first_kernel_custom=""
+	local first_kernel_redhat=""
+	local first_kernel_redhat_variant=""
+
 	for kernel in ${1}
 	do
 		if [[ -e "${prefix}/lib/modules/${kernel}/build/Makefile" ]]; then
-			# likely a user-build-kernel with available buildfiles
-			# fixme: we should check if uname from Makefile is the same as ${kernel}
-
 			kernel_versions="${kernel_versions}${kernel}___${prefix}/lib/modules/${kernel}/build/ "
 			print_rpmtemplate_per_kmodpkg --custom "${kernel}"
 
-			# create development package
 			if [[ -n "${devel}" ]]; then
-				# create devel package including common headers
-				print_rpmtemplate_kmoddevelpkg --custom "${kernel}"
-
-				# create devel package
 				print_rpmtemplate_per_kmoddevelpkg --custom "${kernel}"
 			fi
+			[[ -z "${first_kernel_custom}" ]] && first_kernel_custom="${kernel}"
 		elif [[ -e "${buildroot}/usr/src/kernels/${kernel}" ]]; then
-			# this looks like a Fedora/RH kernel -- print a normal template (which includes the proper BR) and be happy :)
 			kernel_versions="${kernel_versions}${kernel}___${buildroot}%{_usrsrc}/kernels/${kernel} "
 
-			# parse kernel versions string and print template
 			local kernel_verrelarch=${kernel%%${kernels_known_variants}}
 			print_rpmtemplate_per_kmodpkg --redhat ${kernel} ${kernel##${kernel_verrelarch}}
 
-			# create development package
 			if [[ -n "${devel}" ]]; then
-				# create devel package including common headers
-				print_rpmtemplate_kmoddevelpkg --redhat ${kernel} ${kernel##${kernel_verrelarch}}
-
-				# create devel package
 				print_rpmtemplate_per_kmoddevelpkg --redhat ${kernel} ${kernel##${kernel_verrelarch}}
+			fi
+			if [[ -z "${first_kernel_redhat}" ]]; then
+				first_kernel_redhat="${kernel}"
+				first_kernel_redhat_variant="${kernel##${kernel_verrelarch}}"
 			fi
 		else
 			error_out 2 "Don't know how to handle ${kernel} -- ${prefix}/lib/modules/${kernel}/build/Makefile not found"
 		fi
 	done
+
+	# Common devel package (only once, outside the per-kernel loop)
+	if [[ -n "${devel}" ]]; then
+		if [[ -n "${first_kernel_custom}" ]]; then
+			print_rpmtemplate_kmoddevelpkg --custom "${first_kernel_custom}"
+		elif [[ -n "${first_kernel_redhat}" ]]; then
+			print_rpmtemplate_kmoddevelpkg --redhat ${first_kernel_redhat} ${first_kernel_redhat_variant}
+		fi
+	fi
 
 	# well, it's no header anymore, but who cares ;-)
 	print_rpmtemplate_header
@@ -386,6 +389,9 @@ print_rpmtemplate ()
 	# and print it and some other required stuff as macro
 	print_rpmtemplate_header
 
+	local first_kernel=""
+	local first_kernel_variant=""
+
 	# now print the packages
 	for kernel in ${kernel_versions_to_build_for} ; do
 
@@ -398,13 +404,20 @@ print_rpmtemplate ()
 		print_rpmtemplate_per_kmodpkg "${kernel}" "${kernel##${kernel_verrelarch}}"
 
 		if [[ -n "${devel}" ]]; then
-			# create devel package including common headers
-			print_rpmtemplate_kmoddevelpkg "${kernel}" "${kernel##${kernel_verrelarch}}"
-
-			# create devel package
+			# create per-kernel devel package
 			print_rpmtemplate_per_kmoddevelpkg "${kernel}" "${kernel##${kernel_verrelarch}}"
 		fi
+
+		if [[ -z "${first_kernel}" ]]; then
+			first_kernel="${kernel}"
+			first_kernel_variant="${kernel##${kernel_verrelarch}}"
+		fi
 	done
+
+	# Common devel package (only once, outside the per-kernel loop)
+	if [[ -n "${devel}" && -n "${first_kernel}" ]]; then
+		print_rpmtemplate_kmoddevelpkg "${first_kernel}" "${first_kernel_variant}"
+	fi
 }
 
 myprog_help ()


### PR DESCRIPTION
Add akmod (Automatic Kernel Module) support to ZFS, providing a third
packaging option alongside the existing DKMS and kmod packages.

Akmod packages automatically build binary kmod RPMs when new kernels
are installed, enabling:
- Automatic kernel module rebuilds on kernel updates
- Distribution of binary kmod RPMs without recompilation
- Seamless minor version upgrades on RHEL/Fedora and clones

### Key changes

- **rpm/generic/zfs-kmod.spec.in**: Add conditional akmod support via
  `rpmbuild --define '_enable_akmod 1'`. When enabled, sets
  `buildforkernels=akmod` and `repo=rpmfusion` so kmodtool generates an
  `akmod-zfs` package. Add `-common` subpackage for shared license/doc
  files. Guard `chmod` and `%files` sections for empty `kernel_versions`.
- **config/rpm.am**: Add `make rpm-akmod` and `make srpm-akmod` targets.
  These targets use the generic spec with `_enable_akmod` and
  intentionally omit kernel-specific defines (`kernels`, `ksrc`, `kobj`)
  so kmodtool enters its akmod-only code path.
- **config/zfs-build.m4**: Update comments to document the akmod vs
  regular kmod distinction for `RPM_DEFINE_KMOD`.
- **scripts/kmodtool**: Fix a pre-existing bug where
  `print_rpmtemplate_kmoddevelpkg` (the common `kmod-NAME-devel` package)
  was called inside the per-kernel loop in `print_customrpmtemplate`
  and `print_rpmtemplate`, causing duplicate `%package` definitions when
  multiple `kernel-devel` packages are installed. Move it outside the
  loop so it is emitted exactly once.

### How it works

The akmod infrastructure requires the `akmods` package on the target system.
When `akmod-zfs` is installed, it places a `zfs-kmod` src.rpm in
`/usr/src/akmods/`. The `akmods` service then automatically rebuilds it
for each new kernel via `rpmbuild --define 'kernels <uname-r>' --rebuild`.

This follows the same pattern used by [negativo17's nvidia-kmod](https://github.com/negativo17/nvidia-kmod/blob/master/nvidia-kmod.spec).

### Usage

```
make rpm-akmod    # Build akmod-zfs, kmod-zfs (meta), zfs-kmod-common
make srpm-akmod   # Build source RPM only
```

### Testing

Tested the full akmod lifecycle on:
- **Fedora 43** (kernel 7.1.13) — ZFS 2.4.4 akmod backport
- **RHEL 9.8** (kernel 5.14.0-687) — ZFS 2.3.9 akmod backport

Verified: build → install `akmod-zfs` → `akmods --force` → `kmod-zfs-<kernel>` automatically built and installed → remove kmod → `akmods --force` rebuilds it.

Closes #16949

Signed-off-by: Vincent S. Cojot <vcojot@redhat.com>