### PR TITLE
ZTS: Add import_relax_metadata_damaged exception

### DIFF
--- a/tests/test-runner/bin/zts-report.py.in
+++ b/tests/test-runner/bin/zts-report.py.in
@@ -222,6 +222,7 @@ maybe = {
     'cli_root/zfs_share/zfs_share_concurrent_shares': ['FAIL', known_reason],
     'cli_root/zfs_unshare/zfs_unshare_006_pos': ['SKIP', na_reason],
     'cli_root/zpool_import/import_devices_missing': ['FAIL', 16669],
+    'cli_root/zpool_import/import_relax_metadata_damaged': ['FAIL', 19077],
     'cli_root/zpool_trim/setup': ['SKIP', trim_reason],
     'delegate/setup': ['SKIP', exec_reason],
     'fault/auto_replace_002_pos': ['FAIL', known_reason],


### PR DESCRIPTION
### Motivation and Context

Issue #19077

### Description

The newly added import_relax_metadata_damaged test case is flaky. Add it to the exceptions script until the underlying issue is resolved.

### How Has This Been Tested?

It has not.  Will be verified by the CI the next time the issue occurs in the test environment.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [x] Documentation (a change to man pages or other documentation)