### PR TITLE
vdev_disk: simplify alignment checks for linear ABDs

### DIFF
--- a/module/os/linux/zfs/vdev_disk.c
+++ b/module/os/linux/zfs/vdev_disk.c
@@ -982,8 +982,7 @@ vdev_disk_check_alignment_cb(struct page *page, size_t off, size_t len,
 }
 
 /*
- * Check if we can submit the pages in this ABD to the kernel as-is. Returns
- * the number of pages, or 0 if it can't be submitted like this.
+ * Check if we can submit the pages in this ABD to the kernel as-is.
  */
 static boolean_t
 vdev_disk_check_alignment(abd_t *abd, uint64_t size, struct block_device *bdev)
@@ -991,6 +990,17 @@ vdev_disk_check_alignment(abd_t *abd, uint64_t size, struct block_device *bdev)
 	vdev_disk_check_alignment_t s = {
 	    .blocksize = bdev_logical_block_size(bdev),
 	};
+
+	/*
+	 * A linear ABD is a single contiguous range, so only its first page
+	 * can carry an offset and only its last one can be short. That leaves
+	 * the alignment of the buffer as the only thing to check, and no
+	 * reason to look up the pages.
+	 */
+	if (abd_is_linear(abd)) {
+		ASSERT(IS_P2ALIGNED(size, s.blocksize));
+		return (IS_P2ALIGNED(abd_to_buf(abd), s.blocksize));
+	}
 
 	if (abd_iterate_page_func(abd, 0, size,
 	    vdev_disk_check_alignment_cb, &s))


### PR DESCRIPTION
A linear ABD is a single contiguous range, so only its first page can carry an offset and only its last one can be short. That leaves the alignment of the buffer as the only thing to check, and no reason to look up the pages.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
