### PR TITLE
Suggest libtirpc-dev for Ubuntu builds

### DIFF
--- a/config/user-libtirpc.m4
+++ b/config/user-libtirpc.m4
@@ -22,9 +22,9 @@ AC_DEFUN([ZFS_AC_CONFIG_USER_LIBTIRPC], [
 	AS_IF([test "x$have_xdr" = "x"], [
             ZFS_AC_FIND_SYSTEM_LIBRARY(LIBTIRPC, [libtirpc], [rpc/xdr.h], [tirpc], [tirpc], [xdrmem_create], [], [
 		AS_IF([test "x$with_tirpc" = "xyes"], [
-		    AC_MSG_FAILURE([--with-tirpc was given, but libtirpc is not available, try installing libtirpc-devel])
+		    AC_MSG_FAILURE([--with-tirpc was given, but libtirpc is not available, try installing libtirpc-devel or libtirpc-dev])
 		],[dnl ELSE
-		    AC_MSG_FAILURE([neither libc sunrpc support nor libtirpc is available, try installing libtirpc-devel])
+		    AC_MSG_FAILURE([neither libc sunrpc support nor libtirpc is available, try installing libtirpc-devel or libtirpc-dev])
 		])
 	    ])
 	])


### PR DESCRIPTION
A minimal Ubuntu install does not include libtirpc and ./configure fails with
"... try installing libtirpc-devel", but that package is named libtirpc-dev on Ubuntu.

Fix the error message to mention both package names.

### Motivation and Context
Improve usability for users building zfs on newly-installed systems.

### Description
Improve error message printed by configure script.

### How Has This Been Tested?
Ran ./configure to see new message.

### Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)

### Checklist
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
