### PR TITLE
dmu: serve cached partial reads from the ARC without a full-record copy

### DIFF
--- a/include/sys/arc.h
+++ b/include/sys/arc.h
@@ -304,6 +304,9 @@ int arc_referenced(arc_buf_t *buf);
 #define	arc_referenced(buf) ((void) sizeof (buf), 0)
 #endif
 
+boolean_t arc_hold_abd_range(spa_t *spa, const blkptr_t *bp, uint64_t off,
+    uint64_t len, abd_t **viewp, arc_buf_hdr_t **hdrp, const void *tag);
+void arc_rele_abd_range(abd_t *view, arc_buf_hdr_t *hdr, const void *tag);
 int arc_read(zio_t *pio, spa_t *spa, const blkptr_t *bp,
     arc_read_done_func_t *done, void *priv, zio_priority_t priority,
     int flags, arc_flags_t *arc_flags, const zbookmark_phys_t *zb);

--- a/include/sys/dbuf.h
+++ b/include/sys/dbuf.h
@@ -380,6 +380,8 @@ dbuf_dirty_record_t *dbuf_dirty_lightweight(dnode_t *dn, uint64_t blkid,
     dmu_tx_t *tx);
 boolean_t dbuf_undirty(dmu_buf_impl_t *db, dmu_tx_t *tx);
 int dmu_buf_get_bp_from_dbuf(dmu_buf_impl_t *db, blkptr_t **bp);
+boolean_t dbuf_hold_arc_range(dmu_buf_impl_t *db, uint64_t off, uint64_t len,
+    abd_t **viewp, arc_buf_hdr_t **hdrp, const void *tag);
 int dmu_buf_untransform_direct(dmu_buf_impl_t *db, spa_t *spa);
 void dmu_buf_write_embedded(dmu_buf_t *dbuf, void *data,
     bp_embedded_type_t etype, enum zio_compress comp,

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -5876,6 +5876,101 @@ arc_cached(spa_t *spa, const blkptr_t *bp)
 }
 
 /*
+ * Take a zero-copy reference to a range of a block that is already present in
+ * the ARC in the form the caller wants it: uncompressed, unencrypted and not
+ * in need of a byteswap.  Note that this is a property of the header, not of
+ * the block pointer: a block that is compressed on disk qualifies whenever the
+ * ARC holds it expanded, as it does when zfs_compressed_arc_enabled is off.
+ *
+ * This lets a reader copy out only the bytes it actually asked for.  The
+ * alternative, arc_buf_alloc_impl(), has to allocate a second buffer the size
+ * of the whole record and memcpy the record into it, which is what every dbuf
+ * cache miss against an otherwise warm ARC pays today.  Unlike the sharing
+ * done by arc_can_share(), this works with a scattered b_pabd, because the
+ * caller consumes the data through the ABD interface and never needs a
+ * contiguous pointer.
+ *
+ * We only do this when b_pabd is of a kind that arc_buf_alloc_impl() refuses
+ * to share - anything but a plain linear ABD, so scattered ABDs and the single
+ * compound page ("linear page") that Linux hands back for a whole record.  That
+ * is both the interesting case and the safe one: since sharing cannot happen,
+ * ARC_FLAG_SHARED_DATA can never be set on this header and none of the paths
+ * that swap out b_pabd (arc_release(), arc_buf_destroy_impl()) can run.  The
+ * reference we take keeps the header off the evictable lists, so b_pabd stays
+ * allocated, and a hashed header's data is immutable, so it stays correct.
+ *
+ * Returns B_FALSE if the caller has to fall back to a normal read.
+ */
+boolean_t
+arc_hold_abd_range(spa_t *spa, const blkptr_t *bp, uint64_t off, uint64_t len,
+    abd_t **viewp, arc_buf_hdr_t **hdrp, const void *tag)
+{
+	arc_buf_hdr_t *hdr;
+	kmutex_t *hash_lock;
+
+	if (BP_IS_EMBEDDED(bp) || BP_IS_HOLE(bp) || BP_IS_REDACTED(bp) ||
+	    BP_IS_PROTECTED(bp))
+		return (B_FALSE);
+
+	hdr = buf_hash_find(spa_load_guid(spa), bp, &hash_lock);
+	if (hdr == NULL)
+		return (B_FALSE);
+
+	if (!HDR_HAS_L1HDR(hdr) || HDR_IO_IN_PROGRESS(hdr) ||
+	    HDR_PROTECTED(hdr) || HDR_SHARED_DATA(hdr) ||
+	    hdr->b_l1hdr.b_pabd == NULL ||
+	    (abd_is_linear(hdr->b_l1hdr.b_pabd) &&
+	    !abd_is_linear_page(hdr->b_l1hdr.b_pabd)) ||
+	    arc_hdr_get_compress(hdr) != ZIO_COMPRESS_OFF ||
+	    hdr->b_l1hdr.b_byteswap != DMU_BSWAP_NUMFUNCS ||
+	    off + len > HDR_GET_LSIZE(hdr)) {
+		mutex_exit(hash_lock);
+		return (B_FALSE);
+	}
+
+	ASSERT3U(abd_get_size(hdr->b_l1hdr.b_pabd), ==, HDR_GET_LSIZE(hdr));
+
+	/*
+	 * Stay away from arc_uncached: dropping the last reference on such a
+	 * header destroys it, and we do not want a read to throw away data
+	 * that is still sitting in the cache.
+	 */
+	if (hdr->b_l1hdr.b_state != arc_mru &&
+	    hdr->b_l1hdr.b_state != arc_mfu) {
+		mutex_exit(hash_lock);
+		return (B_FALSE);
+	}
+
+	DTRACE_PROBE1(arc__hit, arc_buf_hdr_t *, hdr);
+	arc_access(hdr, 0, B_TRUE);
+	add_reference(hdr, tag);
+	boolean_t is_data = !HDR_ISTYPE_METADATA(hdr);
+	mutex_exit(hash_lock);
+
+	ARCSTAT_BUMP(arcstat_hits);
+	ARCSTAT_CONDSTAT(B_TRUE, demand, prefetch, is_data, data, metadata,
+	    hits);
+
+	*viewp = abd_get_offset_size(hdr->b_l1hdr.b_pabd, off, len);
+	*hdrp = hdr;
+	return (B_TRUE);
+}
+
+/*
+ * Drop a reference taken by arc_hold_abd_range().
+ */
+void
+arc_rele_abd_range(abd_t *view, arc_buf_hdr_t *hdr, const void *tag)
+{
+	kmutex_t *hash_lock = HDR_LOCK(hdr);
+
+	abd_free(view);
+	mutex_enter(hash_lock);
+	(void) remove_reference(hdr, tag);
+	mutex_exit(hash_lock);
+}
+
+/*
  * "Read" the block at the specified DVA (in bp) via the
  * cache.  If the block is found in the cache, invoke the provided
  * callback immediately and return.  Note that the `zio' parameter
@@ -6692,7 +6787,8 @@ arc_release(arc_buf_t *buf, const void *tag)
 	 */
 	if (hdr->b_l1hdr.b_buf != buf || !ARC_BUF_LAST(buf) ||
 	    (HDR_L2_WRITING(hdr) && !ARC_BUF_SHARED(buf)) ||
-	    HDR_IO_IN_PROGRESS(hdr)) {
+	    HDR_IO_IN_PROGRESS(hdr) ||
+	    zfs_refcount_count(&hdr->b_l1hdr.b_refcnt) > 1) {
 		arc_buf_hdr_t *nhdr;
 		uint64_t spa = hdr->b_spa;
 		uint64_t psize = HDR_GET_PSIZE(hdr);

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -1746,6 +1746,49 @@ dbuf_fix_old_data(dmu_buf_impl_t *db, uint64_t txg)
 	}
 }
 
+/*
+ * Fast path for a partial read of a block that is in the ARC but has no buffer
+ * of its own in this dbuf yet.  On success the caller gets a zero-copy ABD
+ * reference to [off, off + len) of the block, which it must release with
+ * arc_rele_abd_range().
+ *
+ * Nothing is cached in the dbuf, so this only helps when the dbuf cache is
+ * missing anyway - which is exactly when the full-record copy done by
+ * dbuf_read() -> arc_buf_alloc_impl() dominates the cost of a small read.
+ */
+boolean_t
+dbuf_hold_arc_range(dmu_buf_impl_t *db, uint64_t off, uint64_t len,
+    abd_t **viewp, arc_buf_hdr_t **hdrp, const void *tag)
+{
+	blkptr_t *bp, bp_copy;
+	db_lock_type_t dblt;
+	boolean_t have_bp = B_FALSE;
+
+	ASSERT(!zfs_refcount_is_zero(&db->db_holds));
+
+	if (db->db_level != 0 || db->db_blkid == DMU_BONUS_BLKID)
+		return (B_FALSE);
+
+	mutex_enter(&db->db_mtx);
+	if (db->db_state != DB_UNCACHED || db->db_dirtycnt != 0) {
+		mutex_exit(&db->db_mtx);
+		return (B_FALSE);
+	}
+	dblt = dmu_buf_lock_parent(db, RW_READER, FTAG);
+	if (dmu_buf_get_bp_from_dbuf(db, &bp) == 0 && bp != NULL) {
+		bp_copy = *bp;
+		have_bp = B_TRUE;
+	}
+	dmu_buf_unlock_parent(db, dblt, FTAG);
+	mutex_exit(&db->db_mtx);
+
+	if (!have_bp)
+		return (B_FALSE);
+
+	return (arc_hold_abd_range(db->db_objset->os_spa, &bp_copy, off, len,
+	    viewp, hdrp, tag));
+}
+
 int
 dbuf_read(dmu_buf_impl_t *db, zio_t *pio, dmu_flags_t flags)
 {

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -1567,16 +1567,146 @@ dmu_redact(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
 }
 
 #ifdef _KERNEL
+/*
+ * Answer reads of blocks that are already in the ARC by copying only the
+ * requested range out of a zero-copy ABD reference, instead of materializing a
+ * full-record arc_buf_t for the dbuf.  Set to 0 to restore the old path.
+ */
+static int dmu_arc_range_read = 1;
+
+static int
+dmu_abd_uio_cb(void *buf, size_t len, void *priv)
+{
+	return (zfs_uio_fault_move(buf, len, UIO_READ, (zfs_uio_t *)priv));
+}
+
+/*
+ * Serve as much of a read as possible straight out of the ARC, copying only
+ * the bytes that were asked for.
+ *
+ * The normal path has to hand the caller a dmu_buf_t, whose db_data is a
+ * contiguous pointer, so every dbuf cache miss on a warm ARC allocates a
+ * buffer the size of the whole record and memcpys the record into it: 128 KiB
+ * of memcpy to answer a 4 KiB read.  Here we take a zero-copy ABD reference to
+ * the record as it sits in the ARC and copy out just the requested range.
+ * Nothing lands in the dbuf cache, which is fine, since this only triggers
+ * when the dbuf cache missed to begin with.
+ *
+ * Stops at the first block that cannot be served this way and reports what is
+ * left in *residp, so the caller can finish through the normal path.  That
+ * block's dbuf is handed back in *heldp still held, so that the fallback finds
+ * it in the dbuf hash instead of creating it a second time; the caller must
+ * release it once the fallback is done with it.
+ */
+static int
+dmu_read_uio_arc(dnode_t *dn, zfs_uio_t *uio, uint64_t size,
+    dmu_flags_t flags, uint64_t *residp, dmu_buf_impl_t **heldp)
+{
+	uint64_t start = zfs_uio_offset(uio);
+	int err = 0;
+
+	*heldp = NULL;
+
+	for (;;) {
+		uint64_t off = zfs_uio_offset(uio);
+		uint64_t left = size - (off - start);
+		uint64_t bufoff, tocpy;
+		dmu_buf_impl_t *db;
+		arc_buf_hdr_t *hdr;
+		abd_t *view;
+		boolean_t held;
+
+		if (left == 0)
+			break;
+
+		rw_enter(&dn->dn_struct_rwlock, RW_READER);
+		db = dbuf_hold(dn, dbuf_whichblock(dn, 0, off), FTAG);
+		rw_exit(&dn->dn_struct_rwlock);
+		if (db == NULL) {
+			err = SET_ERROR(EIO);
+			break;
+		}
+
+		bufoff = off - db->db.db_offset;
+		if (bufoff >= db->db.db_size) {
+			*heldp = db;
+			break;
+		}
+		tocpy = MIN(db->db.db_size - bufoff, left);
+		held = dbuf_hold_arc_range(db, bufoff, tocpy, &view, &hdr,
+		    FTAG);
+		if (!held) {
+			*heldp = db;
+			break;
+		}
+		dbuf_rele(db, FTAG);
+
+		/*
+		 * The ABD chunk is mapped across the copy, so we must not take
+		 * a page fault here.  zfs_read() has already faulted the user
+		 * pages in; if that no longer holds we stop and let the normal
+		 * path redo the rest of the read, which is allowed to fault.
+		 */
+		zfs_uio_fault_disable(uio, B_TRUE);
+		err = abd_iterate_func(view, 0, tocpy, dmu_abd_uio_cb, uio);
+		zfs_uio_fault_disable(uio, B_FALSE);
+		arc_rele_abd_range(view, hdr, FTAG);
+
+		if (err != 0) {
+			if (err == EFAULT)
+				err = 0;
+			break;
+		}
+	}
+
+	*residp = size - (zfs_uio_offset(uio) - start);
+
+	/*
+	 * Keep the prefetcher's stream alive, but only when we served the whole
+	 * read.  If we have to fall back, dmu_buf_hold_array_by_dnode() runs
+	 * the prefetcher itself, with the block-level miss information we do
+	 * not have here; running it twice, or running it with the wrong miss
+	 * status, costs far more than it saves.
+	 */
+	if (*residp == 0 && (flags & DMU_READ_NO_PREFETCH) == 0) {
+		uint64_t blkid = dbuf_whichblock(dn, 0, start);
+		uint64_t nblks = 1;
+
+		if (dn->dn_datablkshift) {
+			int shift = dn->dn_datablkshift;
+			nblks = (P2ROUNDUP(start + size, 1ULL << shift) -
+			    P2ALIGN_TYPED(start, 1ULL << shift, uint64_t)) >>
+			    shift;
+		}
+		dmu_zfetch(&dn->dn_zfetch, blkid, nblks, B_TRUE, B_FALSE,
+		    B_FALSE, (flags & DMU_UNCACHEDIO) != 0);
+	}
+	return (err);
+}
+
 int
 dmu_read_uio_dnode(dnode_t *dn, zfs_uio_t *uio, uint64_t size,
     dmu_flags_t flags)
 {
 	dmu_buf_t **dbp;
+	dmu_buf_impl_t *held = NULL;
 	int numbufs, i, err;
 
 	if ((flags & DMU_DIRECTIO) && (uio->uio_extflg & UIO_DIRECT))
 		return (dmu_read_uio_direct(dn, uio, size, flags));
 	flags &= ~DMU_DIRECTIO;
+
+	if (dmu_arc_range_read) {
+		uint64_t resid;
+
+		err = dmu_read_uio_arc(dn, uio, size, flags, &resid, &held);
+		if (err != 0 || resid == 0) {
+			if (held != NULL)
+				dbuf_rele(held, FTAG);
+			return (err);
+		}
+		size = resid;
+	}
 
 	/*
 	 * NB: we could do this block-at-a-time, but it's nice
@@ -1584,8 +1714,11 @@ dmu_read_uio_dnode(dnode_t *dn, zfs_uio_t *uio, uint64_t size,
 	 */
 	err = dmu_buf_hold_array_by_dnode(dn, zfs_uio_offset(uio), size,
 	    TRUE, FTAG, &numbufs, &dbp, flags);
-	if (err)
+	if (err) {
+		if (held != NULL)
+			dbuf_rele(held, FTAG);
 		return (err);
+	}
 
 	for (i = 0; i < numbufs; i++) {
 		uint64_t tocpy;
@@ -1607,6 +1740,8 @@ dmu_read_uio_dnode(dnode_t *dn, zfs_uio_t *uio, uint64_t size,
 		size -= tocpy;
 	}
 	dmu_buf_rele_array(dbp, numbufs, FTAG);
+	if (held != NULL)
+		dbuf_rele(held, FTAG);
 
 	return (err);
 }
@@ -3206,6 +3341,11 @@ EXPORT_SYMBOL(dmu_assign_arcbuf_by_dnode);
 EXPORT_SYMBOL(dmu_assign_arcbuf_by_dbuf);
 EXPORT_SYMBOL(dmu_buf_hold);
 EXPORT_SYMBOL(dmu_ot);
+
+#ifdef _KERNEL
+ZFS_MODULE_PARAM(zfs, , dmu_arc_range_read, INT, ZMOD_RW,
+	"Read partial blocks straight from the ARC without a full-record copy");
+#endif
 
 ZFS_MODULE_PARAM(zfs, zfs_, nopwrite_enabled, INT, ZMOD_RW,
 	"Enable NOP writes");


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
tl;dr: up to x9 on random 4k reads of cached recordsize=128k UNCOMPRESSED data, 2x increase on sequential read.

On tinkering with AI on perf questions I've found an interesting case for uncompressed data, see below. In this state PR successfully passes full CI run and basic benchmarks in VM. Please see this PR as a way to at least discuss the topic with a PoC/MVP.

Note: I'm against adding new module param, BUT it's way easier to test before/after with that. Ready to remove it.

### Description
<!--- Describe your changes in detail -->

dmu_read_uio_dnode() has to hand its caller a dmu_buf_t, whose db_data is a contiguous pointer, so a read that misses the dbuf cache but hits the ARC allocates a second buffer the size of the whole record and memcpys the record into it.  For a 4K read out of a 128K record that is 128 KiB of memcpy to deliver 4 KiB of data, and it dominates any random read workload whose working set outgrows the dbuf cache.

arc_buf_alloc_impl() can avoid that copy by sharing hdr->b_pabd with the buffer, but only when b_pabd is a plain linear ABD.  On Linux a whole record is normally a single compound page, flagged ABD_FLAG_LINEAR_PAGE, which sharing refuses because the handover needs
abd_release_ownership_of_buf(); a scattered b_pabd is refused for the same structural reason.  So in practice the copy is never avoided.

Add arc_hold_abd_range(), which takes a reference on a hashed header and returns a zero-copy ABD view of a range of its data, and use it from dmu_read_uio_dnode() to copy just the bytes the caller asked for straight into the uio.  The consumer goes through the ABD interface and never needs a contiguous pointer, so this covers exactly the buffers sharing cannot handle.

The gate is the negation of the sharing condition: a reference is only taken when b_pabd is anything but a plain linear ABD.  That is what makes it safe as well as useful.  Sharing can then never be established on the header, so ARC_FLAG_SHARED_DATA stays clear and neither arc_release() nor arc_buf_destroy_impl() can swap b_pabd out from under the view.  The reference itself keeps the header off the evictable lists, and a hashed header's data is immutable, so the view stays valid and correct.  The one case where a single-buffer arc_release() would otherwise have recycled the header now takes the copying path instead, which is what it already does for every other header somebody else holds.

Eligibility is a property of the header rather than of the block pointer, so a block that is compressed on disk qualifies whenever the ARC holds it expanded, as it does when zfs_compressed_arc_enabled is off.  A header that still holds compressed data does not, since it has to be decompressed into a buffer before anyone can read a byte of it.

If a block cannot be served this way the read falls back to the existing path for the remainder, keeping the dbuf it already holds so that the fallback finds it in the dbuf hash rather than creating it a second time.  The prefetcher is only run here when the whole read was served, so that dmu_buf_hold_array_by_dnode() keeps owning zfetch, and its per-block miss accounting, in every other case.



The path can be turned off with the dmu_arc_range_read tunable.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Measured on a Linux VM, 32 cores, pool on four ramdisks, ashift=12, recordsize=128k, ARC capped at 12 GiB, fio psync, 16 threads, three passes each, spread under 3%:

  4K random read, 8 GiB working set (dbuf cache thrashing)
    before   293-301 kIOPS
    after   2490-2593 kIOPS      8.6x

  4K random read, 256 MiB working set (dbuf cache hits)
    before  2419-2483 kIOPS
    after   2753-2870 kIOPS      1.14x

  128K sequential read, cold ARC
    before   5.0-5.3 GB/s
    after    6.8-7.2 GB/s        1.36x

  128K sequential read, warm ARC
    before  10.7-11.2 GB/s
    after   22.1-23.6 GB/s       2.11x

On a compression=lz4 dataset whose data compresses 2.28x, two passes:

    zfs_compressed_arc_enabled=1    270 -> 268 kIOPS   1.00x
    zfs_compressed_arc_enabled=0    360 -> 2691 kIOPS  7.5x

Over ten seconds of the first workload bpftrace counts 2.7 M arc_buf_fill() calls before the change and none after, with 98% of the reads taking the new path.  arcstat overhead_size, which is exactly the duplicated buffers, drops from 289 MB to 12.7 MB, and the ARC's own allocation behaviour is untouched: 4 linear ABDs before and after.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
