### PR TITLE
build: Fix building kernel module when builddir is different from srcdir

### DIFF
--- a/module/Makefile.in
+++ b/module/Makefile.in
@@ -54,6 +54,14 @@ FMAKE = env -u MAKEFLAGS make $(FMAKEFLAGS)
 modules-Linux:
 	mkdir -p $(sort $(dir $(spl-objs) $(spl-)))
 	mkdir -p $(sort $(dir $(zfs-objs) $(zfs-)))
+	# Pre-6.10 kernel builds didn't need to copy over the source files to the
+	# build directory. We need to do it though post-6.10 due to these commits:
+	#
+	# b1992c3 kbuild: use $(src) instead of $(srctree)/$(src) for source dir
+	# 9a0ebe5 kbuild: use $(obj)/ instead of $(src)/ for common pattern rules
+	if [ "@abs_srcdir@" != "@abs_builddir@" ]; then \
+		cp -rsf "@abs_srcdir@"/*/ "@abs_builddir@"; \
+	fi
 	$(MAKE) -C @LINUX_OBJ@ $(if @KERNEL_CC@,CC=@KERNEL_CC@) \
 		$(if @KERNEL_LD@,LD=@KERNEL_LD@) $(if @KERNEL_LLVM@,LLVM=@KERNEL_LLVM@) \
 		$(if @KERNEL_CROSS_COMPILE@,CROSS_COMPILE=@KERNEL_CROSS_COMPILE@) \

--- a/rpm/generic/zfs-kmod.spec.in
+++ b/rpm/generic/zfs-kmod.spec.in
@@ -148,23 +148,6 @@ for kernel_version in %{?kernel_versions}; do
         %{?kernel_cross_compile} \
         %{?kernel_arch}
 
-    # Pre-6.10 kernel builds didn't need to copy over the source files to the
-    # build directory.  However we do need to do it though post-6.10 due to
-    # these commits:
-    #
-    # b1992c3772e6 kbuild: use $(src) instead of $(srctree)/$(src) for source
-    #                      directory
-    #
-    # 9a0ebe5011f4 kbuild: use $(obj)/ instead of $(src)/ for common pattern
-    #                      rules
-    #
-    # Note that kmodtool actually copies over the source into the build
-    # directory, so what we're doing here is normal.  For efficiency reasons
-    # though we just use hardlinks instead of copying.
-    #
-    # See https://github.com/openzfs/zfs/issues/16439 for more info.
-    cp -lR ../%{module}-%{version}/module/* module/
-
     make %{?_smp_mflags}
     cd ..
 done


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
It was noticed and fixed in f2f4ada24 that the kernel was changed in 6.10 to make it difficult have the build directory be different from the source directory. The fix is to copy the module sources to the build directory. However, the fix was only applied to building distro packages. This same problem exists when building outside of the root of the source tree.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
Instead do the copy when building the `modules-Linux` target, which initiates the kernel module build. Commit f2f4ada24 hardlinks the source files because it knows they are on the same filesystem. However, this is not necessarily true generally when having a separate build directory. So make a symlink tree instead of hardlinks. Also, only do the copy if the build directory is different from the source tree.
<!--- Describe your changes in detail -->

### How Has This Been Tested?
Tested by verifying that `make` and `make pkg-kmod` build successfully.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [X] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
